### PR TITLE
Use GitHub's mirror for python-mode

### DIFF
--- a/recipes/python-mode.el
+++ b/recipes/python-mode.el
@@ -1,6 +1,6 @@
 (:name python-mode
-       :type bzr
-       :url "lp:python-mode"
+       :type git
+       :url "https://github.com/emacsmirror/python-mode.git"
        :features (python-mode doctest-mode)
        :compile nil
        :post-init (lambda ()


### PR DESCRIPTION
Use GitHub's mirror for python-mode (older systems like SLES11 don't understand lp:\* addresses)
