### PR TITLE
Hi, there may be a typo of "ant" in recipe of ahg.el

### DIFF
--- a/recipes/ahg.el
+++ b/recipes/ahg.el
@@ -1,4 +1,4 @@
-(:name ant
+(:name ahg
        :type hg
        :url "http://bitbucket.org/agriggio/ahg"
        :features ahg)


### PR DESCRIPTION
Hi, dimitri,

I was informed of duplicated sources ("ant") when I tried to install something using "C-u M-x el-get-install", and I find duplicated name of "ant" in recipe ant.el and ahg.el.
