### PR TITLE
Improve el-get-describe-1: guess website for github type recipe

### DIFF
--- a/el-get-list-packages.el
+++ b/el-get-list-packages.el
@@ -99,7 +99,10 @@ matching REGEX with TYPE and ARGS as parameter."
     (princ ".\n\n")
 
     (let ((website (or website
-                       (and (eq 'git type) (el-get-guess-github-website url)))))
+                       (and (eq 'git type) (el-get-guess-github-website url))
+                       (and (eq 'github type)
+                            (el-get-guess-github-website
+                             (el-get-github-url package))))))
       (when website
         (el-get-describe-princ-button (format "Website: %s\n" website)
                                       ": \\(.+\\)" 'help-url website)))


### PR DESCRIPTION
If `:website` of a github type recipe is not specified, it is assumed to be project's github URL.
