### PR TITLE
fix for magit.el recipe

### DIFF
--- a/recipes/magit.el
+++ b/recipes/magit.el
@@ -1,6 +1,6 @@
 (:name magit
        :type git
-       :url "http://github.com/philjackson/magit.git"
+       :url "http://github.com/magit/magit.git"
        :info "."
        ;; that used to be how to build it :build ("./autogen.sh" "./configure" "make")
        :build ("make all")


### PR DESCRIPTION
It looks like http://github.com/philjackson/magit.git no longer valid.
Fixed with correct link.
