### PR TITLE
Use setq instead of let in tests

### DIFF
--- a/test/caching-speedtest.el
+++ b/test/caching-speedtest.el
@@ -19,36 +19,36 @@
 (put 'suppress-messages 'lisp-indent-function
      (get 'progn 'lisp-indent-function))
 
-(let ((debug-on-error t)
-      ;; (el-get-byte-compile nil)
-      (el-get-verbose t)
-      (el-get-default-process-sync t)
-      (el-get-notify-type 'message)
-      (el-get-generate-autoloads nil)
-      (el-get-byte-compile nil)
-      (repetitions 50)
-      (el-get-sources
-       (list `(:name pkg
-                     :type builtin))))
-  ;; Install and remove once to warm up the disk cache and whatever
-  (suppress-messages
-    (el-get-install 'pkg)
-    (el-get-remove 'pkg))
-  (message "Beginning benchmark")
-  ;; Repeat benchmark 5 times to see consistency
-  (let ((times
-         (loop
-          for rep from 1 upto 5
-          collect
-          (timeit
-            (suppress-messages
-              ;; Benchmark is to repeatedly install, hit the cache 5 times,
-              ;; and then remove the same package. Repeat N times.
-              (dotimes (x repetitions)
-                (el-get-install 'pkg)
-                (dotimes (y 5)
-                  (el-get-read-package-status-recipe 'pkg)
-                  (el-get-init 'pkg))
-                (el-get-remove 'pkg)))))))
-    (message "Summary: %S" (mapcar (lambda (n) (string-to-number (format "%.4f" n))) times)))
-  (message "Finished benchmark"))
+(setq debug-on-error t
+      el-get-verbose t
+      el-get-default-process-sync t
+      el-get-notify-type 'message
+      el-get-generate-autoloads nil
+      el-get-byte-compile nil
+      repetitions 50
+      el-get-sources
+      (list
+       `(:name pkg :type builtin)))
+
+;; Install and remove once to warm up the disk cache and whatever
+(suppress-messages
+ (el-get-install 'pkg)
+ (el-get-remove 'pkg))
+(message "Beginning benchmark")
+;; Repeat benchmark 5 times to see consistency
+(let ((times
+       (loop
+        for rep from 1 upto 5
+        collect
+        (timeit
+         (suppress-messages
+          ;; Benchmark is to repeatedly install, hit the cache 5 times,
+          ;; and then remove the same package. Repeat N times.
+          (dotimes (x repetitions)
+            (el-get-install 'pkg)
+            (dotimes (y 5)
+              (el-get-read-package-status-recipe 'pkg)
+              (el-get-init 'pkg))
+            (el-get-remove 'pkg)))))))
+  (message "Summary: %S" (mapcar (lambda (n) (string-to-number (format "%.4f" n))) times)))
+(message "Finished benchmark")

--- a/test/el-get-issue-176.el
+++ b/test/el-get-issue-176.el
@@ -2,11 +2,11 @@
 ;;
 ;; Git clone should be done with the depth flag
 
-(let ((debug-on-error t)
-      ;; (el-get-byte-compile nil)
-      (el-get-verbose t)
-      (el-get-git-shallow-clone t))
-  (el-get 'sync 'yasnippet))
+(setq debug-on-error t
+      el-get-verbose t
+      el-get-git-shallow-clone t)
+
+(el-get 'sync 'yasnippet)
 
 ;; After running the test, check the git log for yasnippet to see if
 ;; it only has a few log entries, rather than hundreds.

--- a/test/el-get-issue-200.el
+++ b/test/el-get-issue-200.el
@@ -2,7 +2,7 @@
 ;;
 ;; yasnippet recipe fails to install
 
-(let ((debug-on-error t)
-      ;; (el-get-byte-compile nil)
-      (el-get-verbose t))
-  (el-get 'sync 'yasnippet))
+(setq debug-on-error t
+      el-get-verbose t)
+
+(el-get 'sync 'yasnippet)

--- a/test/el-get-issue-284.el
+++ b/test/el-get-issue-284.el
@@ -5,8 +5,9 @@
 ;; following. It fails because initsplit has not been added to the load
 ;; path.
 
-(let ((debug-on-error t))
-  (setq el-get-byte-compile nil
-	el-get-verbose t)
-  (el-get 'sync '(initsplit))
-  (find-library "initsplit"))
+(setq debug-on-error t)
+
+(setq el-get-byte-compile nil
+      el-get-verbose t)
+(el-get 'sync '(initsplit))
+(find-library "initsplit")

--- a/test/el-get-issue-289.el
+++ b/test/el-get-issue-289.el
@@ -7,7 +7,8 @@
 ;; solution is either to remove :features from the flymake-fringe-icons
 ;; recipe or to make el-get-init respect the :depends clause.
 
-(let ((debug-on-error t))
-  (setq el-get-byte-compile nil
-	el-get-verbose t)
-  (el-get 'sync '(flymake-fringe-icons)))
+(setq debug-on-error t)
+
+(setq el-get-byte-compile nil
+      el-get-verbose t)
+(el-get 'sync '(flymake-fringe-icons))

--- a/test/el-get-issue-303.el
+++ b/test/el-get-issue-303.el
@@ -2,15 +2,14 @@
 ;;
 ;; error in process sentinel
 
-(let (
-      (debug-on-error t)
-      (debug-ignored-errors '())
-      ;; (el-get-byte-compile nil)
-      (el-get-verbose t)
-      (el-get-default-process-sync t)
-      (el-get-sources
-       '((:name xmlunicode :depends
-		(unichars)
-		:type http :url "http://nwalsh.com/emacs/xmlchars/xmlunicode.el")
-	 (:name unichars :type http :url "http://nwalsh.com/emacs/xmlchars/unichars.el"))))
-  (el-get-install "xmlunicode"))
+(setq debug-on-error t
+      debug-ignored-errors 'nil
+      el-get-verbose t
+      el-get-default-process-sync t
+      el-get-sources
+      '((:name xmlunicode :depends
+               (unichars)
+               :type http :url "http://nwalsh.com/emacs/xmlchars/xmlunicode.el")
+        (:name unichars :type http :url "http://nwalsh.com/emacs/xmlchars/unichars.el")))
+
+(el-get-install "xmlunicode")

--- a/test/el-get-issue-310.el
+++ b/test/el-get-issue-310.el
@@ -2,8 +2,9 @@
 ;;
 ;; el-get refuses to compile
 
-(let ((debug-on-error t)
-      (debug-ignored-errors '()))
-  (setq el-get-default-process-sync t
-	el-get-verbose t)
-  (el-get-install "mailq"))
+(setq debug-on-error t
+      debug-ignored-errors 'nil)
+
+(setq el-get-default-process-sync t
+      el-get-verbose t)
+(el-get-install "mailq")

--- a/test/el-get-issue-400.el
+++ b/test/el-get-issue-400.el
@@ -2,10 +2,11 @@
 ;;
 ;; el-get-install does not run the init hooks
 
-(let ((debug-on-error t)
-      (el-get-verbose t))
-      ;; (el-get-sources '((:name php-mode :features php-mode))))
-  (el-get 'sync 'php-mode)
-  (message "auto-mode-alist: %S" (rassoc 'php-mode auto-mode-alist))
-  (with-current-buffer (find-file "foo.php")
-    (message "%s: %s" (buffer-file-name) major-mode)))
+(setq debug-on-error t
+      el-get-verbose t)
+
+;; (el-get-sources '((:name php-mode :features php-mode))))
+(el-get 'sync 'php-mode)
+(message "auto-mode-alist: %S" (rassoc 'php-mode auto-mode-alist))
+(with-current-buffer (find-file "foo.php")
+  (message "%s: %s" (buffer-file-name) major-mode))

--- a/test/el-get-issue-418.el
+++ b/test/el-get-issue-418.el
@@ -2,9 +2,10 @@
 ;;
 ;; info installation broken
 
-(let ((debug-on-error t)
-      (el-get-default-process-sync t)
-      (el-get-verbose t)
-      (debug-ignored-errors '()))
-  (el-get 'sync 'magit)
-  (message "%S" (symbol-function 'magit-status)))
+(setq debug-on-error t
+      el-get-default-process-sync t
+      el-get-verbose t
+      debug-ignored-errors 'nil)
+
+(el-get 'sync 'magit)
+(message "%S" (symbol-function 'magit-status))

--- a/test/el-get-issue-432.el
+++ b/test/el-get-issue-432.el
@@ -3,11 +3,12 @@
 ;; Real-life example: cperl-mode depends on mode-compile. Try installing
 ;; mode-compile first, then cperl-mode.
 
-(let ((debug-on-error t)
-      (debug-ignored-errors '())
-      (el-get-default-process-sync t)
-      (el-get-verbose t)
-      (el-get-byte-compile-at-init t))
-  (message "%S" (el-get-dependencies 'cperl-mode))
-  (el-get-install "mode-compile")
-  (el-get-install "cperl-mode"))
+(setq debug-on-error t
+      debug-ignored-errors 'nil
+      el-get-default-process-sync t
+      el-get-verbose t
+      el-get-byte-compile-at-init t)
+
+(message "%S" (el-get-dependencies 'cperl-mode))
+(el-get-install "mode-compile")
+(el-get-install "cperl-mode")

--- a/test/el-get-issue-513.el
+++ b/test/el-get-issue-513.el
@@ -2,21 +2,21 @@
 ;;
 ;; Testing the github and emacsmirror methods
 
-(let ((debug-on-error t)
-      ;; (el-get-byte-compile nil)
-      (el-get-verbose t))
-  ;; Install a github-type recipe
-  (el-get 'sync 'window-layout)
-  ;; Install an emacsmirror-type recipe
-  (el-get 'sync 'dired-plus)
+(setq debug-on-error t
+      el-get-verbose t)
 
-  (condition-case err
-      (progn
-        ;; Should fail
-        (let ((el-get-sources
-               '((:name broken-pkg
-                        :type github))))
-          (el-get 'sync 'broken-pkg))
-        (signal 'test-failure
-                '("The package\"broken-pkg\" should have caused an error, but it didn't.")))
-    (error (message "Installing \"broken-pkg\" failed as expected. The error message was: %S" err))))
+;; Install a github-type recipe
+(el-get 'sync 'window-layout)
+;; Install an emacsmirror-type recipe
+(el-get 'sync 'dired-plus)
+
+(condition-case err
+    (progn
+      ;; Should fail
+      (let ((el-get-sources
+             '((:name broken-pkg
+                      :type github))))
+        (el-get 'sync 'broken-pkg))
+      (signal 'test-failure
+              '("The package\"broken-pkg\" should have caused an error, but it didn't.")))
+  (error (message "Installing \"broken-pkg\" failed as expected. The error message was: %S" err)))

--- a/test/el-get-issue-535.el
+++ b/test/el-get-issue-535.el
@@ -5,8 +5,8 @@
 ;; Run this test with the environment variable HTTP_PROXY set
 ;; appropriately!
 
-(let ((debug-on-error t)
-      ;; (el-get-byte-compile nil)
-      (el-get-verbose t))
-  (require 'el-get)
-  (el-get 'sync 'mailcrypt))
+(setq debug-on-error t
+      el-get-verbose t)
+
+(require 'el-get)
+(el-get 'sync 'mailcrypt)

--- a/test/el-get-issue-541.el
+++ b/test/el-get-issue-541.el
@@ -2,11 +2,17 @@
 ;;
 ;; Pass load-path to byte-compiling child process
 
-(let ((debug-on-error t)
-      (el-get-verbose t))
-  (el-get 'sync 'js2-mode))
+(setq debug-on-error t
+      el-get-verbose t)
 
-(let ((compiled-file (concat (file-name-as-directory (el-get-package-directory 'js2-mode)) "js2-mode.elc")))
-  (if (file-exists-p compiled-file)
-      (message "Byte-compiling succeeded.")
-    (error "Byte-compiling failed.")))
+(el-get 'sync 'js2-mode)
+
+(setq compiled-file
+      (concat
+       (file-name-as-directory
+        (el-get-package-directory 'js2-mode))
+       "js2-mode.elc"))
+
+(if (file-exists-p compiled-file)
+    (message "Byte-compiling succeeded.")
+  (error "Byte-compiling failed."))

--- a/test/el-get-issue-548.el
+++ b/test/el-get-issue-548.el
@@ -2,11 +2,11 @@
 ;;
 ;; Use `default-directory' in :post-init and similar recipe init hooks.
 
-(let ((debug-on-error t)
-      ;; (el-get-byte-compile nil)
-      (el-get-verbose t))
-  (el-get 'sync 'pcmpl-git)
-  (el-get-init 'pcmpl-git)
-  ;; Verify that the option in :post-init was set correctly
-  (assert (string= pcmpl-git-options-file
-                   (expand-file-name "git-options" (el-get-package-directory 'pcmpl-git)))))
+(setq debug-on-error t
+      el-get-verbose t)
+
+(el-get 'sync 'pcmpl-git)
+(el-get-init 'pcmpl-git)
+;; Verify that the option in :post-init was set correctly
+(assert (string= pcmpl-git-options-file
+                 (expand-file-name "git-options" (el-get-package-directory 'pcmpl-git))))

--- a/test/el-get-issue-559.el
+++ b/test/el-get-issue-559.el
@@ -2,37 +2,29 @@
 ;;
 ;; Testing the github-tar and github-zip methods
 
-(let ((debug-on-error t)
-      ;; (el-get-byte-compile nil)
-      (el-get-verbose t)
-      (el-get-sources
-       '((:name indirect-region-http-tar
-                :type http-tar
-                :options ("xzf")
-                :description "Act like indirect buffer for region."
-                :url "https://github.com/renard/indirect-region/tarball/master")
-         (:name indirect-region-tar
-                :type github-tar
-                :description "Act like indirect buffer for region."
-                :pkgname "renard/indirect-region")
-         (:name indirect-region-zip
-                :type github-zip
-                :description "Act like indirect buffer for region."
-                :pkgname "renard/indirect-region"))))
-  ;; Install a http-tar recipe
-  (el-get 'sync 'indirect-region-http-tar)
-  ;; Install a github-tar recipe
-  (el-get 'sync 'indirect-region-tar)
-  ;; Install a github-zip recipe
-  (el-get 'sync 'indirect-region-zip)
+(setq debug-on-error t
+      el-get-verbose t
+      el-get-sources
+      '((:name indirect-region-http-tar :type http-tar :options
+               ("xzf")
+               :description "Act like indirect buffer for region." :url "https://github.com/renard/indirect-region/tarball/master")
+        (:name indirect-region-tar :type github-tar :description "Act like indirect buffer for region." :pkgname "renard/indirect-region")
+        (:name indirect-region-zip :type github-zip :description "Act like indirect buffer for region." :pkgname "renard/indirect-region")))
 
-  (condition-case err
-      (progn
-        ;; Should fail
-        (let ((el-get-sources
-               '((:name broken-pkg
-                        :type github-tar))))
-          (el-get 'sync 'broken-pkg))
-        (signal 'test-failure
-                '("The package\"broken-pkg\" should have caused an error, but it didn't.")))
-    (error (message "Installing \"broken-pkg\" failed as expected. The error message was: %S" err))))
+;; Install a http-tar recipe
+(el-get 'sync 'indirect-region-http-tar)
+;; Install a github-tar recipe
+(el-get 'sync 'indirect-region-tar)
+;; Install a github-zip recipe
+(el-get 'sync 'indirect-region-zip)
+
+(condition-case err
+    (progn
+      ;; Should fail
+      (let ((el-get-sources
+             '((:name broken-pkg
+                      :type github-tar))))
+        (el-get 'sync 'broken-pkg))
+      (signal 'test-failure
+              '("The package\"broken-pkg\" should have caused an error, but it didn't.")))
+  (error (message "Installing \"broken-pkg\" failed as expected. The error message was: %S" err)))

--- a/test/el-get-issue-581.el
+++ b/test/el-get-issue-581.el
@@ -2,7 +2,7 @@
 ;;
 ;; ipython should depend on python-mode
 
-(let ((debug-on-error t)
-      ;; (el-get-byte-compile nil)
-      (el-get-verbose t))
-  (el-get 'sync 'ipython))
+(setq debug-on-error t
+      el-get-verbose t)
+
+(el-get 'sync 'ipython)

--- a/test/el-get-issue-583.el
+++ b/test/el-get-issue-583.el
@@ -4,29 +4,24 @@
 ;;
 ;; Also related: https://github.com/dimitri/el-get/issues/576
 
-(let ((el-get-default-process-sync t)
-      (el-get-verbose t)
-      (el-get-sources
-       '((:name a
-                :type builtin
-                :depends (b c d e f))
-         (:name b
-                :type builtin)
-         (:name c
-                :type builtin)
-         (:name d
-                :type builtin)
-         (:name e
-                :type builtin)
-         (:name f
-                :type builtin))))
-  ;; Ensure a is uninstalled
-  (ignore-errors (el-get-remove 'a))
-  ;; Install a and all deps
-  (el-get-install 'a)
-  ;; Remove a, leaving deps installed
-  (el-get-remove 'a)
-  ;; Try to install a again, this fails and only inits b and c.
-  (el-get-install 'a)
-  (assert (el-get-package-is-installed 'a) nil
-          "Package A should be installed but isn't."))
+(setq el-get-default-process-sync t
+      el-get-verbose t
+      el-get-sources
+      '((:name a :type builtin :depends
+               (b c d e f))
+        (:name b :type builtin)
+        (:name c :type builtin)
+        (:name d :type builtin)
+        (:name e :type builtin)
+        (:name f :type builtin)))
+
+;; Ensure a is uninstalled
+(ignore-errors (el-get-remove 'a))
+;; Install a and all deps
+(el-get-install 'a)
+;; Remove a, leaving deps installed
+(el-get-remove 'a)
+;; Try to install a again, this fails and only inits b and c.
+(el-get-install 'a)
+(assert (el-get-package-is-installed 'a) nil
+        "Package A should be installed but isn't.")

--- a/test/el-get-issue-586.el
+++ b/test/el-get-issue-586.el
@@ -2,11 +2,11 @@
 ;;
 ;; Many recipes use git-emacs github repo
 
-(let ((debug-on-error t)
-      ;; (el-get-byte-compile nil)
-      (el-get-verbose t))
-  (el-get 'sync 'git-blame 'git-modeline)
-  (assert (reduce '(lambda (a b) (and a b))
-                  (mapcar 'el-get-package-is-installed '(git-emacs git-blame git-modeline)))
-          nil
-          "Git-emacs, git-blame, and git-modeline pacakges should all be installed."))
+(setq debug-on-error t
+      el-get-verbose t)
+
+(el-get 'sync 'git-blame 'git-modeline)
+(assert (reduce '(lambda (a b) (and a b))
+                (mapcar 'el-get-package-is-installed '(git-emacs git-blame git-modeline)))
+        nil
+        "Git-emacs, git-blame, and git-modeline pacakges should all be installed.")

--- a/test/el-get-issue-589.el
+++ b/test/el-get-issue-589.el
@@ -2,30 +2,29 @@
 ;;
 ;; Lazy loading is broken
 
-(let ((debug-on-error t)
-      ;; (el-get-byte-compile nil)
-      (el-get-default-process-sync t)
-      (el-get-verbose t)
-      (el-get-is-lazy t)
-      (post-init-function-ran nil)
-      (prepare-function-ran nil)
-      (el-get-sources
-       '((:name test-pkg
-                :type builtin
-                :features ido
-                :prepare (setq prepare-function-ran t)
-                :post-init (setq post-init-function-ran t)
-                :lazy t))))
-  (assert (not post-init-function-ran) nil
-          "Post-init function should not run before installation")
-  (el-get 'sync 'test-pkg)
-  (assert prepare-function-ran nil
-          "Prepare function should have run after package installation.")
-  (assert (not post-init-function-ran) nil
-          "Post-init function should not run during installation")
-  (el-get-init 'test-pkg)
-  (assert (not post-init-function-ran) nil
-          "Post-init function should not run during init")
-  (require 'ido)
-  (assert post-init-function-ran nil
-          "Post-init function should have run when package feature was required"))
+(setq debug-on-error t
+      el-get-default-process-sync t
+      el-get-verbose t
+      el-get-is-lazy t
+      post-init-function-ran nil
+      prepare-function-ran nil
+      el-get-sources
+      '((:name test-pkg :type builtin :features ido :prepare
+               (setq prepare-function-ran t)
+               :post-init
+               (setq post-init-function-ran t)
+               :lazy t)))
+
+(assert (not post-init-function-ran) nil
+        "Post-init function should not run before installation")
+(el-get 'sync 'test-pkg)
+(assert prepare-function-ran nil
+        "Prepare function should have run after package installation.")
+(assert (not post-init-function-ran) nil
+        "Post-init function should not run during installation")
+(el-get-init 'test-pkg)
+(assert (not post-init-function-ran) nil
+        "Post-init function should not run during init")
+(require 'ido)
+(assert post-init-function-ran nil
+        "Post-init function should have run when package feature was required")

--- a/test/el-get-issue-594.el
+++ b/test/el-get-issue-594.el
@@ -2,18 +2,18 @@
 ;;
 ;; handle empty/missing PYTHONPATH correctly in pymacs
 
-(let ((debug-on-error t)
-      ;; (el-get-byte-compile nil)
-      (el-get-verbose t)
-      (el-get-default-process-sync t))
-  ;; Test Pymacs recipe with unset PYTHONPATH
-  (setenv "PYTHONPATH" nil)
-  (el-get 'sync 'pymacs)
-  (el-get-init 'pymacs)
-  (let ((pp (getenv "PYTHONPATH")))
-    (assert pp nil
-            "PYTHONPATH should be non-nil")
-    (assert (not (string= pp "")) nil
-            "PYTHONPATH should be non-empty")
-    (assert (not (string-match-p ":" pp)) nil
-            "PYTHONPATH should have only one element")))
+(setq debug-on-error t
+      el-get-verbose t
+      el-get-default-process-sync t)
+
+;; Test Pymacs recipe with unset PYTHONPATH
+(setenv "PYTHONPATH" nil)
+(el-get 'sync 'pymacs)
+(el-get-init 'pymacs)
+(let ((pp (getenv "PYTHONPATH")))
+  (assert pp nil
+          "PYTHONPATH should be non-nil")
+  (assert (not (string= pp "")) nil
+          "PYTHONPATH should be non-empty")
+  (assert (not (string-match-p ":" pp)) nil
+          "PYTHONPATH should have only one element"))

--- a/test/el-get-issue-596.el
+++ b/test/el-get-issue-596.el
@@ -2,7 +2,7 @@
 ;;
 ;; package.el fails to install
 
-(let ((debug-on-error t)
-      ;; (el-get-byte-compile nil)
-      (el-get-verbose t))
-  (el-get 'sync 'package))
+(setq debug-on-error t
+      el-get-verbose t)
+
+(el-get 'sync 'package)

--- a/test/el-get-issue-613.el
+++ b/test/el-get-issue-613.el
@@ -3,20 +3,20 @@
 ;; Do recipe autoloads in :prepare instead of :post-init
 (require 'loadhist)
 
-(let ((debug-on-error t)
-      ;; (el-get-byte-compile nil)
-      (el-get-default-process-sync t)
-      (el-get-verbose t)
-      (el-get-is-lazy t))
-  (el-get 'sync 'n3-mode)
-  (assert (not (file-loadhist-lookup "n3-mode")) nil
-          "n3-mode package should not be loaded because el-get is lazy")
-  (assert (functionp 'n3-mode) nil
-          "n3-mode function should be defined because it is autoloaded")
-  (assert (equal 'autoload (car (symbol-function 'n3-mode))) nil
-          "n3-mode function definition should be an autoload")
-  (with-temp-buffer (n3-mode))
-  (assert (file-loadhist-lookup "n3-mode") nil
-          "n3-mode package should be loaded after calling n3-mode function")
-  (assert (not (equal 'autoload (car-safe (symbol-function 'n3-mode)))) nil
-          "n3-mode function should no longer be an autoload after calling it"))
+(setq debug-on-error t
+      el-get-default-process-sync t
+      el-get-verbose t
+      el-get-is-lazy t)
+
+(el-get 'sync 'n3-mode)
+(assert (not (file-loadhist-lookup "n3-mode")) nil
+        "n3-mode package should not be loaded because el-get is lazy")
+(assert (functionp 'n3-mode) nil
+        "n3-mode function should be defined because it is autoloaded")
+(assert (equal 'autoload (car (symbol-function 'n3-mode))) nil
+        "n3-mode function definition should be an autoload")
+(with-temp-buffer (n3-mode))
+(assert (file-loadhist-lookup "n3-mode") nil
+        "n3-mode package should be loaded after calling n3-mode function")
+(assert (not (equal 'autoload (car-safe (symbol-function 'n3-mode)))) nil
+        "n3-mode function should no longer be an autoload after calling it")

--- a/test/el-get-issue-628.el
+++ b/test/el-get-issue-628.el
@@ -3,7 +3,8 @@
         "unix:abstract=/tmpX/Xdbus-oBU7t7f9Pv,guid=X7bb736a5c60b6c3be8a1312800000064X")
 
 ;; Trigger a notification
-(let ((el-get-sources
-       (list '(:name pkg
-                     :type builtin))))
-  (el-get 'sync 'pkg))
+(setq el-get-sources
+      (list
+       '(:name pkg :type builtin)))
+
+(el-get 'sync 'pkg)

--- a/test/el-get-issue-640.el
+++ b/test/el-get-issue-640.el
@@ -2,15 +2,15 @@
 ;;
 ;; void-function el-get-package-name
 
-(let ((debug-on-error t)
-      ;; (el-get-byte-compile nil)
-      (el-get-verbose t)
-      (el-get-default-process-sync t))
-  ;; Install pkg with type builtin
-  (let ((el-get-sources
-         (list `(:name pkg
-                       :type builtin))))
-    (el-get 'sync 'pkg))
-  ;; Force a re-read of the status file after installing and updating
-  (setq el-get-status-file-cache nil)
-  (el-get-read-status-file))
+(setq debug-on-error t
+      el-get-verbose t
+      el-get-default-process-sync t)
+
+;; Install pkg with type builtin
+(let ((el-get-sources
+       (list `(:name pkg
+                     :type builtin))))
+  (el-get 'sync 'pkg))
+;; Force a re-read of the status file after installing and updating
+(setq el-get-status-file-cache nil)
+(el-get-read-status-file)

--- a/test/el-get-issue-642.el
+++ b/test/el-get-issue-642.el
@@ -2,27 +2,27 @@
 ;;
 ;; Reinstall on type change
 
-(let ((debug-on-error t)
-      ;; (el-get-byte-compile nil)
-      (el-get-verbose t)
-      (el-get-default-process-sync t))
-  ;; Install pkg with type builtin
-  (let ((el-get-sources
-         (list `(:name pkg
-                       :type builtin))))
-    (el-get 'sync 'pkg))
-  (assert (eq 'builtin
-              (el-get-package-method (el-get-read-package-status-recipe 'pkg)))
-          t
-          "Package type should be 'builtin.")
-  ;; Even though "no-op" is an alias for the same behavior as
-  ;; "builtin", they are still considered different types. Thus, this
-  ;; should trigger a reinstall.
-  (let ((el-get-sources
-         (list `(:name pkg
-                       :type no-op))))
-    (el-get-update 'pkg))
-  (assert (eq 'no-op
-              (el-get-package-method (el-get-read-package-status-recipe 'pkg)))
-          t
-          "Package type should now be 'no-op, not 'builtin."))
+(setq debug-on-error t
+      el-get-verbose t
+      el-get-default-process-sync t)
+
+;; Install pkg with type builtin
+(let ((el-get-sources
+       (list `(:name pkg
+                     :type builtin))))
+  (el-get 'sync 'pkg))
+(assert (eq 'builtin
+            (el-get-package-method (el-get-read-package-status-recipe 'pkg)))
+        t
+        "Package type should be 'builtin.")
+;; Even though "no-op" is an alias for the same behavior as
+;; "builtin", they are still considered different types. Thus, this
+;; should trigger a reinstall.
+(let ((el-get-sources
+       (list `(:name pkg
+                     :type no-op))))
+  (el-get-update 'pkg))
+(assert (eq 'no-op
+            (el-get-package-method (el-get-read-package-status-recipe 'pkg)))
+        t
+        "Package type should now be 'no-op, not 'builtin.")

--- a/test/el-get-issue-650.el
+++ b/test/el-get-issue-650.el
@@ -10,19 +10,19 @@
 (el-get-register-derived-method :builtin-with-checksum :builtin
   :compute-checksum #'el-get-builtin-compute-checksum)
 
-(let ((debug-on-error t)
-      ;; (el-get-byte-compile nil)
-      (el-get-verbose t)
-      (el-get-default-process-sync t))
-  ;; Install pkg with type builtin
-  (let ((el-get-sources
-         (list `(:name pkg
-                       :type builtin-with-checksum
-                       :checksum "0"))))
-    (el-get 'sync 'pkg))
-  ;; Now, with the recipe no longer in `el-get-sources', do a bunch of
-  ;; things that require the recipe, to make sure that they obtain it
-  ;; from the status file.
-  (el-get-checksum 'pkg)
-  (el-get-reload 'pkg)
-  (el-get-remove 'pkg))
+(setq debug-on-error t
+      el-get-verbose t
+      el-get-default-process-sync t)
+
+;; Install pkg with type builtin
+(let ((el-get-sources
+       (list `(:name pkg
+                     :type builtin-with-checksum
+                     :checksum "0"))))
+  (el-get 'sync 'pkg))
+;; Now, with the recipe no longer in `el-get-sources', do a bunch of
+;; things that require the recipe, to make sure that they obtain it
+;; from the status file.
+(el-get-checksum 'pkg)
+(el-get-reload 'pkg)
+(el-get-remove 'pkg)

--- a/test/el-get-issue-652.el
+++ b/test/el-get-issue-652.el
@@ -2,37 +2,31 @@
 ;;
 ;; Handle changing dependencies in `el-get-update'
 
-(let ((el-get-default-process-sync t)
-      (el-get-verbose t)
-      (el-get-sources
-       '((:name a
-                :type builtin
-                :depends (b c d))
-         (:name b
-                :type builtin)
-         (:name c
-                :type builtin)
-         (:name d
-                :type builtin)
-         (:name e
-                :type builtin)
-         (:name f
-                :type builtin)
-         (:name g
-                :type builtin))))
-  ;; Ensure a is uninstalled
-  (ignore-errors (el-get-remove 'a))
-  ;; Install a and some deps
-  (el-get-install 'a)
-  ;; Make sure deps got installed
-  (assert (el-get-package-is-installed 'd) nil
-          "Package D should be installed after installing A.")
-  ;; Add some more deps
-  (setf (car el-get-sources)
-        '(:name a
-                :type builtin
-                :depends (b c d e f g)))
-  ;; Run update with the new dependencies
-  (el-get-update 'a)
-  (assert (el-get-package-is-installed 'g) nil
-          "Package G should be installed after updating A."))
+(setq el-get-default-process-sync t
+      el-get-verbose t
+      el-get-sources
+      '((:name a :type builtin :depends
+               (b c d))
+        (:name b :type builtin)
+        (:name c :type builtin)
+        (:name d :type builtin)
+        (:name e :type builtin)
+        (:name f :type builtin)
+        (:name g :type builtin)))
+
+;; Ensure a is uninstalled
+(ignore-errors (el-get-remove 'a))
+;; Install a and some deps
+(el-get-install 'a)
+;; Make sure deps got installed
+(assert (el-get-package-is-installed 'd) nil
+        "Package D should be installed after installing A.")
+;; Add some more deps
+(setf (car el-get-sources)
+      '(:name a
+              :type builtin
+              :depends (b c d e f g)))
+;; Run update with the new dependencies
+(el-get-update 'a)
+(assert (el-get-package-is-installed 'g) nil
+        "Package G should be installed after updating A.")

--- a/test/el-get-issue-656.el
+++ b/test/el-get-issue-656.el
@@ -7,64 +7,54 @@
 
 (el-get-register-method-alias :test :builtin)
 
-(let ((el-get-default-process-sync t)
-      (el-get-verbose t)
-      (el-get-sources
-       ;; Package A depends on B, and it also requires the feature
-       ;; provided by B.
-       `((:name a
-                :type test
-                :compile "."
-                :features a
-                :build (("sh" "-c"
-                         ,(format "echo %s > a.el"
-                                  (shell-quote-argument
-                                   (mapconcat
-                                    #'pp-to-string
-                                    '((require 'b)
-                                      (provide 'a))
-                                    "\n")))))
-                :depends b)
-         (:name b
-                :type test
-                :compile "."
-                ;; Don't automatically require the feature
-                :features nil
-                :build (("sh" "-c"
-                         ,(format "echo %s > b.el"
-                                  (shell-quote-argument
-                                   (pp-to-string '(provide 'b))))))))))
-  ;; Ensure both are uninstalled
-  (ignore-errors (el-get-remove 'a))
-  (ignore-errors (el-get-remove 'b))
-  ;; Install a and b
-  (el-get-install 'a)
-  ;; Make sure B got installed
-  (assert (el-get-package-is-installed 'b) nil
-          "Package B should be installed after installing A.")
-  ;; Make sure that B got loaded
-  (assert (featurep 'b) nil
-          "Installing package A should have loaded package B.")
-  ;; Unload both features and remove their load-paths
-  (unload-feature 'a)
-  (unload-feature 'b)
-  (assert (not (featurep 'b)) nil
-          "Feature B should be unloaded")
-  ;; Remove load paths
-  (setq load-path
-        (set-difference load-path (mapcan #'el-get-load-path '(a b))
-                        :test #'string=))
-  ;; Make sure B is no longer loadable
-  (condition-case err
-      (progn
-        (require 'b)
-        (signal 'test-failure
-                '("Loading B should have failed")))
-    (error nil))
+(setq el-get-default-process-sync t
+      el-get-verbose t
+      el-get-sources
+      `((:name a :type test :compile "." :features a :build
+               (("sh" "-c" ,(format "echo %s > a.el"
+                                    (shell-quote-argument
+                                     (mapconcat #'pp-to-string
+                                                '((require 'b)
+                                                  (provide 'a))
+                                                "\n")))))
+               :depends b)
+        (:name b :type test :compile "." :features nil :build
+               (("sh" "-c" ,(format "echo %s > b.el"
+                                    (shell-quote-argument
+                                     (pp-to-string
+                                      '(provide 'b)))))))))
 
-  ;; Now init A again, and make sure it *again* requires B
-  (condition-case err
-      (el-get-init 'a)
-    (error (error "HIT ISSUE #656: Need to init B before A. Error was: %S" err)))
-  (assert (featurep 'b) nil
-          "Initializing package A should have loaded package B."))
+;; Ensure both are uninstalled
+(ignore-errors (el-get-remove 'a))
+(ignore-errors (el-get-remove 'b))
+;; Install a and b
+(el-get-install 'a)
+;; Make sure B got installed
+(assert (el-get-package-is-installed 'b) nil
+        "Package B should be installed after installing A.")
+;; Make sure that B got loaded
+(assert (featurep 'b) nil
+        "Installing package A should have loaded package B.")
+;; Unload both features and remove their load-paths
+(unload-feature 'a)
+(unload-feature 'b)
+(assert (not (featurep 'b)) nil
+        "Feature B should be unloaded")
+;; Remove load paths
+(setq load-path
+      (set-difference load-path (mapcan #'el-get-load-path '(a b))
+                      :test #'string=))
+;; Make sure B is no longer loadable
+(condition-case err
+    (progn
+      (require 'b)
+      (signal 'test-failure
+              '("Loading B should have failed")))
+  (error nil))
+
+;; Now init A again, and make sure it *again* requires B
+(condition-case err
+    (el-get-init 'a)
+  (error (error "HIT ISSUE #656: Need to init B before A. Error was: %S" err)))
+(assert (featurep 'b) nil
+        "Initializing package A should have loaded package B.")


### PR DESCRIPTION
This makes it easier to run tests interactively and inspect the
results afterward, because the variables such as "el-get-sources" that
were set for the tests are still bound to the values they had during
the test.

This was an automated conversion accomplished with the following code. You can verify that only the let forms were changed by using `git diff -w` to view only non-whitespace changes. For each file, you'll see that the varlist of the `let` form is now a `setq` form, and the body of the let form is unchanged except for deleting the trailing close-paren of the let form.

``` lisp
(defun pp-setq-to-string (setq-form)
  (assert (eq (car setq-form) 'setq))
  (with-temp-buffer
    (insert (pp-to-string setq-form))
    (goto-char (point-min))
    (down-list 1)
    (forward-sexp 1)
    (ignore-errors
      (while t
        (forward-sexp 3)
        (backward-sexp 1)
        (insert "\n")
        (indent-for-tab-command t)))
    (buffer-string)))

(defun transform-test-file (test-file)
  (with-current-buffer (find-file-noselect test-file)
    (goto-char (point-min))
    ;; Fix top-level let forms
    (ignore-errors
      (while t
        (let ((expr (read (current-buffer))))
          (when (eq (car expr) 'let)
            ;; Go back to start of let form
            (backward-sexp)
            ;; Go into let form
            (down-list 1)
            ;; check for and kill opening paren of let form
            (assert (looking-back "("))   
            (delete-backward-char 1)
            ;; Kill let symbol and varlist
            (kill-sexp 2)
            ;; Insert setq form
            (let* ((varlist (cadr expr))
                   (setq-form 
                    (cons 'setq (mapcan 'identity
                                        varlist))))
              (insert (pp-setq-to-string setq-form)))            
            ;; Exit let form
            (up-list 1)
            ;; Check for and kill closing paren of let form
            (assert (looking-back ")"))
            (delete-backward-char 1)))))
    (when (buffer-modified-p)
      (indent-region (point-min) (point-max))
      (save-buffer))
    (kill-buffer)))

(mapc 'transform-test-file (directory-files "~/Projects/public/el-get/test/" t ".*\\.el$"))
```
