### PR TITLE
Fix the recipe for rust-mode.

### DIFF
--- a/recipes/cm-mode.rcp
+++ b/recipes/cm-mode.rcp
@@ -1,0 +1,5 @@
+(:name cm-mode
+       :type http
+       :url "https://raw.github.com/mozilla/rust/master/src/etc/emacs/cm-mode.el"
+       :description "Wrapper for CodeMirror-style emacs modes."
+       :features cm-mode)

--- a/recipes/rust-mode.rcp
+++ b/recipes/rust-mode.rcp
@@ -1,5 +1,6 @@
 (:name rust-mode
-       :type github
-       :pkgname "marijnh/rust-mode"
+       :type http
+       :url "https://raw.github.com/mozilla/rust/master/src/etc/emacs/rust-mode.el"
+       :depends cm-mode
        :description "Emacs mode for Rust"
        :features rust-mode)


### PR DESCRIPTION
The Emacs mode for Rust now lives in the main Rust repository. Also adds a recipe for cm-mode, a dependency of rust-mode.
