### PR TITLE
Fix for #490 - Issue with shell quoting on Windows with a cygwin shell

### DIFF
--- a/el-get-build.el
+++ b/el-get-build.el
@@ -93,6 +93,9 @@ recursion.
 	 (wdir   (if subdir (concat (file-name-as-directory pdir) subdir) pdir))
 	 (buf    (format "*el-get-build: %s*" package))
 	 (default-directory (file-name-as-directory wdir))
+         (shell-file-name (or (and (eq system-type 'windows-nt)
+                              (executable-find "cmdproxy.exe"))
+                          shell-file-name))
 	 (process-list
 	  (mapcar (lambda (c)
 		    (let* ((split    (cond ((stringp c)


### PR DESCRIPTION
If on a Windows system default to "cmdproxy.exe", otherwise use the currently configured shell-file-name.

This fixes #490 by ensuring proper shell quoting on NT Emacs when a cygwin shell is being used.
