### PR TITLE
Recipe for RT Liberation

### DIFF
--- a/recipes/rt-liberation.el
+++ b/recipes/rt-liberation.el
@@ -1,0 +1,7 @@
+(:name rt-liberation
+       :type git
+       :url "http://yrk.nfshost.com/repos/rt-liberation.git/"
+       :build ("cd doc; make")
+       :info "./doc"
+       :features rt-liberation)
+       


### PR DESCRIPTION
I notice one problem with this...

The info file is called "rt-liberation.info"

The dir file that is written by ginstall-info shortens the name to "rt-liber", so that Info then has a problem finding the documentation.  I'm not sure where the problem lies; doesn't appear to be either in rt-liberation or in el-git.  Could ginstall-info be truncating the name?
