### PR TITLE
Recipe for VHDL mode.

### DIFF
--- a/recipes/vhdl-mode.rcp
+++ b/recipes/vhdl-mode.rcp
@@ -1,0 +1,7 @@
+(:name vhdl-mode
+       :description "VHDL Mode is an Emacs major mode for editing VHDL code."
+       :website "http://www.iis.ee.ethz.ch/~zimmi/emacs/vhdl-mode.html"
+       :type http-tar
+       :options ("xzf")
+       :info "."
+       :url "http://www.iis.ee.ethz.ch/~zimmi/emacs/vhdl-mode-3.33.28.tar.gz")


### PR DESCRIPTION
Sadly there doesn't seem to be a public vcs and the recipe pulls the release file. It has to be manually changed for new releases. But the latest is two years old now. However vhdl-mode is very popular for editing vhdl files and it shouldn't be lacking from el-get.

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
