### PR TITLE
Always use "message" to notify in a terminal

### DIFF
--- a/el-get-notify.el
+++ b/el-get-notify.el
@@ -51,12 +51,13 @@
 	(require 'notify))))
 
   (condition-case nil
-      (cond ((not (window-system))           (error "Fallback to message"))
-            ((fboundp 'notifications-notify) (notifications-notify :title title
-                                                                   :body message))
-            ((fboundp 'notify)               (notify title message))
-            ((fboundp 'el-get-growl)         (el-get-growl title message))
-            (t                               (error "Fallback to message")))
+      (cond
+       ((not (window-system))           (error "Fallback to message"))
+       ((fboundp 'notifications-notify) (notifications-notify :title title
+                                                              :body message))
+       ((fboundp 'notify)               (notify title message))
+       ((fboundp 'el-get-growl)         (el-get-growl title message))
+       (t                               (error "Fallback to message")))
     ;; when notification function errored out, degrade gracefully to `message'
     (error (message "%s: %s" title message))))
 


### PR DESCRIPTION
Now if you are running emacs in a terminal, el-get will always use `message` to do notifications.

This is the correct version of https://github.com/dimitri/el-get/pull/497 , along with a few other improvements.
