### PR TITLE
Use more of the same code path for sync and async operations

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -2359,30 +2359,6 @@ recursion.
          (bytecomp-command (el-get-construct-package-byte-compile-command package))
 	 (default-directory (file-name-as-directory wdir)))
 
-    (if sync
-	(progn
-	  ;; first byte-compile the package, with another "clean" emacs process
-          (if bytecomp-command
-              (let ((build-cmd (mapconcat 'identity bytecomp-command " ")))
-                (message "%S" (shell-command-to-string build-cmd)))
-            (message "el-get: byte-compiling skipped for %s" package))
-
-	  (dolist (c commands)
-            (let ((cmd
-                   (if (stringp c) c
-                     (mapconcat 'shell-quote-argument c " "))))
-              (message "%S" (shell-command-to-string cmd))))
-
-	  ;; now build the Info dir --- some packages will build the info file
-	  ;; in the previous step
-	  (unless installing-info
-	    (el-get-install-or-init-info package 'build))
-
-	  ;; finally call the post-build fin
-	  (when (and post-build-fun (functionp post-build-fun))
-	    (funcall post-build-fun package)))
-
-      ;; async
       (let* ((process-list
 	      (mapcar (lambda (c)
 			(let* ((split    (if (stringp c)
@@ -2394,6 +2370,7 @@ recursion.
 			       (args     (cdr split)))
 
 			  `(:command-name ,name
+                                          :sync sync
 					  :buffer-name ,buf
 					  :default-directory ,wdir
 					  :shell t
@@ -2407,6 +2384,7 @@ recursion.
 	      (append (when bytecomp-command
                         (list
                          `(:command-name "byte-compile"
+                                         :sync sync
                                          :buffer-name ,buf
                                          :default-directory ,wdir
                                          :shell t
@@ -2424,7 +2402,7 @@ recursion.
 		  (el-get-install-or-init-info package 'build)
 		  (funcall post-build-fun package)))))
 
-	(el-get-start-process-list package full-process-list post-build-fun)))))
+	(el-get-start-process-list package full-process-list post-build-fun))))
 
 
 ;;


### PR DESCRIPTION
Addresses but does not purport to fix #269.  This should at least make everything easier to test and reveal where things fail with async even when you're testing with sync.  I do expect this will break some things when doing only sync operations, because as #269 demonstrates, some things are currently broken only for async.

You could also go further with this, making a whole sync/async process API that lets you interact with both the same way, and rewrite el-get-start-process-list in terms of that.  Seems like a lot of work for likely little gain though.
