### PR TITLE
Add powerline recipe using github rather than emacswiki

### DIFF
--- a/recipes/powerline.rcp
+++ b/recipes/powerline.rcp
@@ -1,0 +1,6 @@
+(:name powerline
+       :website "https://github.com/jonathanchu/emacs-powerline"
+       :description "Powerline for Emacs"
+       :type github
+       :pkgname "jonathanchu/emacs-powerline"
+       :features powerline)


### PR DESCRIPTION
I created a recipe for powerline, now that it exists on github, at [jonathanchu/emacs-powerline](https://github.com/jonathanchu/emacs-powerline).
