### PR TITLE
Regarding issue 310 : error while compiling a package from el-get

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -2191,7 +2191,11 @@ newer, then compilation will be skipped."
       files)))
 
 (defun el-get-funcall-from-command-line-args ()
-  "Like `funcall', but reads FUNCTION and ARGS from command line"
+  "Like `funcall', but reads FUNCTION and ARGS from command line.
+
+Also set a command-line-function to prevent emacs to process the remaining arguments.
+A simple lambda function returning t will do."
+  (add-to-list 'command-line-functions '(lambda () t))
   (let ((args (mapcar 'read command-line-args-left)))
     (apply 'funcall args)))
 


### PR DESCRIPTION
Hi,

I looked a bit further into the emacs manual regarding the command line arguments processing and it seems that trying to open the remaining arguments as files is the normal behavior. Where does the error come, I have no idea… Trying from 2 other computers with sensibly the same configuration didn't trigger the error.

But anyway, here is a patch to prevent emacs to try and open the remaining arguments as files, if you are interested.
