### PR TITLE
Don't require the haml-mode feature; autoloads are fine

### DIFF
--- a/recipes/haml-mode.el
+++ b/recipes/haml-mode.el
@@ -1,4 +1,3 @@
 (:name haml-mode
        :type git
-       :url "https://github.com/nex3/haml-mode.git"
-       :features haml-mode)
+       :url "https://github.com/nex3/haml-mode.git")


### PR DESCRIPTION
As per the new el-get policy, haml-mode does not need to use :features.  It provides autoloads both for haml-mode and to add haml-mode to auto-mode-alist,  Let's use these instead.

Please apply.

Ethan
