### PR TITLE
Fixed after => post-init in the yaml-mode recipe 

### DIFF
--- a/recipes/yaml-mode.rcp
+++ b/recipes/yaml-mode.rcp
@@ -2,6 +2,6 @@
        :description "Simple major mode to edit YAML file for emacs"
        :type git
        :url "https://github.com/yoshiki/yaml-mode.git"
-       :after (lambda ()
-                (autoload 'yaml-mode "yaml-mode" nil t)
-                (add-to-list 'auto-mode-alist '("\\.ya?ml\\'" . yaml-mode))))
+       :post-init (lambda ()
+                    (autoload 'yaml-mode "yaml-mode" nil t)
+                    (add-to-list 'auto-mode-alist '("\\.ya?ml\\'" . yaml-mode))))


### PR DESCRIPTION
This should probably be a post-init and not an after, so user-defined :after hooks don't override it.
