### PR TITLE
Align-let recipe failed in Windows, switching to HTTP to allow download.

### DIFF
--- a/recipes/align-let.rcp
+++ b/recipes/align-let.rcp
@@ -1,4 +1,4 @@
 (:name align-let
        :description "Align command for `let' forms and `setq' lists"
-       :type ftp
-       :url "ftp://download.tuxfamily.org/user42/align-let.el")
+       :type http
+       :url "http://download.tuxfamily.org/user42/align-let.el")


### PR DESCRIPTION
I hadn't had the chance to test this recipe on Windows yesterday.

In Linux the `ftp` method and address installed successfully, however on two separate Windows machines the FTP request fails with

```
Opening FTP connection to download.tuxfamily.org...done
Logging in as user anonymous@download.tuxfamily.org...done
Getting PWD...done
Doing CD...done
Listing /anonymous@download.tuxfamily.org:/user42/...done
Doing CD... [12 times]
url-ftp: File does not exist: ftp://download.tuxfamily.org/user42/align-let.el
```

Changing it to the HTTP method and recipe successfully installs on the Windows machines, as well as on Linux.
