### PR TITLE
Recipe for ProofGeneral (requires Emacs >= 23.3)

### DIFF
--- a/recipes/ProofGeneral.el
+++ b/recipes/ProofGeneral.el
@@ -1,0 +1,7 @@
+(:name ProofGeneral ;; Requires Emacs >= 23.3
+       :type http-tar
+       :options ("xzf")
+       :url "http://proofgeneral.inf.ed.ac.uk/releases/ProofGeneral-4.1RC2.tgz"
+       :build ("cd ProofGeneral && make clean" "cd ProofGeneral && make compile")
+       :load  ("ProofGeneral/generic/proof-site.el")
+       :info "./ProofGeneral/doc/")


### PR DESCRIPTION
Adds a new recipe for ProofGeneral (http://proofgeneral.inf.ed.ac.uk/)
