### PR TITLE
Fixed error signaling in el-get-git-executable

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -532,7 +532,7 @@ found."
 				 (file-executable-p magit-git-executable))
 			    magit-git-executable
 			  (executable-find "git"))))
-    (unless (file-executable-p git-executable)
+    (unless git-executable
       (error
        (concat "el-get-git-clone requires `magit-git-executable' to be set, "
 	       "or the binary `git' to be found in your PATH")))


### PR DESCRIPTION
Hello, I noticed that file-executable-p was being called with a nil argument in el-get-git-executable and it was dropping me in the debugger. Here's a potential fix.
