### PR TITLE
Fix for sunrise-x-___. github/emacsmirror/sunrise-x-___ no longer exists.

### DIFF
--- a/recipes/sunrise-x-buttons.el
+++ b/recipes/sunrise-x-buttons.el
@@ -1,4 +1,4 @@
 (:name sunrise-x-buttons
-       :type git
-       :url "git://github.com/emacsmirror/sunrise-x-buttons.git"
+       :type emacswiki
+       :url "https://github.com/emacsmirror/sunrise-commander/raw/master/sunrise-x-buttons.el"
        :features sunrise-x-buttons)

--- a/recipes/sunrise-x-checkpoints.el
+++ b/recipes/sunrise-x-checkpoints.el
@@ -1,4 +1,4 @@
 (:name sunrise-x-checkpoints
-       :type git
-       :url "git://github.com/emacsmirror/sunrise-x-checkpoints.git"
+       :type emacswiki
+       :url "https://github.com/emacsmirror/sunrise-commander/raw/master/sunrise-x-checkpoints.el"
        :features sunrise-x-checkpoints)

--- a/recipes/sunrise-x-loop.el
+++ b/recipes/sunrise-x-loop.el
@@ -1,4 +1,4 @@
 (:name sunrise-x-loop
-       :type git
-       :url "git://github.com/emacsmirror/sunrise-x-loop.git"
+       :type emacswiki
+       :url "https://github.com/emacsmirror/sunrise-commander/raw/master/sunrise-x-loop.el"
        :features sunrise-x-loop)

--- a/recipes/sunrise-x-mirror.el
+++ b/recipes/sunrise-x-mirror.el
@@ -1,4 +1,4 @@
 (:name sunrise-x-mirror
-       :type git
-       :url "git://github.com/emacsmirror/sunrise-x-mirror.git"
+       :type emacswiki
+       :url "https://github.com/emacsmirror/sunrise-commander/raw/master/sunrise-x-mirror.el"
        :features sunrise-x-mirror)

--- a/recipes/sunrise-x-modeline.el
+++ b/recipes/sunrise-x-modeline.el
@@ -1,4 +1,4 @@
 (:name sunrise-x-modeline
-       :type git
-       :url "git://github.com/emacsmirror/sunrise-x-modeline.git"
+       :type emacswiki
+       :url "https://github.com/emacsmirror/sunrise-commander/raw/master/sunrise-x-modeline.el"
        :features sunrise-x-modeline)

--- a/recipes/sunrise-x-popviewer.el
+++ b/recipes/sunrise-x-popviewer.el
@@ -1,4 +1,4 @@
 (:name sunrise-x-popviewer
-       :type git
-       :url "git://github.com/emacsmirror/sunrise-x-popviewer.git"
+       :type emacswiki
+       :url "https://github.com/emacsmirror/sunrise-commander/raw/master/sunrise-x-popviewer.el"
        :features sunrise-x-popviewer)

--- a/recipes/sunrise-x-tabs.el
+++ b/recipes/sunrise-x-tabs.el
@@ -1,4 +1,4 @@
 (:name sunrise-x-tabs
-       :type git
-       :url "git://github.com/emacsmirror/sunrise-x-tabs.git"
+       :type emacswiki
+       :url "https://github.com/emacsmirror/sunrise-commander/raw/master/sunrise-x-tabs.el"
        :features sunrise-x-tabs)

--- a/recipes/sunrise-x-tree.el
+++ b/recipes/sunrise-x-tree.el
@@ -1,4 +1,4 @@
 (:name sunrise-x-tree
-       :type git
-       :url "git://github.com/emacsmirror/sunrise-x-tree.git"
+       :type emacswiki
+       :url "https://github.com/emacsmirror/sunrise-commander/raw/master/sunrise-x-tree.el"
        :features sunrise-x-tree)


### PR DESCRIPTION
Fixed error caused by bad url. Used :type emacswiki because I don't know a better way for wget.
