### PR TITLE
Wrong fboundp check when checkin package.el version

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -1114,7 +1114,7 @@ PACKAGE isn't currently installed by ELPA."
     (unless (and elpa-dir (file-directory-p elpa-dir))
       ;; Make sure we have got *some* kind of record of the package archive.
       ;; TODO: should we refresh and retry once if package-install fails?
-      (let ((p (if (fboundp package-read-all-archive-contents)
+      (let ((p (if (fboundp 'package-read-all-archive-contents)
 		   (package-read-all-archive-contents) ; version from emacs24
 		 (package-read-archive-contents))))     ; old version
 	(unless p


### PR DESCRIPTION
Just tried to get el-get running, but got a
    Symbol's value as variable is void: package-read-all-archive-contents
but I'm on a very fresh emacs build and have this function.

Seems to be a typo in fboudp
