### PR TITLE
ipython recipe update to use python-mode

### DIFF
--- a/recipes/ipython.rcp
+++ b/recipes/ipython.rcp
@@ -4,4 +4,4 @@
        :url "http://ipython.scipy.org/dist/ipython.el"
        :features ipython
        :post-init (lambda ()
-            (setq py-python-command "ipython")))
+            (setq py-shell-name "ipython")))


### PR DESCRIPTION
python-mode.el says about py-python-command: "This variable is obsolete since version 6.0.4;use `py-shell-name' instead."
