### PR TITLE
Support in-process emacswiki-refresh with prefix arg

### DIFF
--- a/methods/el-get-emacswiki.el
+++ b/methods/el-get-emacswiki.el
@@ -85,33 +85,43 @@ into a local recipe file set"
 	  (indent-region (point-min) (point-max))))))
 
 ;;;###autoload
-(defun el-get-emacswiki-refresh (&optional target-dir)
-  "run Emacs -Q in an asynchronous subprocess to get the package
-list from emacswiki and build a local recipe directory out of
-that"
+(defun el-get-emacswiki-refresh (&optional target-dir in-process)
+  "Generate recipes for all lisp files on Emacswiki.
+
+By default, this is done in a separate process so that you can
+continue to work while the recipes are being updated. If this
+fails, you can force the update to be done in-process by running
+this with a prefix arg (noninteractively: set optional arg
+`in-process' non-nil)."
   (interactive
    (list (let ((dummy (unless (file-directory-p el-get-recipe-path-emacswiki)
 			(make-directory el-get-recipe-path-emacswiki))))
 	   (read-directory-name "emacswiki recipes go to: "
-				el-get-recipe-path-emacswiki))))
-  (let* ((name "*el-get-emacswiki*")
-	 (dummy (when (get-buffer name) (kill-buffer name)))
-	 (args
-	  (format
-	   "-Q -batch -L %s -L %s -l %s -f el-get-emacswiki-build-local-recipes %s"
-	   (el-get-package-directory 'el-get)
-	   (expand-file-name "methods" (el-get-package-directory 'el-get))
-	   (file-name-sans-extension
-	    (symbol-file 'el-get-emacswiki-build-local-recipes 'defun))
-	   target-dir))
-	 (process
-	  (apply 'start-process name name el-get-emacs (split-string args))))
-    (message "%s %s" el-get-emacs args)
-    (set-process-sentinel
-     process
-     '(lambda (proc event)
-	(when (eq (process-status proc) 'exit)
-	  (el-get-notify "el-get: EmacsWiki"
-			 "EmacsWiki local recipe list refreshed"))))))
+				el-get-recipe-path-emacswiki))
+         current-prefix-arg))
+  (if in-process
+      (progn
+        (el-get-emacswiki-build-local-recipes target-dir)
+        (el-get-notify "el-get: EmacsWiki"
+                       "EmacsWiki local recipe list refreshed"))
+    (let* ((name "*el-get-emacswiki*")
+           (dummy (when (get-buffer name) (kill-buffer name)))
+           (args
+            (format
+             "-Q -batch -L %s -L %s -l %s -f el-get-emacswiki-build-local-recipes %s"
+             (el-get-package-directory 'el-get)
+             (expand-file-name "methods" (el-get-package-directory 'el-get))
+             (file-name-sans-extension
+              (symbol-file 'el-get-emacswiki-build-local-recipes 'defun))
+             target-dir))
+           (process
+            (apply 'start-process name name el-get-emacs (split-string args))))
+      (message "%s %s" el-get-emacs args)
+      (set-process-sentinel
+       process
+       '(lambda (proc event)
+          (when (eq (process-status proc) 'exit)
+            (el-get-notify "el-get: EmacsWiki"
+                           "EmacsWiki local recipe list refreshed")))))))
 
 (provide 'el-get-emacswiki)


### PR DESCRIPTION
Now `C-u M-x el-get-emacswiki-refresh` updates in-process.

Fixes #569.
