### PR TITLE
fix pymacs recipe for the case PYTHONPATH is nil

### DIFF
--- a/recipes/pymacs.rcp
+++ b/recipes/pymacs.rcp
@@ -8,9 +8,11 @@
          (setenv
           "PYTHONPATH"
           (let ((pp (getenv "PYTHONPATH")))
-            (concat default-directory
-                    (unless (string-prefix-p ":" pp) ":")
-                    pp)))
+            (unless (eq pp nil)
+              (concat default-directory
+                      (unless (string-prefix-p ":" pp) ":")
+                      pp))
+            default-directory))
          (autoload 'pymacs-load "pymacs" nil t)
          (autoload 'pymacs-eval "pymacs" nil t)
          (autoload 'pymacs-exec "pymacs" nil t)


### PR DESCRIPTION
Current pymacs recipe set additional path, default-directory, into PYTHONPATH.
However if PYTHONPATH is nil, "string-prefix-p(":" pp)" is evaluated as "string-prefix-p(":" nil)" and crash.
I fix "(unless (eq pp nil)" and else set default-directory to PYTHONPATH.
