### PR TITLE
Make nognus recipe work with paths containing spaces

### DIFF
--- a/recipes/nognus.rcp
+++ b/recipes/nognus.rcp
@@ -2,9 +2,8 @@
        :description "A newsreader for GNU Emacs"
        :type git
        :url "http://git.gnus.org/gnus.git"
-       :build ("./configure" "make")
+       :build `(("./configure" ,(concat "--with-emacs='" el-get-emacs "'")) ("make"))
        :build/windows-nt `(,(concat "\"make.bat " invocation-directory "\""))
-       :build/darwin `(,(concat "./configure --with-emacs=" el-get-emacs) "make")
        :info "texi"
        :load-path ("lisp")
        :autoloads nil


### PR DESCRIPTION
Also eliminated special build step for darwin.  One could have
multiple emacs executables (of different versions) installed on any
platform, and you want to be sure you're byte-compiling for the emacs
actually being used.
