### PR TITLE
Only install info when `el-get-install-info` is not nil.

### DIFF
--- a/el-get-build.el
+++ b/el-get-build.el
@@ -193,7 +193,7 @@ recursion.
 
 	  ((eq build-or-init 'build)
 	   ;; rebuild each time asked --- e.g. on update
-	   (when (and infodir
+	   (when (and infodir el-get-install-info
 		      (file-directory-p infodir-abs)
 		      (not (file-exists-p info-dir)))
 	     (el-get-set-info-path package infodir-rel)


### PR DESCRIPTION
If `ginstall-info` or `install-info` isn't on the PATH or installed on the system el-get fails to install any package that provides :info.
