### PR TITLE
recipes/reftex: do not use :after in recipe.

### DIFF
--- a/recipes/reftex.el
+++ b/recipes/reftex.el
@@ -5,6 +5,4 @@
        :build ("make" "make info")
        :features reftex
        :load-path ("lisp")
-       :info "doc"
-       :after (lambda ()
-		(load "reftex")))
+       :info "doc")


### PR DESCRIPTION
Load unnecessary anyway becase :features are required.
