### PR TITLE
Changed: el-get-hg-compute-checksum returns full 40-digit hex now

### DIFF
--- a/methods/el-get-hg.el
+++ b/methods/el-get-hg.el
@@ -78,12 +78,9 @@
   "Return the hash of the checked-out revision of PACKAGE."
   (with-temp-buffer
     (cd (el-get-package-directory package))
-    (let* ((args '("hg" "id" "--id"))
+    (let* ((args '("hg" "log" "--rev" "." "--template" "{node}"))
            (cmd (mapconcat 'shell-quote-argument args " "))
-           (output (shell-command-to-string cmd))
-           ;; strip tailing "+" if exists
-           (hash (and (string-match "^\\([0-9A-Fa-f]+\\)" output)
-                      (match-string 0 output))))
+           (hash (shell-command-to-string cmd)))
       hash)))
 
 (el-get-register-method :hg

--- a/test/el-get-issue-619.el
+++ b/test/el-get-issue-619.el
@@ -7,7 +7,7 @@
        (el-get-verbose t)
        ;; Just need to install something
        (pkg 'qmake-mode)
-       (checksum "a3f9655f346c")
+       (checksum "a3f9655f346c6efe54e3ffc000adb3435c99f90b")
        (el-get-sources
         (list
          `(:name ,pkg


### PR DESCRIPTION
See #626
