### PR TITLE
Improve support for emacsmirror packages

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -297,6 +297,10 @@ force their evaluation on some packages only."
 		       :install-hook el-get-git-clone-hook
 		       :update el-get-git-pull
 		       :remove el-get-rmdir)
+    :emacsmirror (:install el-get-emacsmirror-clone
+		       :install-hook el-get-git-clone-hook
+		       :update el-get-git-pull
+		       :remove el-get-rmdir)
     :git-svn (:install el-get-git-svn-clone
 		       :install-hook el-get-git-svn-clone-hook
 		       :update el-get-git-svn-update
@@ -451,6 +455,16 @@ Used to avoid errors when exploring the path for recipes"
   "The emacswiki base URL used in the index"
   :group 'el-get
   :type 'string)
+
+(defcustom el-get-emacsmirror-base-url
+  "http://github.com/emacsmirror/%s.git"
+  "The base URL where to fetch :emacsmirror packages.  Consider using
+\"git://github.com/emacsmirror/%s.git\"."
+  :group 'el-get
+  :type '(choice (const "http://github.com/emacsmirror/%s.git")
+                 (const "https://github.com/emacsmirror/%s.git")
+                 (const "git://github.com/emacsmirror/%s.git")
+                 string))
 
 (defcustom el-get-pacman-base "/usr/share/emacs/site-lisp"
   "Where to link the el-get symlink to, /<package> will get appended."
@@ -1286,7 +1300,13 @@ found."
 		      :message "git submodule update ok"
 		      :error "Could not update git submodules"))
      post-update-fun)))
-
+
+;;
+;; emacsmirror support
+;;
+(defun el-get-emacsmirror-clone (package url post-install-fun)
+  (let ((url (or url (format el-get-emacsmirror-base-url package))))
+    (el-get-git-clone package url post-install-fun)))
 
 ;;
 ;; git-svn support

--- a/recipes/cheat.el
+++ b/recipes/cheat.el
@@ -1,0 +1,1 @@
+(:name cheat :type emacsmirror)

--- a/recipes/dired-plus.el
+++ b/recipes/dired-plus.el
@@ -1,1 +1,1 @@
-(:name dired-plus :type git :url "https://github.com/emacsmirror/dired-plus.git")
+(:name dired-plus :type emacsmirror)

--- a/recipes/imaxima.el
+++ b/recipes/imaxima.el
@@ -1,4 +1,3 @@
 (:name imaxima
-       :type git
-       :url "https://github.com/emacsmirror/imaxima.git"
+       :type emacsmirror
        :features imaxima)

--- a/recipes/javadoc-help.el
+++ b/recipes/javadoc-help.el
@@ -1,0 +1,1 @@
+(:name javadoc-help :type emacsmirror)

--- a/recipes/js2-mode.el
+++ b/recipes/js2-mode.el
@@ -1,6 +1,5 @@
 (:name js2-mode
-       :type git
-       :url "https://github.com/emacsmirror/js2-mode.git"
+       :type emacsmirror
        :compile "js2-mode.el"
        :post-init (lambda ()
 		    (autoload 'js2-mode "js2-mode" nil t)))

--- a/recipes/nxhtml.el
+++ b/recipes/nxhtml.el
@@ -1,6 +1,5 @@
 (:name nxhtml
-       :type git
+       :type emacsmirror
        :build
          (list (concat el-get-emacs " -batch -q -no-site-file -L . -l nxhtmlmaint.el -f nxhtmlmaint-start-byte-compilation"))
-       :url "http://github.com/emacsmirror/nxhtml.git"
        :load "autostart.el")

--- a/recipes/oddmuse.el
+++ b/recipes/oddmuse.el
@@ -1,0 +1,1 @@
+(:name oddmuse :type emacsmirror)

--- a/recipes/python-mode.el
+++ b/recipes/python-mode.el
@@ -1,6 +1,5 @@
 (:name python-mode
-       :type git
-       :url "https://github.com/emacsmirror/python-mode.git"
+       :type emacsmirror
        :features (python-mode doctest-mode)
        :compile nil
        :post-init (lambda ()

--- a/recipes/python-pep8.el
+++ b/recipes/python-pep8.el
@@ -1,6 +1,5 @@
 (:name python-pep8
-       :type git
-       :url "https://github.com/emacsmirror/python-pep8.git"
+       :type emacsmirror
        :features python-pep8
        :post-init (lambda ()
 		    (require 'tramp)))

--- a/recipes/smartchr.el
+++ b/recipes/smartchr.el
@@ -1,4 +1,3 @@
 (:name smartchr
-       :type git
-       :url "https://github.com/emacsmirror/smartchr.git"
+       :type emacsmirror
        :features smartchr)

--- a/recipes/tuareg-mode.el
+++ b/recipes/tuareg-mode.el
@@ -1,6 +1,5 @@
 (:name tuareg-mode
-       :type git
-       :url "https://github.com/emacsmirror/tuareg.git"
+       :type emacsmirror
        :load-path (".")
        :build ("make elc")
        :post-init


### PR DESCRIPTION
Provide a shortcut, :type emacsmirror.

(:name foo :type emacsmirror)

is equivalent to

(:name foo :type git :url "http://github.com/emacsmirror/foo.git")

except that the URL is user-configurable by customize.  We default to
http, but the user can choose https or git protocols if they prefer.

Additionally, we retrofit old recipes to use this shortcut.  Any
package whose name matches its emacsmirror repo name
qualifies.  Certain packages, such as sunrise-x-*, are no longer
entire git repositories, and so don't qualify.  bookmark+
does not qualify because its name in emacsmirror is spelled
bookmark-plus.  Similarly, color-theme-zenburn is just called zenburn,
so cannot be simplified this way.

We also add a few new recipes for emacsmirror packages, since it's so easy.
