### PR TITLE
Distel moved to github.

### DIFF
--- a/recipes/distel.el
+++ b/recipes/distel.el
@@ -1,6 +1,8 @@
 (:name distel
-       :type svn
-       :url "http://distel.googlecode.com/svn/trunk/"
+       :website "https://github.com/massemanet/distel"
+       :description "Distributed Emacs Lisp for Erlang."
+       :type git
+       :url "https://github.com/massemanet/distel.git"
        :info "doc"
        :build `,(mapcar
                  (lambda (target)


### PR DESCRIPTION
recipes/distel.el: Distel moved to github. Updated recipe to use new repo and added :description/:website property.

See http://code.google.com/p/distel/ "This repo is no longer updated. Distel is now hosted on github."
