### PR TITLE
Changed Solarized Theme Repository

### DIFF
--- a/recipes/color-theme-solarized.el
+++ b/recipes/color-theme-solarized.el
@@ -1,4 +1,4 @@
 (:name color-theme-solarized
-       :type http
-       :url "https://gist.github.com/raw/888286/7bb905279b1af2c1bec525e71a4f0cca8948c90a/color-theme-solarized.el"
-       :load "color-theme-solarized.el")
+       :type git
+       :url "https://github.com/sellout/emacs-color-theme-solarized.git"
+       :features color-theme-solarized)


### PR DESCRIPTION
Modified the Solarized color theme recipe to use the [Emacs-only repository](https://github.com/sellout/emacs-color-theme-solarized) the developer of the Emacs port uses. The developer, @sellout, has been making some improvements that are not appearing in the [main repository](https://github.com/altercation/solarized) yet as it appears to lag behind by a few days/weeks.
