### PR TITLE
recipes: org-mode should add "." to load-path

### DIFF
--- a/recipes/org-mode.el
+++ b/recipes/org-mode.el
@@ -6,7 +6,7 @@
                  (lambda (target)
                    (concat "make " target " EMACS=" el-get-emacs))
                  '("clean" "all"))
-       :load-path ("lisp" "contrib/lisp")
+       :load-path ("." "lisp" "contrib/lisp")
        :autoloads nil
        :features org-install)
 


### PR DESCRIPTION
recipes: org-mode should add "." to load-path or some autoloads in org-install fail. (e.g. org-agenda is an autoload to lisp/org-agenda and fails if "." is not in the load-path)
