### PR TITLE
Fix :info of el-get recipe

### DIFF
--- a/recipes/el-get.rcp
+++ b/recipes/el-get.rcp
@@ -5,5 +5,5 @@
        :branch "3.stable"
        :pkgname "dimitri/el-get"
        :features el-get
-       :info    "el-get.info"
+       :info    "."
        :load    "el-get.el")


### PR DESCRIPTION
el-get own recipe was indicating a file for its :info whereas :info must be a directory.

Signed-off-by: Damien Cassou damien.cassou@gmail.com
