### PR TITLE
color themes depend on color-theme and are automatically required

### DIFF
--- a/recipes/color-theme-almost-monokai.rcp
+++ b/recipes/color-theme-almost-monokai.rcp
@@ -3,4 +3,6 @@
        :type git
        :url "git://github.com/lut4rp/almost-monokai.git"
        :depends color-theme
-       :features color-theme-almost-monokai)
+       :post-init (lambda ()
+                    (autoload 'color-theme-almost-monokai "color-theme-almost-monokai"
+                      "color-theme: almost-monokai" t)))

--- a/recipes/color-theme-chocolate-rain.rcp
+++ b/recipes/color-theme-chocolate-rain.rcp
@@ -3,4 +3,6 @@
        :type git
        :url "https://github.com/marktran/color-theme-chocolate-rain.git"
        :depends color-theme
-       :load "color-theme-chocolate-rain.el")
+       :post-init (lambda ()
+                    (autoload 'color-theme-chocolate-rain "color-theme-chocolate-rain"
+                      "color-theme: chocolate-rain" t)))

--- a/recipes/color-theme-desert.rcp
+++ b/recipes/color-theme-desert.rcp
@@ -3,4 +3,6 @@
        :type git
        :url "https://github.com/superbobry/color-theme-desert.git"
        :depends color-theme
-       :features color-theme-desert)
+       :post-init (lambda ()
+                    (autoload 'color-theme-desert "color-theme-desert"
+                      "color-theme: desert" t)))

--- a/recipes/color-theme-ir-black.rcp
+++ b/recipes/color-theme-ir-black.rcp
@@ -1,6 +1,8 @@
 (:name color-theme-ir-black
        :description "IR Black Color Theme for Emacs."
-       :type git 
+       :type git
        :url "https://github.com/burke/color-theme-ir-black.git"
        :depends color-theme
-       :features color-theme-ir-black)
+       :post-init (lambda ()
+                    (autoload 'color-theme-ir-black "color-theme-ir-black"
+                      "color-theme: ir-black" t)))

--- a/recipes/color-theme-mac-classic.rcp
+++ b/recipes/color-theme-mac-classic.rcp
@@ -3,4 +3,6 @@
        :type git
        :url "https://github.com/jbw/color-theme-mac-classic.git"
        :depends color-theme
-       :features color-theme-mac-classic)
+       :post-init (lambda ()
+                    (autoload 'color-theme-mac-classic "color-theme-mac-classic"
+                      "color-theme: mac-classic" t)))

--- a/recipes/color-theme-railscasts.rcp
+++ b/recipes/color-theme-railscasts.rcp
@@ -3,4 +3,6 @@
        :type git
        :url "https://github.com/olegshaldybin/color-theme-railscasts.git"
        :depends color-theme
-       :load "color-theme-railscasts.el")
+       :post-init (lambda ()
+                    (autoload 'color-theme-railscasts "color-theme-railscasts"
+                      "color-theme: railscasts" t)))

--- a/recipes/color-theme-sanityinc.rcp
+++ b/recipes/color-theme-sanityinc.rcp
@@ -3,4 +3,8 @@
        :type git
        :url "https://github.com/purcell/color-theme-sanityinc.git"
        :depends color-theme
-       :features color-theme-sanityinc)
+       :post-init (lambda ()
+                    (autoload 'color-theme-sanityinc-light "color-theme-sanityinc"
+                      "color-theme: sanityinc-light" t)
+                    (autoload 'color-theme-sanityinc-dark "color-theme-sanityinc"
+                      "color-theme: sanityinc-dark" t)))

--- a/recipes/color-theme-solarized.rcp
+++ b/recipes/color-theme-solarized.rcp
@@ -3,4 +3,8 @@
        :type git
        :url "https://github.com/sellout/emacs-color-theme-solarized.git"
        :depends color-theme
-       :features color-theme-solarized)
+       :post-init (lambda ()
+                    (autoload 'color-theme-solarized-light "color-theme-solarized"
+                      "color-theme: solarized-light" t)
+                    (autoload 'color-theme-solarized-dark "color-theme-solarized"
+                      "color-theme: solarized-dark" t)))

--- a/recipes/color-theme-subdued.rcp
+++ b/recipes/color-theme-subdued.rcp
@@ -3,4 +3,6 @@
        :type http
        :url "http://jblevins.org/git/misc.git/plain/color-theme-subdued.el"
        :depends color-theme
