### PR TITLE
Forces windows-nt systems to use cmdproxy.exe as shell for el-get. (Issue #490)

### DIFF
--- a/el-get-build.el
+++ b/el-get-build.el
@@ -93,6 +93,7 @@ recursion.
 	 (wdir   (if subdir (concat (file-name-as-directory pdir) subdir) pdir))
 	 (buf    (format "*el-get-build: %s*" package))
 	 (default-directory (file-name-as-directory wdir))
+         (shell-file-name (if (eq system-type 'windows-nt) "cmdproxy.exe"))
 	 (process-list
 	  (mapcar (lambda (c)
 		    (let* ((split    (cond ((stringp c)


### PR DESCRIPTION
If shell-file-name is set to a cygwin shell (zsh, bash, etc) on windows-nt systems the path is improperly escaped.  This results in el-get not being able to properly install packages.  Testing for system-type and forcing windows-nt to use cmdproxy.exe allows for successful installation.

This is a potential fix for issue #490.
