### PR TITLE
Slime recipe fixes.

### DIFF
--- a/recipes/slime.rcp
+++ b/recipes/slime.rcp
@@ -1,10 +1,11 @@
 (:name slime
        :description "Superior Lisp Interaction Mode for Emacs"
        :type git
-       :module "slime"
+       :features slime-autoloads
        :info "doc"
        :url "https://github.com/nablaone/slime.git"
        :load-path ("." "contrib")
        :compile (".")
        :build ("make -C doc")
+       :post-init slime-setup
        )


### PR DESCRIPTION
Hi,
I added proper initialization for the slime recipe: `:feature slime-autoloads` and a `slime-setup` call in post-init, as documented in https://github.com/nablaone/slime#readme

I also removed the unnecessary :module keyword, as it's not a cvs recipe.

This is the same pull request as the #480, but modified according to jd's request to use the autoloads instead of `require slime`.