-       :features color-theme-subdued)
+       :post-init (lambda ()
+                    (autoload 'color-theme-subdued "color-theme-subdued"
+                      "color-theme: subdued" t)))

--- a/recipes/color-theme-tango-2.rcp
+++ b/recipes/color-theme-tango-2.rcp
@@ -3,4 +3,6 @@
        :type git
        :url "https://github.com/wfarr/color-theme-tango-2.git"
        :depends color-theme
-       :features color-theme-tango-2)
+       :post-init (lambda ()
+                    (autoload 'color-theme-tango-2 "color-theme-tango-2"
+                      "color-theme: tango-2" t)))

--- a/recipes/color-theme-tango.rcp
+++ b/recipes/color-theme-tango.rcp
@@ -1,4 +1,7 @@
 (:name color-theme-tango
        :description "Color theme based on Tango Palette. Created by danranx@gmail.com"
        :type emacswiki
-       :load "color-theme-tango.el")
+       :depends color-theme
+       :post-init (lambda ()
+                    (autoload 'color-theme-tango "color-theme-tango"
+                      "color-theme: tango" t)))

--- a/recipes/color-theme-tangotango.rcp
+++ b/recipes/color-theme-tangotango.rcp
@@ -3,4 +3,6 @@
        :type git
        :url "https://github.com/juba/color-theme-tangotango.git"
        :depends color-theme
-       :features color-theme-tangotango)
+       :post-init (lambda ()
+                    (autoload 'color-theme-tangotango "color-theme-tangotango"
+                      "color-theme: tangotango" t)))

--- a/recipes/color-theme-tomorrow.rcp
+++ b/recipes/color-theme-tomorrow.rcp
@@ -2,5 +2,15 @@
        :description "Emacs highlighting using Chris Charles's Tomorrow color scheme"
        :type git
        :url "https://github.com/ccharles/Tomorrow-Theme.git"
-       :load "GNU Emacs/color-theme-tomorrow.el"
-       :depends color-theme)
+       :depends color-theme
+       :post-init (lambda ()
+                    (autoload 'color-theme-tomorrow "GNU Emacs/color-theme-tomorrow"
+                      "color-theme: tomorrow" t)
+                    (autoload 'color-theme-tomorrow-night "GNU Emacs/color-theme-tomorrow"
+                      "color-theme: tomorrow-night" t)
+                    (autoload 'color-theme-tomorrow-night-eighties "GNU Emacs/color-theme-tomorrow"
+                      "color-theme: tomorrow-night-eighties" t)
+                    (autoload 'color-theme-tomorrow-night-blue "GNU Emacs/color-theme-tomorrow"
+                      "color-theme: tomorrow-night-blue" t)
+                    (autoload 'color-theme-tomorrow-night-bright "GNU Emacs/color-theme-tomorrow"
+                      "color-theme: tomorrow-night-bright" t)))

--- a/recipes/color-theme-twilight.rcp
+++ b/recipes/color-theme-twilight.rcp
@@ -3,4 +3,6 @@
        :type git
        :url "http://github.com/crafterm/twilight-emacs.git"
        :depends color-theme
-       :features color-theme-twilight)
+       :post-init (lambda ()
+                    (autoload 'color-theme-twilight "color-theme-twilight"
+                      "color-theme: twilight" t)))

--- a/recipes/color-theme-zen-and-art.rcp
+++ b/recipes/color-theme-zen-and-art.rcp
@@ -2,4 +2,7 @@
        :description "Irfn's zen with a bit of art."
        :type git
        :url "https://github.com/irfn/zen-and-art.git"
-       :load "zen-and-art.el")
+       :depends color-theme
+       :post-init (lambda ()
+                    (autoload 'color-theme-zen-and-art "zen-and-art"
+                      "color-theme: zen-and-art" t)))


### PR DESCRIPTION
Autoloads are rarely (if ever?) present for color themes. color-theme-zenburn
installs its own in the :post-init hook, but that's not typically done for el-get
packages, so I've just added a :load or :feature property (depending on whether
the library provides a feature).

For color-theme-twilight, the current version available automatically installs
itself as the current color theme, so the :feature property is omitted. I have a
pull request in to the project, so if that's fixed, I'll add it.
