### PR TITLE
Sleep 5 seconds between tests

### DIFF
--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -18,6 +18,10 @@ set_default TMPDIR "$(dirname "$(mktemp --dry-run)")"
 set_default TEST_HOME "$TMPDIR/el-get-test-home"
 set_default EMACS "$(which emacs)"
 
+# 5 seconds in between tests to avoid accidental DoS from running too
+# many tests in a short time
+set_default DELAY_BETWEEN_TESTS 5
+
 run_test () {
   testfile="$1"
   echo "*** Running el-get test $testfile ***"
@@ -34,4 +38,5 @@ run_test () {
 
 for t in "$@"; do
   run_test "$t"
+  sleep "$DELAY_BETWEEN_TESTS"
 done

--- a/test/test-recipe.sh
+++ b/test/test-recipe.sh
@@ -18,7 +18,11 @@ set_default TMPDIR "$(dirname "$(mktemp --dry-run)")"
 set_default TEST_HOME "$TMPDIR/el-get-test-home"
 set_default EMACS "$(which emacs)"
 
-RECIPE_DIR="$EL_GET_LIB_DIR/recipes"
+# 5 seconds in between tests to avoid accidental DoS from running too
+# many tests in a short time
+set_default DELAY_BETWEEN_TESTS 5
+
+set_default RECIPE_DIR "$EL_GET_LIB_DIR/recipes"
 
 get_recipe_file () {
   for x in "$1" "$RECIPE_DIR/$1" "$RECIPE_DIR/$1.rcp" "$RECIPE_DIR/$1.el"; do
@@ -73,4 +77,5 @@ EOF
 
 for r in "$@"; do
   test_recipe "$r"
+  sleep "$DELAY_BETWEEN_TESTS"
 done


### PR DESCRIPTION
This avoids accidentally DoSing the servers that host many packages,
such as GitHub or the ELPA servers.

With this, it is now reasonable to actually use `./run-all-tests.sh` and `./test-all-recipes.sh`, though they will take a while to run.
