### PR TITLE
distel depends on erlang-mode (and fails to install if it cannot require...

### DIFF
--- a/recipes/distel.rcp
+++ b/recipes/distel.rcp
@@ -9,5 +9,6 @@
                    (concat "make " target " EMACS=" el-get-emacs))
                  '("clean" "all"))
        :load-path ("elisp")
+       :require erlware-mode
        :features distel)
 


### PR DESCRIPTION
... erlang). Since el-get also has a recipe for erlware-mode, it is natural to require it here in the recipe.
