### PR TITLE
Fix gnuplot-mode recipe

### DIFF
--- a/recipes/gnuplot-mode.el
+++ b/recipes/gnuplot-mode.el
@@ -2,5 +2,5 @@
        :type http-tar
        :url "http://cars9.uchicago.edu/~ravel/software/gnuplot-mode/gnuplot-mode.0.6.0.tar.gz"
        :options ("xzf")
-       :build `("./configure" ,(concat "make EMACS=" el-get-emacs))
+       :build `("./configure", "touch info-look.elc", (concat "make EMACS=" el-get-emacs))
        :info "gnuplot.info")


### PR DESCRIPTION
This fix circumvents the check for info-look.el and assumes that it is already provided by emacs, which is the case since emacs 21.0.

The check in the Makefile assumes that the EMACS variable is only 'emacs' or 'xemacs', but we provide the full path, so that make exits with an error. Creating info-look.elc before invoking make skips the check.
