### PR TITLE
doctest-mode is still on emacsmirror in the same repo as python-mode. It 

### DIFF
--- a/recipes/python-mode.el
+++ b/recipes/python-mode.el
@@ -1,8 +1,9 @@
 (:name python-mode
        :type emacsmirror
        :description "Major mode for editing Python programs"
-       :features python-mode
+       :features (python-mode doctest-mode)
        :compile nil
+       :load "test/doctest-mode.el"
        :post-init (lambda ()
             (add-to-list 'auto-mode-alist '("\\.py$" . python-mode))
             (add-to-list 'interpreter-mode-alist '("python" . python-mode))


### PR DESCRIPTION
doctest-mode is still on emacsmirror in the same repo as python-mode. It was moved to a subdirectory.

this should close #368
