### PR TITLE
el-get-package-method should use the package def not the argument passed 

### DIFF
--- a/el-get-recipes.el
+++ b/el-get-recipes.el
@@ -142,7 +142,7 @@ return 'builtin."
 
     (if (and builtin (>= emacs-major-version builtin))
         'builtin
-      (plist-get package-or-source :type))))
+      (plist-get def :type))))
 
 (defalias 'el-get-package-type #'el-get-package-method)
 


### PR DESCRIPTION
In adding the `builtin` type, I broke `el-get-package-method`, which has broken post-install hooks.

I noticed this when attempting to install color-theme; the http-tar install hook was never being run.

This fixes it.
