### PR TITLE
update processing-mode repo url because omouse moved to gitorious

### DIFF
--- a/recipes/processing-mode.rcp
+++ b/recipes/processing-mode.rcp
@@ -1,5 +1,5 @@
 (:name processing-mode
        :description "Processing mode for Emacs. Written by Rudolf Olah. This mode is a derivative of the java-mode. It adds key-bindings for running/compiling Processing sketches and it also highlights keywords found in the Processing language, such as ``setup'', ``draw'', and ``frameRate''."
        :type http
-       :url "http://github.com/omouse/processing-emacs/raw/master/processing-mode.el"
+       :url "https://git.gitorious.org/processing-emacs/processing-emacs.git"
        :features processing-mode)


### PR DESCRIPTION
~omouse moved his repositories to gitorious. The new processing-emacs repo is at http://gitorious.org/processing-emacs
