### PR TITLE
add a cdlatex-mode recipe to el-get

### DIFF
--- a/recipes/cdlatex-mode.rcp
+++ b/recipes/cdlatex-mode.rcp
@@ -1,0 +1,4 @@
+(:name cdlatex-mode
+       :description "a minor mode which re-implements many features also found in the AUCTeX LaTeX mode."
+       :type http
+       :url "http://staff.science.uva.nl/~dominik/Tools/cdlatex/cdlatex.el")


### PR DESCRIPTION
While auctex is the killer feature for emacs to edit tex and latex files, cdlatex is still useful minor mode. It has fast inserting template for section, subsection, subsubsection, etc. together with some convenient features when inserting mathematical symbols. 

The author of cdlatex said "The reason for this is mainly historical - much of it was written before I knew about AUCTeX. So check this out if you would like to try a different implementation. ", I prefer the combination of both auctex and cdlatex. 

The good news is the rcp for cdlatex is quite simple that I just copy, modify, and paste an existing rcp to make this rcp, anyway, hope it's useful. 
