### PR TITLE
Replace more "(lambda ()" with "(progn" in recipes

### DIFF
--- a/recipes/alert.rcp
+++ b/recipes/alert.rcp
@@ -4,7 +4,7 @@
        :type github
        :pkgname "jwiegley/alert"
        :post-init
-       (lambda ()
+       (progn
          (autoload 'alert "alert"
            "Alert the user that something has happened.")
          (autoload 'alert-add-rule "alert"

--- a/recipes/ampc.rcp
+++ b/recipes/ampc.rcp
@@ -4,5 +4,5 @@
        :type git
        :url "http://ch.ristopher.com/r/ampc"
        :features ampc
-       :post-init (lambda ()
+       :post-init (progn
                     (autoload 'ampc "ampc" nil t)))

--- a/recipes/auto-async-byte-compile.rcp
+++ b/recipes/auto-async-byte-compile.rcp
@@ -3,6 +3,6 @@
        :website "http://www.emacswiki.org/emacs/AutoAsyncByteCompile"
        :type emacswiki
        :post-init
-       (lambda ()
+       (progn
          (add-hook 'emacs-lisp-mode-hook 'enable-auto-async-byte-compile-mode))
        :features "auto-async-byte-compile")

--- a/recipes/babel.rcp
+++ b/recipes/babel.rcp
@@ -4,7 +4,7 @@
        :type github
        :pkgname "juergenhoetzel/babel"
        :prepare
-       (lambda ()
+       (progn
          (autoload 'babel "babel"
            "Use a web translation service to translate the message MSG." t)
          (autoload 'babel-region "babel"

--- a/recipes/blender-python-mode.rcp
+++ b/recipes/blender-python-mode.rcp
@@ -3,7 +3,7 @@
        :description "The Blender Python Mode makes it easy to use Emacs for Blender Python development."
        :type bzr
        :url "http://bazaar.launchpad.net/~diresu/blender-python-mode/blender-python-mode/"
-       :prepare (lambda ()
+       :prepare (progn
 		  (setq blender-python-mode-installation-dir
 			(el-get-package-directory "blender-python-mode")))
-       :features 'blender-python-mode)
+       :features blender-python-mode)

--- a/recipes/cmake-mode.rcp
+++ b/recipes/cmake-mode.rcp
@@ -4,6 +4,6 @@
        :type http
        :url "http://www.cmake.org/CMakeDocs/cmake-mode.el"
        :features "cmake-mode"
-       :post-init (lambda()
+       :post-init (progn
                     (add-to-list 'auto-mode-alist '("CMakeLists\\.txt\\'" . cmake-mode))
                     (add-to-list 'auto-mode-alist '("\\.cmake\\'" . cmake-mode))))

--- a/recipes/color-theme-zenburn.rcp
+++ b/recipes/color-theme-zenburn.rcp
@@ -3,7 +3,7 @@
        :pkgname "zenburn-theme"
        :description "Just some alien fruit salad to keep you in the zone"
        :post-init
-       (lambda ()
+       (progn
          (autoload 'color-theme-zenburn "zenburn"
            "Just some alien fruit salad to keep you in the zone." t)
          (defalias 'zenburn #'color-theme-zenburn)))

--- a/recipes/django-mode.rcp
+++ b/recipes/django-mode.rcp
@@ -4,7 +4,7 @@
        :pkgname "myfreeweb/django-mode"
        :depends yasnippet
        :post-init
-       (lambda ()
+       (progn
          ;; Load yasnippet because yas/load-directory has no autoload
          (require 'yasnippet)
 	 (yas/load-directory (expand-file-name "snippets"))

--- a/recipes/flymake-html-validator.rcp
+++ b/recipes/flymake-html-validator.rcp
@@ -3,4 +3,4 @@
        :type git
        :url "https://github.com/dwdreisigmeyer/flymake-html-validator"
        :features "flymake-html-validator"
-       :prepare (lambda () (setq validator-script (concat el-get-dir "flymake-html-validator"))))
+       :prepare (progn (setq validator-script (concat el-get-dir "flymake-html-validator"))))

--- a/recipes/google-c-style.rcp
+++ b/recipes/google-c-style.rcp
@@ -2,6 +2,6 @@
        :description "Google's C/C++ style for c-mode"
        :url "http://google-styleguide.googlecode.com/svn/trunk/google-c-style.el"
        :features google-c-style
-       :post-init (lambda()
+       :post-init (progn
                     (add-hook 'c-mode-common-hook 'google-set-c-style)
                     (add-hook 'c-mode-common-hook 'google-make-newline-indent)))

--- a/recipes/jaspace.rcp
+++ b/recipes/jaspace.rcp
@@ -2,7 +2,7 @@
        :description "Make Japanese whitespaces visible"
        :url "http://homepage3.nifty.com/satomii/software/jaspace.el"
        :features jaspace
-       :post-init (lambda()
+       :post-init (progn
                     (global-font-lock-mode t)
                     (setq jaspace-alternate-jaspace-string "?")
                     (setq jaspace-alternate-eol-string "\n")

--- a/recipes/lorem-ipsum.rcp
+++ b/recipes/lorem-ipsum.rcp
@@ -2,7 +2,7 @@
        :description "Lorem Ipsum Generator"
        :type emacswiki
        :features lorem-ipsum
-       :post-init (lambda()
+       :post-init (progn
 		    (autoload 'Lorem-ipsum-insert-paragraphs "lorem-ipsum")
 		    (autoload 'Lorem-ipsum-insert-sentences "lorem-ipsum")
 		    (autoload 'Lorem-ipsum-insert-list "lorem-ipsum")))

--- a/recipes/ntcmd.rcp
+++ b/recipes/ntcmd.rcp
@@ -2,6 +2,6 @@
        :type emacswiki
        :description "major mode for editing cmd scripts"
        :load-path "."
-       :post-init (lambda()
+       :post-init (progn
                     (add-to-list 'auto-mode-alist '("\\.[bB][Aa][Tt]\\'" . ntcmd-mode))
                     (add-to-list 'auto-mode-alist '("\\.[Cc][Mm][Dd]\\'" . ntcmd-mode))))

--- a/recipes/pcmpl-git.rcp
+++ b/recipes/pcmpl-git.rcp
@@ -3,6 +3,6 @@
        :type github
        :pkgname "leoliu/pcmpl-git-el"
        :features pcmpl-git
-       :prepare (lambda ()
+       :prepare (progn
                   (setq pcmpl-git-options-file
                         (expand-file-name "git-options"))))

--- a/recipes/point-stack.rcp
+++ b/recipes/point-stack.rcp
@@ -8,7 +8,7 @@
 ;;
 ;; Configuration example:
 ;;
-;;        :post-init (lambda()
-;;              (global-set-key '[(f5)] 'point-stack-push)
-;;              (global-set-key '[(f6)] 'point-stack-pop)
-;;              (global-set-key '[(f7)] 'point-stack-forward-stack-pop))
+;;        :after (progn
+;;                 (global-set-key '[(f5)] 'point-stack-push)
+;;                 (global-set-key '[(f6)] 'point-stack-pop)
+;;                 (global-set-key '[(f7)] 'point-stack-forward-stack-pop))

--- a/recipes/ppindent.rcp
+++ b/recipes/ppindent.rcp
@@ -1,7 +1,7 @@
 (:name ppindent :type emacswiki
        :description "Indents C preprocessor directives"
        :features ppindent
-       :post-init (lambda()
+       :post-init (progn
                     (setq ppindent-increment 4)
                     (message (format "%s" (current-buffer)))
                     (add-hook

--- a/recipes/pymacs.rcp
+++ b/recipes/pymacs.rcp
@@ -3,7 +3,7 @@
        :type github
        :pkgname "pinard/Pymacs"
        :post-init
-       (lambda ()
+       (progn
          ;; do PYTHONPATH=~/.emacs.d/el-get/pymacs/:$PYTHONPATH
          (setenv
           "PYTHONPATH"

--- a/recipes/q-mode.rcp
+++ b/recipes/q-mode.rcp
@@ -5,7 +5,7 @@
        :load-path (".")
        :features (q-minor-mode kdbp-mode)
        :post-init
-       (lambda ()
+       (progn
          (add-to-list 'auto-mode-alist '("\\.[kq]$" . kdbp-mode))
          (autoload 'q-mode "q-mode")
          (autoload 'q-help "q-mode")

--- a/recipes/rope.rcp
+++ b/recipes/rope.rcp
@@ -1,7 +1,7 @@
 (:name rope
        :description "A python refactoring library"
        :post-init
-       (lambda ()
+       (progn
          (unless (boundp 'pymacs-load-path) (setq pymacs-load-path nil))
          (add-to-list 'pymacs-load-path default-directory))
        :type hg

--- a/recipes/ropemacs.rcp
+++ b/recipes/ropemacs.rcp
@@ -1,7 +1,7 @@
 (:name ropemacs
        :description "An Emacs minor mode for using rope python refactoring library in emacs."
        :post-init
-       (lambda ()
+       (progn
          (unless (boundp 'pymacs-load-path) (setq pymacs-load-path nil))
          (add-to-list 'pymacs-load-path default-directory))
        :depends (rope ropemode)

--- a/recipes/ropemode.rcp
+++ b/recipes/ropemode.rcp
@@ -1,7 +1,7 @@
 (:name ropemode
        :description "Common parts of ropemacs and ropevim."
        :post-init
-       (lambda ()
+       (progn
          (unless (boundp 'pymacs-load-path) (setq pymacs-load-path nil))
          (add-to-list 'pymacs-load-path default-directory))
        :type hg

--- a/recipes/shadow.rcp
+++ b/recipes/shadow.rcp
@@ -2,7 +2,7 @@
        :description "That's not the file. That's shadow."
        :type git :url "https://github.com/mooz/shadow.el.git"
        :features shadow
-       :post-init (lambda()
+       :post-init (progn
                     (add-hook 'find-file-hooks 'shadow-on-find-file)
                     (add-hook 'shadow-find-unshadow-hook
                               (lambda () (auto-revert-mode t)))))

--- a/recipes/tuareg-mode.rcp
+++ b/recipes/tuareg-mode.rcp
@@ -4,7 +4,7 @@
        :description "A  GOOD Emacs mode to edit Objective Caml code."
        :load-path (".")
        :post-init
-       (lambda ()
+       (progn
          (add-to-list 'auto-mode-alist '("\\.ml[iylp]?" . tuareg-mode))
          (autoload 'tuareg-mode "tuareg" "Major mode for editing Caml code" t)
          (autoload 'camldebug "camldebug" "Run the Caml debugger" t)


### PR DESCRIPTION
I just found some sneaky lambda forms that I missed when converting everything to progn. I think this is the last of the recipes that need conversion.
