### PR TITLE
Tuareg-Mode fixes

### DIFF
--- a/recipes/tuareg-mode.el
+++ b/recipes/tuareg-mode.el
@@ -1,4 +1,11 @@
 (:name tuareg-mode
-       :type bzr
-       :url "https://forge.ocamlcore.org/anonscm/bzr/tuareg/mode/trunk"
-       :features tuareg)
+       :type git
+       :url "git://github.com/emacsmirror/tuareg.git"
+       :load-path (".")
+       :after
+       (lambda ()
+         (add-to-list 'auto-mode-alist '("\\.ml[iylp]?" . tuareg-mode))
+         (autoload 'tuareg-mode "tuareg" "Major mode for editing Caml code" t)
+         (autoload 'camldebug "camldebug" "Run the Caml debugger" t)
+         (dolist (ext '(".cmo" ".cmx" ".cma" ".cmxa" ".cmi"))
+           (add-to-list 'completion-ignored-extensions ext))))


### PR DESCRIPTION
- Uses emacsmirror's repository instead of ocamlforge. So, we now have Tuareg-mode version 2.0x instead of 1.x
- Associate with ml files.
