### PR TITLE
Yasnippet has moved to GitHub, updated recipe accordingly.

### DIFF
--- a/recipes/yasnippet.rcp
+++ b/recipes/yasnippet.rcp
@@ -1,8 +1,8 @@
 (:name yasnippet
        :website "http://code.google.com/p/yasnippet/"
        :description "YASnippet is a template system for Emacs."
-       :type svn
-       :url "http://yasnippet.googlecode.com/svn/trunk/"
+       :type git
+       :url "https://github.com/capitaomorte/yasnippet.git"
        :features "yasnippet"
        :prepare (lambda ()                      
                       ;; Set up the default snippets directory


### PR DESCRIPTION
The author of Yasnippet has moved the project to GitHub as evident by the bottom of the [ReadMe](https://github.com/capitaomorte/yasnippet), and [this](https://github.com/alpaker/Fill-Column-Indicator/issues/3#issuecomment-2337411) comment.
