### PR TITLE
Fix wrong URL in org-website recipe.

### DIFF
--- a/recipes/org-website.el
+++ b/recipes/org-website.el
@@ -1,3 +1,3 @@
 (:name org-website
        :type git
-       :url "https://github.com:renard/org-website.git")
+       :url "https://github.com/renard/org-website.git")


### PR DESCRIPTION
Hi Dimitri:

The org-website recipe does not work due to wrong URL in the recipe.
Please check and merge.  Thanks.

Best regards,
Tibor Simko
