### PR TITLE
Added flymake-lua recipe and updated lua-mode recipe

### DIFF
--- a/recipes/flymake-lua.el
+++ b/recipes/flymake-lua.el
@@ -1,0 +1,7 @@
+(:name flymake-lua
+       :website "https://github.com/sroccaserra/emacs/blob/master/flymake-lua.el"
+       :description "Flymake support for Lua."
+       :type http
+       :url "https://raw.github.com/sroccaserra/emacs/master/flymake-lua.el"
+       :post-init (lambda ()
+		(add-hook 'lua-mode-hook 'flymake-lua-load)))

--- a/recipes/lua-mode.el
+++ b/recipes/lua-mode.el
@@ -1,7 +1,5 @@
 (:name lua-mode
+       :website "https://github.com/immerrr/lua-mode"
+       :description "A major mode for editing Lua scripts."
        :type git
-       :url "https://github.com/rrthomas/lua-mode.git"
-       :features lua-mode
-       :post-init (lambda ()
-		    (add-to-list 'auto-mode-alist '("\\.lua\\'" . lua-mode))
-		    (autoload 'lua-mode "lua-mode" "Lua editing mode." t)))
+       :url "https://github.com/immerrr/lua-mode")


### PR DESCRIPTION
New recipe for Flymake support for Lua and updated the existing lua-mode recipe to its new home since the previous download location is no longer available.
