### PR TITLE
Disable global-smart-tab-mode in "smart-tab" recipe

### DIFF
--- a/recipes/smart-tab.el
+++ b/recipes/smart-tab.el
@@ -1,5 +1,4 @@
 (:name smart-tab
        :type git
        :url "https://github.com/genehack/smart-tab.git"
-       :features smart-tab
-       :after (lambda () (global-smart-tab-mode 1)))
+       :features smart-tab)


### PR DESCRIPTION
I don't think global-smart-tab-mode should be enabled by default in this recipe because:
1. It takes over <TAB> and interferes with tab expansion in modes like org-mode and yasnippet.
2. I find it annoying to have to maintain my own smart-tab.el.
3. :after hooks should be used for sensible defaults that aren't destructive to other modes and functionality.
4. smart-tab functionality is already bound to M-/ when you require the package. If you want to take it a step further to enable it globally, it should be done elsewhere.
