### PR TITLE
Geiser fix

### DIFF
--- a/recipes/geiser.el
+++ b/recipes/geiser.el
@@ -2,7 +2,7 @@
        :type git
        :url "git://git.sv.gnu.org/geiser.git"
        :load-path ("./elisp")
-       :build ("./autogen.sh" "./configure" "make" "cd doc ; ginstall-info --dir-file=./dir *.info")
+       :build ("./autogen.sh" "./configure" "make" "cd doc ; install-info --dir-file=./dir *.info")
        :info "doc"
        :features geiser-load
        )


### PR DESCRIPTION
```
Geiser: Fix typo that breaks install.
```
