### PR TITLE
Signal an error if reading a recipe causes an error

### DIFF
--- a/el-get-recipes.el
+++ b/el-get-recipes.el
@@ -70,9 +70,12 @@ Used to avoid errors when exploring the path for recipes"
 ;;
 (defun el-get-read-recipe-file (filename)
   "Read given filename and return its content (a valid form is expected)"
-  (with-temp-buffer
-    (insert-file-contents-literally filename)
-    (read (current-buffer))))
+  (condition-case err
+      (with-temp-buffer
+        (insert-file-contents-literally filename)
+        (read (current-buffer)))
+    ((debug error)
+     (error "Error reading recipe %s: %S" filename err))))
 
 (defun el-get-recipe-filename (package)
   "Return the name of the file that contains the recipe for PACKAGE, if any."


### PR DESCRIPTION
While making my changes to my color-theme branch to use autoloading instead of :features, I left a closing paren off one of the recipes. During startup, (el-get 'sync ...) was dying with "unexpected end of file", but no indication of where the problem was. This change at least makes reading recipes a bit more vocal about parse errors.
