### PR TITLE
Last package name not showing up in completion lists

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -2394,7 +2394,7 @@ each directory listed in `el-get-recipe-path' in order."
      (loop for dir in (el-get-recipe-dirs)
 	   nconc (loop for recipe in (directory-files dir nil "^[^.].*\.el$")
 		       for filename = (concat (file-name-as-directory dir) recipe)
-		       and package = (file-name-sans-extension (file-name-nondirectory recipe))
+		       for package = (file-name-sans-extension (file-name-nondirectory recipe))
 		       unless (member package packages)
 		       do (push package packages)
                        and collect (ignore-errors (el-get-read-recipe-file filename)))))))


### PR DESCRIPTION
When el-get completes package names in the minibuffer it doesn't have the last package name in the list. For example, when using `el-get-install` interactively it doesn't show zencoding-mode as a suggested completion. It only shows up if it is already in el-get-sources. Same thing happens for other recipe directories.

I was able to fix this by changing this line in `el-get-read-all-recipes`:

```
and package = (file-name-sans-extension (file-name-nondirectory recipe))
```

to

```
for package = (file-name-sans-extension (file-name-nondirectory recipe))
```
