### PR TITLE
Updated org-mode recipe to build on BSD

### DIFF
--- a/recipes/org-mode.rcp
+++ b/recipes/org-mode.rcp
@@ -4,6 +4,10 @@
        :type git
        :url "git://orgmode.org/org-mode.git"
        :info "doc"
+       :build/berkeley-unix `,(mapcar
+                               (lambda (target)
+                                 (list "gmake" target (concat "EMACS=" (shell-quote-argument el-get-emacs))))
+                               '("clean" "all"))
        :build `,(mapcar
                  (lambda (target)
                    (list "make" target (concat "EMACS=" (shell-quote-argument el-get-emacs))))


### PR DESCRIPTION
Let's try this again…

The org-mode makefile is not compatible with BSD make, so I defined :build/berkeley-unix to use GNU make (gmake) instead.
