### PR TITLE
Small fix in python-mode recipe

### DIFF
--- a/recipes/python-mode.el
+++ b/recipes/python-mode.el
@@ -4,6 +4,6 @@
        :features (python-mode doctest-mode)
        :compile nil
        :after (lambda ()
-                (add-to-list 'auto-mode-alist '("\\.py$" .python-mode))
+                (add-to-list 'auto-mode-alist '("\\.py$" . python-mode))
                 (add-to-list 'interpreter-mode-alist '("python" . python-mode))
                 (autoload 'python-mode "python-mode" "Python editing mode." t)))


### PR DESCRIPTION
There seems to be a typo in python-mode recipe -- missing whitespace, which causes wrong cons cell to be added to auto-mode-alist:

```
'("\\.py$" . (.python-mode . nil))
```

instead of 
    '("\.py$" . python-mode)
