### PR TITLE
Add missing :features for drag-stuff

### DIFF
--- a/recipes/drag-stuff.rcp
+++ b/recipes/drag-stuff.rcp
@@ -1,5 +1,6 @@
 (:name drag-stuff
        :website "https://github.com/rejeep/drag-stuff#readme"
        :description "Drag Stuff is a minor mode for Emacs that makes it possible to drag stuff, such as words, region and lines, around in Emacs."
+       :features drag-stuff
        :type http
        :url "https://github.com/rejeep/drag-stuff/raw/master/drag-stuff.el")


### PR DESCRIPTION
As indicated in drag-stuff documentation, it is necessary to "require" drag-stuff.
