### PR TITLE
Remove global settings from .dir-locals.el

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -9,6 +9,7 @@
   (whitespace-style face trailing lines-tail)
   (whitespace-line-column . 80)
   (eval ignore-errors
+        "Write-contents-functions is a buffer-local alternative to before-save-hook"
         (add-hook 'write-contents-functions
                   (lambda ()
                     (delete-trailing-whitespace (point-min) (point-max))


### PR DESCRIPTION
Some of the settings in .dir-locals.el were modifying variables or
properties that are not buffer-local. This commit attempts to fix that
while preserving the same functionality as much as possible.

Should fix #618.
