### PR TITLE
Update the Zenburn package name.

### DIFF
--- a/recipes/color-theme-zenburn.rcp
+++ b/recipes/color-theme-zenburn.rcp
@@ -1,6 +1,6 @@
 (:name color-theme-zenburn
        :type emacsmirror
-       :pkgname "zenburn"
+       :pkgname "zenburn-theme"
        :description "Just some alien fruit salad to keep you in the zone"
        :post-init
        (lambda ()


### PR DESCRIPTION
The Zenburn package changed its name on emacsmirror. This patch fixes the recipe.
