### PR TITLE
Matlab mode

### DIFF
--- a/recipes/matlab-mode.el
+++ b/recipes/matlab-mode.el
@@ -1,0 +1,8 @@
+(:name matlab-mode
+       :type cvs
+       :module "matlab-emacs"
+       :url ":pserver:anonymous@matlab-emacs.cvs.sourceforge.net:/cvsroot/matlab-emacs"
+       :build ("make")
+       :load-path (".")
+       :features matlab-load)
+       


### PR DESCRIPTION
Recipe for Matlab Mode. I'm doing the default install which requires CEDET, but I can create a separate recipe to install it without the cedet integration.
