### PR TITLE
Add recipes for eproject, ghc-mod and scion.

### DIFF
--- a/recipes/eproject.rcp
+++ b/recipes/eproject.rcp
@@ -1,0 +1,9 @@
+(:name eproject
+       :description "File grouping (\"project\") extension for emacs"
+       :type git
+       :url "https://github.com/jrockway/eproject.git"
+       :load-path ("." "lang")
+       ;; the core functionality needs to be present.
+       ;; eproject-extras, otoh, has autoload cookies.
+       ;; lang/* can be added by the user as needed.
+       :features eproject)

--- a/recipes/ghc-mod.rcp
+++ b/recipes/ghc-mod.rcp
@@ -1,0 +1,5 @@
+(:name ghc-mod
+       :description "Happy Haskell programming"
+       :type git
+       :url "https://github.com/kazu-yamamoto/ghc-mod.git"
+       :load-path "elisp")

--- a/recipes/scion.rcp
+++ b/recipes/scion.rcp
@@ -1,0 +1,6 @@
+(:name scion
+       :description "IDE library for Haskell based on the GHC API."
+       :type git
+       :url "https://github.com/nominolo/scion.git"
+       :load-path "emacs"
+       :features scion)


### PR DESCRIPTION
ghc-mod and scion are haskell support modes.

eproject is from https://github.com/jrockway/eproject
