### PR TITLE
add feature-mode recipe

### DIFF
--- a/recipes/feature-mode.rcp
+++ b/recipes/feature-mode.rcp
@@ -1,0 +1,7 @@
+(:name feature-mode
+       :description "Major mode for Cucumber feature files"
+       :type git
+       :url "git://github.com/michaelklishin/cucumber.el.git"
+       :features feature-mode
+       :post-init (lambda ()
+                    (add-to-list 'auto-mode-alist '("\\.feature\\'" . feature-mode))))


### PR DESCRIPTION
Adds a recipe for [feature-mode](https://github.com/michaelklishin/cucumber.el/), a mode for editing Cucumber .feature files.

Not sure why the :features property was necessary, but I couldn't get `(require 'feature-mode)` to function without it.
