### PR TITLE
Fix some recipes to build on windows

### DIFF
--- a/recipes/cedet.el
+++ b/recipes/cedet.el
@@ -2,4 +2,7 @@
   :type bzr
   :url "bzr://cedet.bzr.sourceforge.net/bzrroot/cedet/code/trunk"
   :build ("touch `find . -name Makefile`" "make")
+  :build/windows-nt ("echo #!/bin/sh > tmp.sh & echo touch `/usr/bin/find . -name Makefile` >> tmp.sh & echo make FIND=/usr/bin/find >> tmp.sh" 
+		     "sed 's/^M$//' tmp.sh  > tmp2.sh"
+		     "sh ./tmp2.sh" "rm ./tmp.sh ./tmp2.sh")
   :load-path ("./common"))

--- a/recipes/dvc.el
+++ b/recipes/dvc.el
@@ -2,6 +2,7 @@
   :type bzr
   :url "http://bzr.xsteve.at/dvc/"
   :build ("autoconf" "./configure" "make")
+  :build/windows-nt ("sh /usr/bin/autoconf" "sh ./configure" "make")
   :features dvc-autoloads
   :info "texinfo"
   :load-path ("./lisp"))

--- a/recipes/emacs-w3m.el
+++ b/recipes/emacs-w3m.el
@@ -3,4 +3,5 @@
       :module "emacs-w3m"
       :url ":pserver:anonymous@cvs.namazu.org:/storage/cvsroot"
       :build `("autoconf" ("./configure" ,(concat "--with-emacs=" el-get-emacs)) "make")
+      :build/windows-nt ("sh /usr/bin/autoconf" "sh ./configure" "make")
       :info "doc")

--- a/recipes/geiser.el
+++ b/recipes/geiser.el
@@ -4,6 +4,8 @@
        :load-path ("./elisp")
        :build `("./autogen.sh" "./configure" "make"
 	       ,(concat "cd doc ; " el-get-install-info " --dir-file=./dir *.info"))
+       :build/windows-nt `("sh ./autogen.sh" "sh ./configure" "make"
+	       ,(concat "cd doc & " el-get-install-info " --dir-file=./dir *.info"))
        :info "doc"
        :features geiser-load
        )


### PR DESCRIPTION
Hello,
I've fixed the recipes: cedet, emacs-w3m, geiser, dvc to be able to build them on windows. But it requires cygwin bin in PATH. I do hope it could be useful for other people.
Thank you for your great project.

Kind regards,
Nodir
