### PR TITLE
recipes/drag-stuff load type

### DIFF
--- a/recipes/drag-stuff.el
+++ b/recipes/drag-stuff.el
@@ -1,4 +1,3 @@
 (:name drag-stuff
-       :type git
-       :url "https://github.com/rejeep/drag-stuff.git"
-       :features drag-stuff)
+       :type http
+       :url "https://github.com/rejeep/drag-stuff/raw/master/drag-stuff.el")


### PR DESCRIPTION
recipes/drag-stuff: load extension via http instead of git, due to submodules [issue](https://github.com/rejeep/drag-stuff/issues/1) during clone process.
