### PR TITLE
Fix pymacs: handle empty/missing PYTHONPATH correctly

### DIFF
--- a/recipes/pymacs.rcp
+++ b/recipes/pymacs.rcp
@@ -8,9 +8,11 @@
          (setenv
           "PYTHONPATH"
           (let ((pp (getenv "PYTHONPATH")))
-            (concat default-directory
-                    (unless (string-prefix-p ":" pp) ":")
-                    pp)))
+            (if (and pp (not (string= pp "")))
+                (concat default-directory
+                        (unless (string-prefix-p ":" pp) ":")
+                        pp)
+              default-directory)))
          (autoload 'pymacs-load "pymacs" nil t)
          (autoload 'pymacs-eval "pymacs" nil t)
          (autoload 'pymacs-exec "pymacs" nil t)


### PR DESCRIPTION
If the PYTHONPATH variable isn't set, the getenv function returns nil and concat will fail. In addition an unnecessary colon is set if the variable exists but is empty:

(setenv "PYTHONPATH" "")
...code...
(getenv "PYTHONPATH") ==> "/home/$USER/.emacs.d/el-get/pymacs:"

I hope that the code is okay, because I have no experience with Lisp :)
