### PR TITLE
Use undo-tree from git

### DIFF
--- a/recipes/undo-tree.el
+++ b/recipes/undo-tree.el
@@ -1,3 +1,6 @@
 (:name undo-tree
-       :type http
-       :url "http://www.dr-qubit.org/undo-tree/undo-tree.el")
+       :type git
+       :url "http://www.dr-qubit.org/git/undo-tree.git"
+       :after (lambda ()
+                (autoload 'undo-tree-mode "undo-tree.el" "Undo tree mode; see undo-tree.el for details" t)
+                (autoload 'global-undo-tree-mode "undo-tree.el" "Global undo tree mode" t)))


### PR DESCRIPTION
This commit switches to undo-tree from git, which has a nice feature that it doesn't enable in buffers that define their own "undo" behavior (calc-mode being the notable example).

Also, this commit provides autoloads for undo-tree functions, making it conform better to policy.  I've emailed upstream requesting that he add autoload cookies to the relevant functions, but he hasn't yet responded.
