### PR TITLE
Add version requirement to tomorrow and tomorrow-night-paradise themes

### DIFF
--- a/recipes/tomorrow-night-paradise-theme.rcp
+++ b/recipes/tomorrow-night-paradise-theme.rcp
@@ -3,5 +3,6 @@
        :website "https://github.com/jimeh/tomorrow-night-paradise-theme.el"
        :type github
        :pkgname "jimeh/tomorrow-night-paradise-theme.el"
+       :minimum-emacs-version 24
        :post-init (add-to-list 'custom-theme-load-path
                                default-directory))

--- a/recipes/tomorrow-theme.rcp
+++ b/recipes/tomorrow-theme.rcp
@@ -4,5 +4,6 @@
        :type github
        :pkgname "chriskempson/tomorrow-theme"
        :load-path "GNU Emacs"
+       :minimum-emacs-version 24
        :post-init (add-to-list 'custom-theme-load-path
                                default-directory))


### PR DESCRIPTION
Additionally, as far as I can tell both `naquadah-theme` and `zenburn-theme` should have the same version requirement set. However, I'll leave that to the respective authors in case I'm wrong :)
