### PR TITLE
BUGFIX: elisp lambdas are not closures

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -2281,6 +2281,10 @@ absolute filename obtained with expand-file-name is executable."
 	  ((file-executable-p fullname) fullname)
 	  (t (or exe name)))))
 
+(defun el-get-finish-build (post-build-fun package)
+  (el-get-install-or-init-info package 'build)
+  (funcall post-build-fun package))
+
 (defun el-get-build
   (package commands &optional subdir sync post-build-fun installing-info)
   "Run each command from the package directory.
@@ -2348,9 +2352,7 @@ recursion.
 	 ;; building info too
 	 (build-info-then-post-build-fun
 	  (if installing-info post-build-fun
-	    (lambda (package)
-	      (el-get-install-or-init-info package 'build)
-	      (funcall post-build-fun package)))))
+            (apply-partially 'el-get-finish-build post-build-fun))))
 
     (el-get-start-process-list
      package full-process-list build-info-then-post-build-fun)))


### PR DESCRIPTION
The lambda doesn't do what you think because post-build-fun doesn't get bound into the lambda.

See http://www.emacswiki.org/emacs/DynamicBindingVsLexicalBinding and
http://www.emacswiki.org/emacs/FakeClosures
