### PR TITLE
Add a some simple bash scripts for easily running tests

### DIFF
--- a/test/run-all-tests.sh
+++ b/test/run-all-tests.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+
+exec ./run-test.sh el-get-*.el 2>/dev/null

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 testfile1 [testfile2 ...]"
+  exit 0
+fi
+
+set_default () {
+  eval "
+if [ -z \$$1 ]; then
+  $1=$2
+fi
+"
+}
+
+set_default EL_GET_LIB_DIR "$(dirname "$(dirname "$(readlink -f "$0")")")"
+set_default TMPDIR "$(dirname "$(mktemp --dry-run)")"
+set_default TEST_HOME "$TMPDIR/el-get-test-home"
+set_default EMACS "$(which emacs)"
+
+run_test () {
+  testfile="$1"
+  echo "*** Running el-get test $testfile ***"
+  mkdir -p "$TEST_HOME"/.emacs.d
+  rm -rf "$TEST_HOME"/.emacs.d/el-get/
+  HOME="$TEST_HOME" "$EMACS" -Q -batch -L "$EL_GET_LIB_DIR" -l "$testfile"
+  result="$?"
+  if [ "$result" = 0 ]; then
+    echo "*** SUCCESS $testfile ***"
+  else
+    echo "*** FAILED $testfile ***"
+  fi
+}
+
+for t in "$@"; do
+  run_test "$t"
+done


### PR DESCRIPTION
I just took the directions in `test/README.asciidoc` and hacked them into a bash script to make it dead easy to run a test. I also added a second script to just run _all_ the tests at once, showing only the success or failure messages.

As a result, you can just do test/run-all-tests.sh to do a full-automated run of all available tests against the current version of el-get. Doing so on the latest master yields this output:

```
$ ./run-all-tests.sh 
*** Running el-get test el-get-issue-200.el ***
*** SUCCESS el-get-issue-200.el ***
*** Running el-get test el-get-issue-284.el ***
*** SUCCESS el-get-issue-284.el ***
*** Running el-get test el-get-issue-289.el ***
*** SUCCESS el-get-issue-289.el ***
*** Running el-get test el-get-issue-303.el ***
*** SUCCESS el-get-issue-303.el ***
*** Running el-get test el-get-issue-310.el ***
*** SUCCESS el-get-issue-310.el ***
*** Running el-get test el-get-issue-400.el ***
*** SUCCESS el-get-issue-400.el ***
*** Running el-get test el-get-issue-407.el ***
*** SUCCESS el-get-issue-407.el ***
*** Running el-get test el-get-issue-418.el ***
*** SUCCESS el-get-issue-418.el ***
*** Running el-get test el-get-issue-432.el ***
*** SUCCESS el-get-issue-432.el ***
```
