### PR TITLE
Convert more recipes to github type

### DIFF
--- a/recipes/auto-indent-mode.rcp
+++ b/recipes/auto-indent-mode.rcp
@@ -1,5 +1,5 @@
 (:name auto-indent-mode
        :website "https://github.com/mlf176f2/auto-indent-mode.el"
        :description "Automatically Indent  when pressing return, pasting, and other customizable features."
-       :type git
-       :url "https://github.com/mlf176f2/auto-indent-mode.el.git")
+       :type github
+       :pkgname "mlf176f2/auto-indent-mode.el")

--- a/recipes/diff-git.rcp
+++ b/recipes/diff-git.rcp
@@ -1,5 +1,5 @@
 (:name diff-git
        :website "https://github.com/alanfalloon/diff-git.el"
        :description "A small emacs extension for working with the git index from within diff-mode"
-       :type git
-       :url "https://github.com/alanfalloon/diff-git.el.git")
+       :type github
+       :pkgname "alanfalloon/diff-git.el")

--- a/recipes/el-autoyas.rcp
+++ b/recipes/el-autoyas.rcp
@@ -1,5 +1,5 @@
 (:name el-autoyas
        :website "https://github.com/mlf176f2/el-autoyas.el"
        :description "Automatic yasnippet creation for emacs lisp."
-       :type git
-       :url "https://github.com/mlf176f2/el-autoyas.el.git")
+       :type github
+       :pkgname "mlf176f2/el-autoyas.el")

--- a/recipes/eproject.rcp
+++ b/recipes/eproject.rcp
@@ -1,7 +1,7 @@
 (:name eproject
        :description "File grouping (\"project\") extension for emacs"
-       :type git
-       :url "https://github.com/jrockway/eproject.git"
+       :type github
+       :pkgname "jrockway/eproject"
        :load-path ("." "lang")
        ;; the core functionality needs to be present.
        ;; eproject-extras, otoh, has autoload cookies.

--- a/recipes/ess-smart-underscore.rcp
+++ b/recipes/ess-smart-underscore.rcp
@@ -1,5 +1,5 @@
 (:name ess-smart-underscore
         :website "https://github.com/mlf176f2/ess-smart-underscore.el"
         :description "Smarter underscore behavior in emacs"
-        :type git
-        :url "https://github.com/mlf176f2/ess-smart-underscore.el.git")
+        :type github
+        :pkgname "mlf176f2/ess-smart-underscore.el")

