### PR TITLE
Slime should build only info file from doc/

### DIFF
--- a/recipes/slime.rcp
+++ b/recipes/slime.rcp
@@ -6,6 +6,6 @@
        :pkgname "nablaone/slime"
        :load-path ("." "contrib")
        :compile (".")
-       :build ("make -C doc")
+       :build ("make -C doc slime.info")
        :post-init (slime-setup)
        )


### PR DESCRIPTION
The slime recipe does a "make -C doc" - this requires TeX to be present as it tries to rebuild a PDF file that already exists (timestamp skew on download, that's a different problem).

The info file does not exist and is useful.

This tweaks the build to do just "make -C slime.info", fixing both issues.
