### PR TITLE
Add a recipe for cython-mode

### DIFF
--- a/recipes/cython-mode.rcp
+++ b/recipes/cython-mode.rcp
@@ -1,0 +1,6 @@
+(:name cython-mode
+       :description "Major mode for the Cython language"
+       :type http
+       :url "https://raw.github.com/cython/cython/master/Tools/cython-mode.el"
+       :features cython-mode
+       :localname "cython-mode.el")


### PR DESCRIPTION
Here is a recipe for the cython-mode.el file which is distributed with [Cython](/cython/cython). It provides a major mode which extends python-mode to add cython-specific keywords etc.

I'm a complete Emacs newbie and don't know anything about elisp so if I made a mistake, please let me know. I made this recipe just by copying another direct HTTP recipe I found in the recipes directory and tweaking it.
