### PR TITLE
Inf ruby bond

### DIFF
--- a/recipes/inf-ruby-bond.rcp
+++ b/recipes/inf-ruby-bond.rcp
@@ -2,4 +2,5 @@
        :description "Use Bond autocompletion from inf-ruby buffers"
        :type git
        :url "https://github.com/pd/inf-ruby-bond.git"
+       :depends inf-ruby
        :features inf-ruby-bond)


### PR DESCRIPTION
Adds a recipe for my inf-ruby-bond project, which adds support to inf-ruby for using [Bond](http://github.com/cldwalker/bond) with inf-ruby.
