### PR TITLE
Simplify "el-get-install" and other fixes

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -596,7 +596,7 @@ PACKAGE may be either a string or the corresponding symbol."
   (el-get-error-unless-package-p package)
   (if (el-get-package-is-installed package)
       (progn
-        (message "el-get: `%s' package is already installed" package)
+        (el-get-verbose-message "el-get: `%s' package is already installed" package)
         (el-get-init package))
     (let* ((status   (el-get-read-package-status package))
 	   (source   (el-get-package-def package))


### PR DESCRIPTION
Now "el-get-install" simply dispatches to
"el-get-install-next-packages" instead of duplicating some of its work
for the first package on the dependency list.

There should be no change in functionality or interface.
