### PR TITLE
Replace :after with :post-init in all recipes

### DIFF
--- a/recipes/puppet-mode.rcp
+++ b/recipes/puppet-mode.rcp
@@ -2,6 +2,6 @@
        :description "A simple mode for editing puppet manifests"
        :type http
        :url "http://projects.puppetlabs.com/projects/puppet/repository/revisions/master/raw/ext/emacs/puppet-mode.el"
-       :after (lambda ()
-                (autoload 'puppet-mode "puppet-mode" "Major mode for editing puppet manifests" t)
-                (add-to-list 'auto-mode-alist '("\\.pp$" . puppet-mode))))
+       :post-init (lambda ()
+                    (autoload 'puppet-mode "puppet-mode" "Major mode for editing puppet manifests" t)
+                    (add-to-list 'auto-mode-alist '("\\.pp$" . puppet-mode))))

--- a/recipes/textmate.rcp
+++ b/recipes/textmate.rcp
@@ -3,4 +3,4 @@
        :type git
        :url "https://github.com/defunkt/textmate.el.git"
        :features textmate
-       :after (lambda () (textmate-mode)))
+       :post-init (lambda () (textmate-mode)))

--- a/recipes/undo-tree.rcp
+++ b/recipes/undo-tree.rcp
@@ -2,6 +2,6 @@
        :description "Treat undo history as a tree"
        :type git
        :url "http://www.dr-qubit.org/git/undo-tree.git"
-       :after (lambda ()
-                (autoload 'undo-tree-mode "undo-tree.el" "Undo tree mode; see undo-tree.el for details" t)
-                (autoload 'global-undo-tree-mode "undo-tree.el" "Global undo tree mode" t)))
+       :post-init (lambda ()
+                    (autoload 'undo-tree-mode "undo-tree.el" "Undo tree mode; see undo-tree.el for details" t)
+                    (autoload 'global-undo-tree-mode "undo-tree.el" "Global undo tree mode" t)))


### PR DESCRIPTION
I literally just did

```
cd recipes
sed -ibak -e 's/:after/:post-init/g' *.rcp
rm *.bak
```

Then I fixed the indentation. I have no idea if some of those were actually _supposed_ to be :after and not :post-init, so if I'm wrong, don't merge it.
