### PR TITLE
remove non need feature and add depends

### DIFF
--- a/recipes/sass-mode.rcp
+++ b/recipes/sass-mode.rcp
@@ -3,6 +3,5 @@
        :type github
        :pkgname "nex3/sass-mode"
        :depends haml-mode
-       :features sass-mode
        :post-init (add-to-list 'auto-mode-alist
                                '("\\.scss$" . sass-mode)))


### PR DESCRIPTION
I remove non-need feature from sass-mode.rcp. el-get make autoload correctly and this feature occur error that File not found.
And I add depends: because this rcp need haml-mode.
