### PR TITLE
Fix auctex recipe so building the package won't result in errors

### DIFF
--- a/recipes/auctex.rcp
+++ b/recipes/auctex.rcp
@@ -4,7 +4,7 @@
        :type cvs
        :module "auctex"
        :url ":pserver:anonymous@cvs.sv.gnu.org:/sources/auctex"
-       :build `("./autogen.sh" ,(concat "./configure --with-lispdir=`pwd` --with-emacs=" el-get-emacs) "make")
+       :build `("./autogen.sh" ,(concat "./configure --without-texmf-dir --with-lispdir=`pwd` --with-emacs=" el-get-emacs) "make")
        :load-path ("." "preview")
        :load  ("tex-site.el" "preview/preview-latex.el")
        :info "doc")


### PR DESCRIPTION
I typically have my own auctex recipe because installing auctex with the standard recipe does only work in the case where the user can write the globally defined texmf directory and this directory is globally accessible. To avoid this problem, AUCTeX has the `--without-texmf-dir` option (see [manual](http://www.gnu.org/software/auctex/manual/auctex/Configure.html#Configure)). This patch fixes the recipe to make use of this option.

Signed-off-by: Damien Cassou damien.cassou@gmail.com
