### PR TITLE
Always print with "print-level" and "print-length" nil

### DIFF
--- a/el-get-core.el
+++ b/el-get-core.el
@@ -24,6 +24,17 @@
 (require 'bytecomp)
 (require 'autoload)
 
+(defun el-get-print-to-string (object &optional pretty)
+  "Return string representation of lisp object.
+
+Unlike the Emacs builtin printing functions, this ignores
+`print-level' and `print-length', ensuring that as much as
+possible the returned string will be a complete representation of
+the original object."
+  (let (print-level print-length)
+    (funcall (if pretty #'pp-to-string #'prin1-to-string)
+             object)))
+
 (defun el-get-verbose-message (format &rest arguments)
   (when el-get-verbose (apply 'message format arguments)))
 
@@ -362,7 +373,7 @@ makes it easier to conditionally splice a command into the list.
                        (infile (when stdin (make-temp-file "el-get")))
                        (dummy  (when infile
                                  (with-temp-file infile
-                                   (insert (prin1-to-string stdin)))))
+                                   (insert (el-get-print-to-string stdin)))))
                        (dummy  (message "el-get is waiting for %S to complete" cname))
                        (status (apply startf program infile cbuf t args))
                        (message (plist-get c :message))
@@ -390,7 +401,7 @@ makes it easier to conditionally splice a command into the list.
               (process-put proc :el-get-final-func final-func)
               (process-put proc :el-get-start-process-list next)
 	      (when stdin
-		(process-send-string proc (prin1-to-string stdin))
+		(process-send-string proc (el-get-print-to-string stdin))
 		(process-send-eof proc))
               (set-process-sentinel proc 'el-get-start-process-list-sentinel)
               (when filter (set-process-filter proc filter)))))

--- a/el-get-custom.el
+++ b/el-get-custom.el
@@ -368,14 +368,14 @@ this is the name to fetch in that system"
                      (if (symbolp e)
                          (cons
                           (list 'const
-                                (intern (substring (prin1-to-string e) 1)))
+                                (intern (substring (el-get-print-to-string e) 1)))
                           r)
                        r))
                    el-get-methods
                    :initial-value nil)
                   (lambda (x y)
-                    (string< (prin1-to-string (cadr x))
-                             (prin1-to-string (cadr y)))))))
+                    (string< (el-get-print-to-string (cadr x))
+                             (el-get-print-to-string (cadr y)))))))
 
        (group :inline t :format "Source URL: %v"
               (const :format "" :url) (string :format "%v"))
@@ -436,7 +436,7 @@ this is the name to fetch in that system"
        :inline t :tag "System-Specific Build Recipes"
        (group :inline t
               (symbol :value ,(concat ":build/"
-                                      (prin1-to-string system-type))
+                                      (el-get-print-to-string system-type))
                       :format "Build Tag: %v%h"
                       :doc "Must be of the form `:build/<system-type>',
 where `<system-type>' is the value of `system-type' on

--- a/el-get-list-packages.el
+++ b/el-get-list-packages.el
@@ -130,7 +130,7 @@ matching REGEX with TYPE and ARGS as parameter."
         (el-get-describe-princ-button (format " in `%s':\n" file)
                                       "`\\([^`']+\\)"
                                       'el-get-help-package-def package)))
-    (prin1 def)))
+    (princ (el-get-print-to-string def))))
 
 (defun el-get-describe (package)
   "Generate a description for PACKAGE."

--- a/el-get-status.el
+++ b/el-get-status.el
@@ -61,9 +61,10 @@
                          (cons package (list 'status status 'recipe recipe))))
                 (lambda (p1 p2)
                   (string< (el-get-as-string (car p1))
-                           (el-get-as-string (car p2)))))))
+                           (el-get-as-string (car p2))))))
+         print-level print-length)
     (with-temp-file el-get-status-file
-      (insert (pp-to-string new-package-status-alist)))
+      (insert (el-get-print-to-string new-package-status-alist 'pretty)))
     ;; Return the new alist
     new-package-status-alist))
 

--- a/el-get.el
+++ b/el-get.el
@@ -842,7 +842,7 @@ itself.")
     ;; Filepath is dir/file
     (let ((filepath (format "%s/%s" dir filename)))
       (with-temp-file filepath
-	(insert (prin1-to-string source))))))
+	(insert (el-get-print-to-string source))))))
 
 ;;;###autoload
 (defun el-get-make-recipes (&optional dir)

--- a/recipes/wanderlust.rcp
+++ b/recipes/wanderlust.rcp
@@ -12,7 +12,7 @@
                    (append
                 '("apel" "flim" "semi")
                 (when (el-get-package-exists-p "bbdb") (list "bbdb"))))
-               "--eval" (prin1-to-string
+               "--eval" (el-get-print-to-string
                  '(progn (setq wl-install-utils t)
                      (setq wl-info-lang "en")
                      (setq wl-news-lang "en")))

--- a/test/el-get-issue-656.el
+++ b/test/el-get-issue-656.el
@@ -13,7 +13,7 @@
       `((:name a :type test :compile "." :features a :build
                (("sh" "-c" ,(format "echo %s > a.el"
                                     (shell-quote-argument
-                                     (mapconcat #'pp-to-string
+                                     (mapconcat #'el-get-print-to-string
                                                 '((require 'b)
                                                   (provide 'a))
                                                 "\n")))))
@@ -21,7 +21,7 @@
         (:name b :type test :compile "." :features nil :build
                (("sh" "-c" ,(format "echo %s > b.el"
                                     (shell-quote-argument
-                                     (pp-to-string
+                                     (el-get-print-to-string
                                       '(provide 'b)))))))))
 
 ;; Ensure both are uninstalled

--- a/test/el-get-issue-672.el
+++ b/test/el-get-issue-672.el
@@ -13,7 +13,7 @@
 ;; Set up the status file with a removed package that has no current
 ;; recipe available.
 (with-temp-buffer
-  (insert (prin1-to-string
+  (insert (el-get-print-to-string
            '(:nonexistent-package "removed")))
   (write-file el-get-status-file))
 


### PR DESCRIPTION
This prevents Emacs from inserting "..." in place of very deep or long data structures, which could corrupt the status file in some cases. This is done by defining a wrapper function "el-get-print-to-string", which el-get should use for all "critical" data stringification tasks.

This also removes the custom status file pretty-printing that I added, since it was causing too many problems for not much gain.
