### PR TITLE
Remove extraneous parentheses

### DIFF
--- a/el-get-build.el
+++ b/el-get-build.el
@@ -32,7 +32,7 @@ strings, each string representing a single shell argument."
 	   (or (plist-get source build-type)
 	       (plist-get source :build)))
          (build-commands
-          (if (listp (raw-build-commands))
+          (if (listp raw-build-commands)
               ;; If the :build property's car is a symbol, assume that it is an
               ;; expression that evaluates to a command list, rather than a
               ;; literal command list.


### PR DESCRIPTION
I accidentally put parens around raw-build-commands, turning it into a void function call. Oops.
