### PR TITLE
el-get was not registering info files anymore

### DIFF
--- a/el-get-build.el
+++ b/el-get-build.el
@@ -157,7 +157,7 @@ recursion.
 
 (defun el-get-set-info-path (package infodir-rel)
   (eval-after-load "paths"
-    '(el-get-add-path-to-list package 'Info-default-directory-list infodir-rel)))
+    `(el-get-add-path-to-list ',package 'Info-default-directory-list ,infodir-rel)))
 
 (defun el-get-install-or-init-info (package build-or-init)
   "Call `el-get-install-info' to create the necessary \"dir\"


### PR DESCRIPTION
el-get is currently not registering Info nodes anymore. Attached 1-line commit fixes this.

Signed-off-by: Damien Cassou damien.cassou@gmail.com
