### PR TITLE
Org-Mode build changes

### DIFF
--- a/recipes/org-mode.rcp
+++ b/recipes/org-mode.rcp
@@ -7,11 +7,11 @@
        :build/berkeley-unix `,(mapcar
                                (lambda (target)
                                  (list "gmake" target (concat "EMACS=" (shell-quote-argument el-get-emacs))))
-                               '("clean" "all"))
+                               '("compile" "autoloads" "info"))
        :build `,(mapcar
                  (lambda (target)
                    (list "make" target (concat "EMACS=" (shell-quote-argument el-get-emacs))))
-                 '("clean" "all"))
+                 '("compile" "autoloads" "info"))
        :load-path ("." "lisp" "contrib/lisp")
        :autoloads nil
        :features org-install)


### PR DESCRIPTION
Org-Mode recently had a major Makefile and build process overhaul. As
per Samuel Wales on the Org-Mode mailing list [1] the correct build
process for when you don’t install org (i.e. run it directly out of the
Git worktree) would be:

=make compile autoloads info=

This patch changes the Org-Mode build accordingly.

[1] http://permalink.gmane.org/gmane.emacs.orgmode/55022
