### PR TITLE
Use actual CEDET repository, not the old one

### DIFF
--- a/recipes/cedet.el
+++ b/recipes/cedet.el
@@ -1,6 +1,5 @@
 (:name cedet
-  :type cvs
-  :module "cedet"
-  :url ":pserver:anonymous@cedet.cvs.sourceforge.net:/cvsroot/cedet"
+  :type bzr
+  :url "bzr://cedet.bzr.sourceforge.net/bzrroot/cedet/code/trunk"
   :build ("touch `find . -name Makefile`" "make")
   :load-path ("./common"))


### PR DESCRIPTION
CEDET had switched from CVS to BZR long time ago, so it's better to use actual repository
