### PR TITLE
`python-mode.el` removed doctest-mode

### DIFF
--- a/recipes/python-mode.el
+++ b/recipes/python-mode.el
@@ -1,7 +1,7 @@
 (:name python-mode
        :type git
        :url "https://github.com/emacsmirror/python-mode.git"
-       :features (python-mode doctest-mode)
+       :features (python-mode)
        :compile nil
        :post-init (lambda ()
 		    (add-to-list 'auto-mode-alist '("\\.py$" . python-mode))


### PR DESCRIPTION
Not sure when this happened, but `doctest-mode` is not [there](http://bazaar.launchpad.net/~python-mode-devs/python-mode/python-mode/files).
