### PR TITLE
FIX: remove dependency that doesn't exist

### DIFF
--- a/recipes/auto-complete-ruby.rcp
+++ b/recipes/auto-complete-ruby.rcp
@@ -2,4 +2,4 @@
        :description "Auto-complete sources for Ruby"
        :type http
        :url "http://www.cx4a.org/pub/auto-complete-ruby.el"
-       :depends (auto-complete rcodetools))
+       :depends (auto-complete))


### PR DESCRIPTION
rcodetools as a dependency does not exist, and thus provokes an error when using this recipe
