### PR TITLE
Added .scss to sass-mode

### DIFF
--- a/recipes/sass-mode.el
+++ b/recipes/sass-mode.el
@@ -2,4 +2,6 @@
        :description "Major mode for editing Sass files"
        :type git
        :url "https://github.com/nex3/sass-mode.git"
-       :features sass-mode)
+       :features sass-mode
+       :post-init (lambda ()
+                    (add-to-list 'auto-mode-alist '("\\.scss$" . sass-mode))))


### PR DESCRIPTION
The commonly used sass extension is .scss but sass-mode does not provide it, so I did it in post-install
