### PR TITLE
Change default el-get-notify-type to both

### DIFF
--- a/el-get-notify.el
+++ b/el-get-notify.el
@@ -35,7 +35,7 @@
       (process-send-string proc (concat message "\n"))
       (process-send-eof proc))))
 
-(defcustom el-get-notify-type 'graphical
+(defcustom el-get-notify-type 'both
   "Type of notification to use for changes in package statuses
 
 Choices are `graphical', `message', or `both'. Note that if


### PR DESCRIPTION
This ensures that all el-get notifications will be logged in the
Messages buffer by default.

Note that the original default of "graphical" was chosen to be be
consistent with the behavior of el-get before the preference was
introduced.

Fixes #519
