### PR TITLE
Add el-get-envpath-prepend util function and traad.rcp

### DIFF
--- a/el-get-recipes.el
+++ b/el-get-recipes.el
@@ -224,4 +224,20 @@ Second argument PACKAGE is optional and only used to construct the error message
       (error "Package %s requires Emacs version %s or higher, but the current emacs is only version %s"
              pname required-version emacs-version))))
 
+(defun el-get-envpath-prepend (envname head)
+  "Prepend HEAD in colon-separated environment variable ENVNAME.
+This is effectively the same as doing the following in shell:
+    export ENVNAME=HEAD:$ENVNAME
+
+Use this to modify environment variable such as $PATH or $PYTHONPATH."
+  (setenv envname (el-get-envpath-prepend-1 (getenv envname) head)))
+
+(defun el-get-envpath-prepend-1 (paths head)
+  "Return \"HEAD:PATHS\" omitting duplicates in it."
+  (let ((pplist (split-string (or paths "") ":" 'omit-nulls)))
+    (mapconcat 'identity
+               (remove-duplicates (cons head pplist)
+                                  :test #'string= :from-end t)
+               ":")))
+
 (provide 'el-get-recipes)

--- a/recipes/pymacs.rcp
+++ b/recipes/pymacs.rcp
@@ -5,13 +5,7 @@
        :prepare
        (progn
          ;; do PYTHONPATH=~/.emacs.d/el-get/pymacs/:$PYTHONPATH
-         (setenv
-          "PYTHONPATH"
-          (let ((pplist (split-string (or (getenv "PYTHONPATH") "") ":" 'omit-nulls)))
-            (mapconcat 'identity
-                       (remove-duplicates (cons default-directory pplist)
-                                          :test #'string= :from-end t)
-                       ":")))
+         (el-get-envpath-prepend "PYTHONPATH" default-directory)
          (autoload 'pymacs-load "pymacs" nil t)
          (autoload 'pymacs-eval "pymacs" nil t)
          (autoload 'pymacs-exec "pymacs" nil t)

--- a/recipes/rope.rcp
+++ b/recipes/rope.rcp
@@ -1,8 +1,7 @@
 (:name rope
        :description "A python refactoring library"
        :post-init
-       (progn
-         (unless (boundp 'pymacs-load-path) (setq pymacs-load-path nil))
-         (add-to-list 'pymacs-load-path default-directory))
+       ;; Add to PYTHONPATH directly as it is used in ropemacs and traad
+       (el-get-envpath-prepend "PYTHONPATH" default-directory)
        :type hg
        :url "http://bitbucket.org/agr/rope")

--- a/recipes/traad.rcp
+++ b/recipes/traad.rcp
@@ -1,0 +1,12 @@
+(:name traad
+       :description "A XMLRPC server for the rope Python refactoring library"
+       :type github
+       :pkgname "abingham/traad"
+       :load-path ("elisp")
+       :prepare
+       (progn
+         ;; do PYTHONPATH=~/.emacs.d/el-get/traad/:$PYTHONPATH
+         (el-get-envpath-prepend "PYTHONPATH" default-directory)
+         (setq traad-server-program '("python" "-m" "traad.server"))
+         (autoload 'traad-open "traad" nil t))
+       :depends rope)


### PR DESCRIPTION
el-get-envpath-prepend is added in order to simplify settings
related to python-related recipes, including newly added traad.rcp.
This function is general enough to use to modify, for example,
the $PATH environment variable.
