### PR TITLE
el-get-install.el: Allow users to change the install directory

### DIFF
--- a/el-get-install.el
+++ b/el-get-install.el
@@ -19,7 +19,8 @@
 
 (let ((el-get-root
        (file-name-as-directory
-	(concat (file-name-as-directory user-emacs-directory) "el-get"))))
+	(or (and (boundp 'el-get-dir) el-get-dir)
+	    (concat (file-name-as-directory user-emacs-directory) "el-get")))))
 
   (when (file-directory-p el-get-root)
     (add-to-list 'load-path el-get-root))


### PR DESCRIPTION
Use the value of `el-get-dir` (if already set) to determine where to install el-get.
