### PR TITLE
Allow install from current master

### DIFF
--- a/el-get-install.el
+++ b/el-get-install.el
@@ -53,7 +53,7 @@
       ;; switch branch if we have to
       (let* ((branch  (plist-get (with-temp-buffer
 				   (insert-file-contents-literally
-				    (expand-file-name "recipes/el-get.el" pdir))
+				    (expand-file-name "recipes/el-get.rcp" pdir))
 				   (read (current-buffer)))
 				 :branch))
 	     (branch (when branch (concat "origin/" branch)))


### PR DESCRIPTION
Install breaks on current master because the recipe has been renamed to el-get.rcp.
