### PR TITLE
Installer fix

### DIFF
--- a/el-get-install.el
+++ b/el-get-install.el
@@ -73,4 +73,3 @@
       (with-current-buffer buf
 	(goto-char (point-max))
 	(insert "\nCongrats, el-get is installed and ready to serve!")))))
-


### PR DESCRIPTION
A few small fixes, plus the important one below:
# Load el-get before let-binding el-get variables

Before, the newly-installed el-get package was loaded while `el-get-default-process-sync` and `el-get-post-install` were let-bound, which caused their corresponding `defvar` statements to be ignored, which resulted in a non-functional el-get unless one manually re-loaded el-get or restarted emacs. To fix this, el-get is loaded before the let-binding of these variables, so the `defvar` statements have a chance to work first. With this fix, el-get will be ready to go as soon as the installer finishes.
