### PR TITLE
Set print-length and print-level to nil.

### DIFF
--- a/el-get-status.el
+++ b/el-get-status.el
@@ -49,7 +49,8 @@
 (defun el-get-save-package-status (package status)
   "Save given package status"
   (let ((p (el-get-package-symbol package))
-	(s (el-get-read-all-packages-status)))
+	(s (el-get-read-all-packages-status))
+	print-length print-level)
     (with-temp-file el-get-status-file
       (insert
        (format "%S" (if s (plist-put s p status)


### PR DESCRIPTION
This prevents .status.el from being written in an abbreviated form.

Signed-off-by: Sébastien Gross <seb•ɑƬ•chezwam•ɖɵʈ•org>
