### PR TITLE
Add recipe for Tomorrow theme

### DIFF
--- a/recipes/tomorrow-theme.rcp
+++ b/recipes/tomorrow-theme.rcp
@@ -1,8 +1,8 @@
 (:name tomorrow-theme
        :description "Colour Schemes for Hackers"
        :website "https://github.com/chriskempson/tomorrow-theme"
-       :type git
-       :url "https://github.com/chriskempson/tomorrow-theme.git"
+       :type github
+       :pkgname "chriskempson/tomorrow-theme"
        :load-path "GNU Emacs"
        :post-init (add-to-list 'custom-theme-load-path
                                default-directory))


### PR DESCRIPTION
My Emacs 24 compatible versions of the Tomorrow theme were [merged](https://github.com/chriskempson/tomorrow-theme/pull/71) into the main repo a while back. So I thought I'd submit a recipe that does not depend on the color-theme package. Specially since there are Zenburn recipes for both :)
