### PR TITLE
Adding wanderlust util dir to load path

### DIFF
--- a/recipes/wanderlust.el
+++ b/recipes/wanderlust.el
@@ -23,4 +23,4 @@
      ("compile-wl-package"  "site-lisp" "icons") 
      ("install-wl-package" "site-lisp" "icons")))
        :info "doc/wl.info"
-       :load-path ("site-lisp/wl"))
+       :load-path ("site-lisp/wl" "utils"))


### PR DESCRIPTION
Hi,

To get bbdb integration working with wanderlust, I needed to include the wanderlust/utils/ dir in the load path.  This seems to be most easily handled by patching the recipe.  If this seems like a good idea, please consider pulling the patch.

Thanks much,
Sasha
