### PR TITLE
Make el-get work with the bundled Emacs 24 version of package.el

### DIFF
--- a/recipes/session.el
+++ b/recipes/session.el
@@ -4,4 +4,5 @@
        :load-path ("lisp")
        :url "http://downloads.sourceforge.net/project/emacs-session/session/2.2a/session-2.2a.tar.gz"
        :info "session management"
+       :disable-autoloads t
        )


### PR DESCRIPTION
One of the package-\* functions has changed its signature; this patch restores compatibility with el-get.
