### PR TITLE
Fix Github URL of scss-mode recipe

### DIFF
--- a/recipes/scss-mode.rcp
+++ b/recipes/scss-mode.rcp
@@ -1,5 +1,5 @@
 (:name scss-mode
        :description "Major mode for editing SCSS files(http://sass-lang.com)"
        :type git
-       :url "git@github.com:antonj/scss-mode.git"
+       :url "https://github.com/antonj/scss-mode.git"
        :features scss-mode)


### PR DESCRIPTION
The scss-mode recipe uses an incorrect public git url from github (afaics): git@github.com:antonj/scss-mode.git

This causes the recipe to fail to execute on my machine (perhaps because I haven't setup a valid github SSH key).

I've changed it to use the standard public git url over HTTPS: https://github.com/antonj/scss-mode.git 
