### PR TITLE
Support el-get-install-branch to specify a branch to install.

### DIFF
--- a/el-get-install.el
+++ b/el-get-install.el
@@ -50,7 +50,7 @@
       ;; switch branch if we have to
       (let* ((branch (cond
                       ;; Check if a specific branch is requested
-                      ((bound-and-true-p 'el-get-install-branch))
+                      ((bound-and-true-p el-get-install-branch))
                       ;; Check if master branch is requested
                       ((boundp 'el-get-master-branch) "master")
                       ;; Read the default branch from the el-get recipe


### PR DESCRIPTION
Use it like this:

```
(url-retrieve
 "https://raw.github.com/dimitri/el-get/master/el-get-install.el"
 (lambda (s)
   (let ((el-get-install-branch "3.stable"))
     (end-of-buffer)
     (eval-print-last-sexp))))
```

This variable takes precedence over "el-get-master-branch", and must
be set to a string.

Documentation for this needs to be added to the readme.
