### PR TITLE
Update smarttabs recipe to use updated fork with minor mode

### DIFF
--- a/recipes/smarttabs.rcp
+++ b/recipes/smarttabs.rcp
@@ -1,5 +1,5 @@
 (:name smarttabs
-       :description "Emacs smart tabs functionality. Intelligently indent with tabs, align with spaces!"
-       :type git
-       :url "git://gist.github.com/488820.git"
-       :features smarttabs)
+       :website "https://github.com/jcsalomon/smarttabs"
+       :description "Emacs smart tabs - indent with tabs, align with spaces!"
+       :type github
+       :pkgname "jcsalomon/smarttabs")


### PR DESCRIPTION
There's a newer version of smarttabs as a full github project.

I removed the features line as autoload cookies are present.
