### PR TITLE
Elpa installation error symlinking package

### DIFF
--- a/methods/el-get-elpa.el
+++ b/methods/el-get-elpa.el
@@ -83,8 +83,7 @@ the recipe, then return nil."
 	  (make-directory (el-get-package-directory package))
 	(message "%s"
 		 (shell-command
-		  (concat "cd " el-get-dir
-			  " && ln -s \"" elpa-dir "\" \"" package "\"")))))))
+		  (format "cd %s && ln -s \"%s\" \"%s\"" el-get-dir elpa-dir package)))))))
 
 (defun el-get-elpa-install (package url post-install-fun)
   "Ask elpa to install given PACKAGE."


### PR DESCRIPTION
I was getting some errors trying to install elpa packages 

The error I would get was:
shell-command: Wrong type argument: sequencep, ruby-mode

I fixed it formatting the string instead of concatenating variables
