### PR TITLE
Use gmake to build CEDET on BSD

### DIFF
--- a/recipes/cedet.rcp
+++ b/recipes/cedet.rcp
@@ -4,6 +4,7 @@
   :type bzr
   :url "bzr://cedet.bzr.sourceforge.net/bzrroot/cedet/code/trunk"
   :build ("touch `find . -name Makefile`" "make")
+  :build/berkeley-unix ("touch `find . -name Makefile`" "gmake")
   :build/windows-nt ("echo #!/bin/sh > tmp.sh & echo touch `/usr/bin/find . -name Makefile` >> tmp.sh & echo make FIND=/usr/bin/find >> tmp.sh"
 		     "sed 's/^M$//' tmp.sh  > tmp2.sh"
 		     "sh ./tmp2.sh" "rm ./tmp.sh ./tmp2.sh")


### PR DESCRIPTION
The Makefile only works with GNU make, so I modified the recipe to use that.
