### PR TITLE
Fossil changes to prevent breaking existing fossil repos

### DIFF
--- a/methods/el-get-fossil.el
+++ b/methods/el-get-fossil.el
@@ -53,7 +53,7 @@ are stored in the package directory"
          (fossil-dir (or (plist-get source :fossil-dir)
                          el-get-fossil-dir
                          pdir))
-         (open-args (list "open" (expand-file-name fossil-name fossil-dir) checkout))
+         (open-args (list "open" "--nested" (expand-file-name fossil-name fossil-dir) checkout))
          (ok (format "Package %s installed." package))
          (ko (format "Could not install package %s." package)))
     (el-get-start-process-list


### PR DESCRIPTION
The first commit is simply to fix the file-encoding.  I had accidentally saved it under Windows with the associated encoding and new-line settings.  It is now saved as `utf-8-unix`.  No other changes were made in this commit.

The second commit adds `"--nested"` as an option when opening a fossil checkout.  Without this fossil fails because it is in an existing checkout.  This also results in the existing `.fossil` being deleted when trying to reinstall/remove fossil packages.  This will break the existing repository.
