### PR TITLE
Attempted fix to ensure that autoloads are actually removed when uninstalling

### DIFF
--- a/el-get-autoloads.el
+++ b/el-get-autoloads.el
@@ -83,19 +83,20 @@
   "Remove from `el-get-autoload-file' any autoloads associated
 with the named PACKAGE"
   (when (file-exists-p el-get-autoload-file)
-    (with-temp-buffer ;; empty buffer to trick `autoload-find-destination'
-      (let ((generated-autoload-file el-get-autoload-file)
-            ;; Generating autoloads runs emacs-lisp-mode-hook; disable it
-            emacs-lisp-mode-hook
-            (autoload-modified-buffers (list (current-buffer))))
+    (let ((generated-autoload-file el-get-autoload-file)
+          ;; Generating autoloads runs emacs-lisp-mode-hook; disable it
+          emacs-lisp-mode-hook
+          (autoload-modified-buffers (list (current-buffer))))
+      (with-current-buffer (find-file-noselect el-get-autoload-file)
         (dolist (dir (el-get-load-path package))
           (when (file-directory-p dir)
             (dolist (f (directory-files dir t el-get-load-suffix-regexp))
               ;; this will clear out any autoloads associated with the file
               ;; `autoload-find-destination' signature has changed in emacs24.
-              (if (> emacs-major-version 23)
-                  (autoload-find-destination f (autoload-file-load-name f))
-                (autoload-find-destination f)))))))
+              (unless (if (> emacs-major-version 23)
+                          (autoload-find-destination f (autoload-file-load-name f))
+                        (autoload-find-destination f))
+                (autoload-remove-section (point))))))))
     (el-get-update-autoloads package)))
 
 (defun el-get-want-autoloads-p (package)


### PR DESCRIPTION
This is my attempt at fixing #446, using a modification of the code that @jd posted in the comment thread.

However, this still doesn't quite remove all traces of an uninstalled
package. Some comments are left behind, and I don't know if they are
functional or not.
