### PR TITLE
Switch default entry format for el-get-sources

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -781,6 +781,7 @@ definition provided by `el-get' recipes locally.
   `(repeat
     (choice
      :tag "Entry"
+     :value (:name "")
      (el-get-symbol :tag "Name of EL-Get Package")
      (list
       :tag "Full Recipe (or Recipe Override)"


### PR DESCRIPTION
Having just a symbol in el-get-sources is now only useful for backward
compatibility.
