### PR TITLE
el-get-init didn't use el-get-sources

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -442,7 +442,7 @@ called by `el-get' (usually at startup) for each installed package."
   (el-get-verbose-message "el-get-init: %s" package)
   (condition-case err
       (let* ((source
-              (el-get-read-package-status-recipe package package-status-alist))
+              (el-get-package-def package))
              (method   (el-get-package-method source))
              (loads    (el-get-as-list (plist-get source :load)))
              (autoloads (plist-get source :autoloads))


### PR DESCRIPTION
I noticed that adding :features to an `el-get-sources` recipe didn't cause the feature to be required on startup. It seems to be because `el-get-init` uses `el-get-read-package-status-recipe` which doesn't consult `el-get-sources`.

Using `el-get-package-def` as per the commit (c4c1b757) works for me, although I'm not sure if it's the Right Thing to do...
