### PR TITLE
el-get fails uncleanly when darcs is not installed

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -247,9 +247,6 @@ the named package action in the given method."
 (defvar el-get-svn (executable-find "svn")
   "The svn executable.")
 
-(defvar el-get-darcs (executable-find "darcs")
-  "The darcs executable.")
-
 (defvar el-get-fink-base "/sw/share/doc"
   "Where to link the el-get symlink to, /<package> will get appended.")
 
@@ -822,9 +819,17 @@ found."
 ;;
 ;; darcs support
 ;;
+(defun el-get-darcs-executable ()
+  "Return darcs executable to use, or signal an error when not
+found."
+  (let ((darcs-executable (executable-find "darcs")))
+    (unless (and darcs-executable (file-executable-p darcs-executable))
+      (error "The  `darcs' binary can not be found in your PATH"))
+    darcs-executable))
+
 (defun el-get-darcs-get (package url post-install-fun)
   "Get a given PACKAGE following the URL using darcs."
-  (let* ((darcs-executable el-get-darcs)
+  (let* ((darcs-executable (el-get-darcs-executable))
 	 (name (format "*darcs get %s*" package))
 	 (ok   (format "Package %s installed" package))
 	 (ko   (format "Could not install package %s." package)))
@@ -841,7 +846,7 @@ found."
 
 (defun el-get-darcs-pull (package url post-update-fun)
   "darcs pull the package."
-  (let* ((darcs-executable el-get-darcs)
+  (let* ((darcs-executable (el-get-darcs-executable))
 	 (pdir (el-get-package-directory package))
 	 (name (format "*darcs pull %s*" package))
 	 (ok   (format "Pulled package %s." package))


### PR DESCRIPTION
The patch uses the same technique as the one for git to display an error message when darcs can't be found.
