### PR TITLE
In process byte compile

### DIFF
--- a/el-get-byte-compile.el
+++ b/el-get-byte-compile.el
@@ -74,7 +74,7 @@ newer, then compilation is skipped."
                 (add-to-list 'files fullpath)
               ;; path is a regexp, so add matching file names in package dir
               (mapc (apply-partially 'add-to-list 'files)
-		    (directory-files pdir nil fullpath))))))
+		    (directory-files pdir nil path))))))
 
        ;; If package has (:compile nil), or package has its own build
        ;; instructions, or package is already pre-compiled by the


### PR DESCRIPTION
Byte compilation wasn't working for all matched files in the package due to load-path issues in the sub-shelled batch emacs process.  This patch makes the compilation happen in-process instead.

Batch byte compilation is a good idea in a Makefile for a package as you can fully specify all the required load-path tweaks there.  But we don't have that information in el-get when processing a general package.

It's possible to set up a somewhat better load-path for the sub-proc using :load-path, but IMO that's a losing battle.  Much better to rely on the load-path already present in the current Emacs process.

There's a second patch that fixes the handling of the :compile property when it contains regexps.  Let me know if you want that separated.

Thanks for el-get, it's brilliant!  I'm finally motivated to use all the new package repos because of it.
