### PR TITLE
identica-mode recipe

### DIFF
--- a/recipes/identica-mode.rcp
+++ b/recipes/identica-mode.rcp
@@ -1,0 +1,5 @@
+(:name identica-mode
+       :description "An identi.ca/status.net client"
+       :type git
+       :url "http://git.savannah.gnu.org/cgit/identica-mode.git"
+       :features identica-mode)


### PR DESCRIPTION
The identica-mode download link at emacswiki is outdated (as stated on the wiki page).
The correct repository is at http://git.savannah.gnu.org/

Thanks for your great work
