### PR TITLE
More build fixes

### DIFF
--- a/el-get-core.el
+++ b/el-get-core.el
@@ -77,6 +77,12 @@ returning a list that contains it (and only it)."
   (if (listp element-or-list) element-or-list
       (list element-or-list)))
 
+(defun el-get-list-of-strings-p (obj)
+  (or (null obj)
+      (and (consp obj)
+           (stringp (car obj))
+           (el-get-list-of-strings-p (cdr obj)))))
+
 (defun el-get-source-name (source)
   "Return the package name (stringp) given an `el-get-sources'
 entry."


### PR DESCRIPTION
- Fixed a bug where the first build command was assumed to be a string (not a list of strings)
- Check that all build commands are strings of lists of strings (after flattening)

See the commit messages for more info.
