### PR TITLE
auto-complete now depends on popup-el and fuzzy-el

### DIFF
--- a/recipes/auto-complete.rcp
+++ b/recipes/auto-complete.rcp
@@ -4,7 +4,6 @@
        :type github
        :pkgname "m2ym/auto-complete"
        :depends (popup fuzzy)
-       :depends popup
        :load-path "."
        :post-init (progn
                     (require 'auto-complete)

--- a/recipes/fuzzy.rcp
+++ b/recipes/fuzzy.rcp
@@ -1,13 +1,7 @@
 (:name fuzzy
        :website "https://github.com/m2ym/fuzzy-el"
-<<<<<<< HEAD
        :description "Fuzzy Matching for Emacs"
        :type github
        :pkgname "m2ym/fuzzy-el"
        :load-path ".")
-=======
-       :description "Fuzzy matching utilities for GNU Emacs"
-       :type github
-       :pkgname "m2ym/fuzzy-el"
        :features fuzzy)
->>>>>>> c7e53f5695ca3b1af775805ea7b3e25356ce99a4


### PR DESCRIPTION
The new auto-complete depends on a separate package, popup-el and fuzzy-el. I've created the recipe for them, and made auto-complete depend on them. I have tested everything installs and works as expected. Please, review the commit.
