### PR TITLE
Add a recipe for jda-minor-mode

### DIFF
--- a/recipes/jda-minor-mode.el
+++ b/recipes/jda-minor-mode.el
@@ -1,0 +1,8 @@
+(:name jda-minor-mode
+       :website "https://github.com/jglee1027/jda-minor-mode#readme"
+       :description "Jong-Gyu Development Assistant minor mode for Developers(like emacs-textmate or VisualAssist"
+       :type git
+       :url "https://github.com/jglee1027/jda-minor-mode.git"
+       :features jda
+       :load    "jda.el"
+       :compile "jda.el")


### PR DESCRIPTION
jda-minor-mode is an Emacs minor-mode written by me for all developers.
see https://github.com/jglee1027/jda-minor-mode
