### PR TITLE
recipes/matlab-mode: Matlab mode's build system depends on cedet.

### DIFF
--- a/recipes/matlab-mode.el
+++ b/recipes/matlab-mode.el
@@ -2,6 +2,7 @@
        :type cvs
        :module "matlab-emacs"
        :url ":pserver:anonymous@matlab-emacs.cvs.sourceforge.net:/cvsroot/matlab-emacs"
+       :depends cedet
        :build ("make")
        :load-path (".")
        :features matlab-load)


### PR DESCRIPTION
Added a :depends cedet or else the make fails.

See http://matlab-emacs.cvs.sourceforge.net/viewvc/matlab-emacs/matlab-emacs/INSTALL?view=markup
