### PR TITLE
Don't allow notification errors to halt el-get

### DIFF
--- a/el-get-notify.el
+++ b/el-get-notify.el
@@ -50,12 +50,13 @@
       (when (featurep 'notify)
 	(require 'notify))))
 
-  (cond ((fboundp 'notifications-notify) (notifications-notify :title title
-							       :body message))
-	((fboundp 'notify)               (notify title message))
-	((fboundp 'el-get-growl)         (el-get-growl title message))
-	(t                               (message "%s: %s" title message))))
-
+  (condition-case nil
+      (cond ((fboundp 'notifications-notify) (notifications-notify :title title
+                                                                   :body message))
+            ((fboundp 'notify)               (notify title message))
+            ((fboundp 'el-get-growl)         (el-get-growl title message))
+            (t                               (error "No notification system available")))
+    (error (message "%s: %s" title message))))
 (defun el-get-post-install-notification (package)
   "Notify the PACKAGE has been installed."
   (el-get-notify (format "%s installed" package)


### PR DESCRIPTION
Notify functions can sometimes fail (due to dbus errors and such), and
this should not cause el-get to halt, because notification is arguably
non-essential. If the chosen notification method fails, "message" is
used instead.

The particular error that led me to make this fix was that el-get pushed too many notifications onto the stack (more than 50), and dbus returned an error because the stack was full.