--- a/recipes/expand-region.rcp
+++ b/recipes/expand-region.rcp
@@ -1,6 +1,6 @@
 (:name expand-region
-       :type git
-       :url "https://github.com/magnars/expand-region.el.git"
+       :type github
+       :pkgname "magnars/expand-region.el"
        :description "Expand region increases the selected region by semantic units. Just keep pressing the key until it selects what you want."
        :website "https://github.com/magnars/expand-region.el#readme"
        :prepare (autoload 'er/expand-region "expand-region" nil t))

--- a/recipes/feature-mode.rcp
+++ b/recipes/feature-mode.rcp
@@ -1,7 +1,7 @@
 (:name feature-mode
        :description "Major mode for Cucumber feature files"
-       :type git
-       :url "git://github.com/michaelklishin/cucumber.el.git"
+       :type github
+       :pkgname "michaelklishin/cucumber.el"
        :features feature-mode
        :post-init (add-to-list 'auto-mode-alist
                                '("\\.feature\\'" . feature-mode)))

--- a/recipes/ghc-mod.rcp
+++ b/recipes/ghc-mod.rcp
@@ -1,5 +1,5 @@
 (:name ghc-mod
        :description "Happy Haskell programming"
-       :type git
-       :url "https://github.com/kazu-yamamoto/ghc-mod.git"
+       :type github
+       :pkgname "kazu-yamamoto/ghc-mod"
        :load-path "elisp")

--- a/recipes/hide-url.rcp
+++ b/recipes/hide-url.rcp
@@ -1,6 +1,6 @@
 (:name hide-url
        :description "Hide annoyingly long URLs"
        :website "https://github.com/tkf/hide-url.el"
-       :type git
-       :url "git://github.com/tkf/hide-url.el.git"
+       :type github
+       :pkgname "tkf/hide-url.el"
        :features "hide-url")

--- a/recipes/jekyll-el.rcp
+++ b/recipes/jekyll-el.rcp
@@ -1,6 +1,6 @@
 (:name jekyll-el
        :description "Jekyll Integration for emacs"
-       :type git
-       :url "git://github.com/diasjorge/jekyll.el.git"
+       :type github
+       :pkgname "diasjorge/jekyll.el"
        :load-path (".")
        :features jekyll)

--- a/recipes/jquery-doc.rcp
+++ b/recipes/jquery-doc.rcp
@@ -1,7 +1,7 @@
 (:name jquery-doc
        :description "jQuery api documentation interface for emacs"
        :website "https://github.com/ananthakumaran/jquery-doc.el"
-       :type git
-       :url "git://github.com/ananthakumaran/jquery-doc.el.git"
+       :type github
+       :pkgname "ananthakumaran/jquery-doc.el"
        :features "jquery-doc"
        :depends auto-complete)

--- a/recipes/maxframe.rcp
+++ b/recipes/maxframe.rcp
@@ -1,7 +1,7 @@
 (:name maxframe
        :description "Maxframe provides the ability to maximize the emacs frame and stay within the display resolution."
-       :type git
-       :url "http://github.com/rmm5t/maxframe.el.git"
+       :type github
+       :pkgname "rmm5t/maxframe.el"
        :post-init (progn
                     (autoload 'maximize-frame "maxframe"
                       "Maximizes the frame to fit the display if under a windowing

--- a/recipes/ncl.rcp
+++ b/recipes/ncl.rcp
@@ -1,6 +1,6 @@
 (:name ncl
-       :type git
+       :type github
        :website "http://www.ncl.ucar.edu/"
        :description "ncl-mode for ncar command line language"
-       :url "git://github.com/yyr/ncl.el.git"
+       :pkgname "yyr/ncl.el"
        :autoloads t)

--- a/recipes/org-cua-dwim.rcp
+++ b/recipes/org-cua-dwim.rcp
@@ -1,5 +1,5 @@
 (:name org-cua-dwim
        :website "https://github.com/mlf176f2/org-cua-dwim.el"
        :description "Allow C-c, C-v, C-x etc to work as you would expect elsewhere when using CUA mode."
-       :type git
-       :url "https://github.com/mlf176f2/org-cua-dwim.el.git")
+       :type github
+       :pkgname "mlf176f2/org-cua-dwim.el")

--- a/recipes/org-outlook.rcp
+++ b/recipes/org-outlook.rcp
@@ -1,4 +1,4 @@
 (:name org-outlook
-       :type git
-       :url "https://github.com/mlf176f2/org-outlook.el.git"
+       :type github
+       :pkgname "mlf176f2/org-outlook.el"
        :description "Integrate Microsoft Outlook with org-mode")

--- a/recipes/org-table-comment.rcp
+++ b/recipes/org-table-comment.rcp
@@ -1,5 +1,5 @@
 (:name org-table-comment
        :website "https://github.com/mlf176f2/org-table-comment.el"
        :description "Org tables in comments"
-       :type git
-       :url "https://github.com/mlf176f2/org-table-comment.el.git")
+       :type github
+       :pkgname "mlf176f2/org-table-comment.el")

--- a/recipes/pg.rcp
+++ b/recipes/pg.rcp
@@ -1,5 +1,5 @@
 (:name pg
        :description "Emacs Lisp interface to the PostgreSQL RDBMS"
-       :type git
-       :url "git://github.com/cbbrowne/pg.el.git"
+       :type github
+       :pkgname "cbbrowne/pg.el"
        :features pg)

--- a/recipes/python.rcp
+++ b/recipes/python.rcp
@@ -1,4 +1,4 @@
 (:name python
        :description "Python's flying circus support for Emacs"
-       :type git
-       :url "https://github.com/fgallina/python.el.git")
+       :type github
+       :pkgname "fgallina/python.el")

--- a/recipes/r-autoyas.rcp
+++ b/recipes/r-autoyas.rcp
@@ -1,5 +1,5 @@
 (:name r-autoyas
        :website "https://github.com/mlf176f2/r-autoyas.el"
        :description "Automatic yasnippet creation for emacs lisp."
-       :type git
-       :url "https://github.com/mlf176f2/r-autoyas.el.git")
+       :type github
+       :pkgname "mlf176f2/r-autoyas.el")

--- a/recipes/scion.rcp
+++ b/recipes/scion.rcp
@@ -1,6 +1,6 @@
 (:name scion
        :description "IDE library for Haskell based on the GHC API."
-       :type git
-       :url "https://github.com/nominolo/scion.git"
+       :type github
+       :pkgname "nominolo/scion"
        :load-path "emacs"
        :features scion)

--- a/recipes/simplenote.rcp
+++ b/recipes/simplenote.rcp
@@ -1,8 +1,8 @@
 (:name simplenote
        :website "https://github.com/cefstat/simplenote.el#readme"
        :description "Helper functions for simple-note.appspot.com"
-       :type git
-       :url "https://github.com/cefstat/simplenote.el.git"
+       :type github
+       :pkgname "cefstat/simplenote.el"
        :features simplenote
        :load    "simplenote.el"
        :compile "simplenote.el"

--- a/recipes/smartrep.rcp
+++ b/recipes/smartrep.rcp
@@ -1,6 +1,6 @@
 (:name smartrep
        :description "Support sequential operation which omitted prefix keys."
        :website "http://sheephead.homelinux.org/2011/12/19/6930/"
-       :type git
-       :url "git://github.com/myuhe/smartrep.el.git"
+       :type github
+       :pkgname "myuhe/smartrep.el"
        :features "smartrep")

--- a/recipes/tabbar-ruler.rcp
+++ b/recipes/tabbar-ruler.rcp
@@ -1,6 +1,6 @@
 (:name tabbar-ruler
        :website "https://github.com/mlf176f2/tabbar-ruler.el"
        :description "Tabbar ruler is an emacs package that allows both the tabbar and the ruler to be used together. In addition it allows auto-hiding of the menu-bar and tool-bar."
-       :type git
+       :type github
        :depends tabbar
-       :url "https://github.com/mlf176f2/tabbar-ruler.el.git")
+       :pkgname "mlf176f2/tabbar-ruler.el")

--- a/recipes/textmate-to-yas.rcp
+++ b/recipes/textmate-to-yas.rcp
@@ -1,5 +1,5 @@
 (:name textmate-to-yas
        :website "https://github.com/mlf176f2/textmate-to-yas.el"
        :description "Convert Textmate snippets to Yasnippets"
-       :type git
-       :url "https://github.com/mlf176f2/textmate-to-yas.el.git")
+       :type github
+       :pkgname "mlf176f2/textmate-to-yas.el")

--- a/recipes/textmate.rcp
+++ b/recipes/textmate.rcp
@@ -1,6 +1,6 @@
 (:name textmate
        :description "TextMate minor mode for Emacs"
-       :type git
-       :url "https://github.com/defunkt/textmate.el.git"
+       :type github
+       :pkgname "defunkt/textmate.el"
        :features textmate
        :post-init (textmate-mode))

--- a/recipes/theme-roller.rcp
+++ b/recipes/theme-roller.rcp
@@ -1,6 +1,6 @@
 (:name theme-roller
        :description "A collection of activly maintained emacs themes"
-       :type git
+       :type github
        :features theme-roller
-       :url "https://github.com/senny/theme-roller.el.git"
+       :pkgname "senny/theme-roller.el"
        :post-init (theme-roller-activate))

--- a/recipes/virtualenv.rcp
+++ b/recipes/virtualenv.rcp
@@ -1,4 +1,4 @@
 (:name virtualenv
        :description "Virtualenv for Python"
-       :type git
-       :url "https://github.com/aculich/virtualenv.el.git")
+       :type github
+       :pkgname "aculich/virtualenv.el")

--- a/recipes/workgroups.rcp
+++ b/recipes/workgroups.rcp
@@ -1,5 +1,5 @@
 (:name workgroups
        :description "Workgroups for windows (for Emacs)"
-       :type git
-       :url "https://github.com/tlh/workgroups.el.git"
+       :type github
+       :pkgname "tlh/workgroups.el"
        :features "workgroups")

--- a/recipes/yas-jit.rcp
+++ b/recipes/yas-jit.rcp
@@ -1,7 +1,7 @@
 (:name yas-jit
        :website "https://github.com/mlf176f2/yas-jit.el"
        :description "Just in time loading of yasnippets"
-       :type git
+       :type github
        :depends yasnippet
        :load-path "."
-       :url "https://github.com/mlf176f2/yas-jit.el.git")
+       :pkgname "mlf176f2/yas-jit.el")


### PR DESCRIPTION
This automated conversion was done with the following sequence of
commands:

```
cd recipes
# Replace :url with :pkgname "user/repo"
perl -iBAK -lape 's{^(\s*):url\s+".*github.com/([A-Za-z0-9.-]+)/([A-Za-z0-9.-]+)\.git"}{$1:pkgname "$2/$3"}' *.rcp
# Change :type from git to github if recipe has a :pkgname property
for x in *.rcp; do if pcregrep -q ":type\s+git\b" $x && grep -q ":pkgname" $x; then perl -iBAK2 -lape 's/:type\s+git(hub)?\b/:type github/g' $x; fi; done
# Clean up backup files
rm -f *BAK *BAK2
cd ..
```

These commands may be repeated at any time in the future to convert
newly-added recipes.
