### PR TITLE
Honor el-get-byte-compile for init files

### DIFF
--- a/el-get-recipes.el
+++ b/el-get-recipes.el
@@ -65,11 +65,11 @@ compiled version."
     (let* ((init-file-name (format "init-%s.el" package))
 	   (package-init-file
 	    (expand-file-name init-file-name el-get-user-package-directory))
-           (file-name-no-extension (file-name-sans-extension package-init-file))
+	   (file-name-no-extension (file-name-sans-extension package-init-file))
 	   (compiled-init-file (concat file-name-no-extension ".elc")))
       (when (file-exists-p package-init-file)
-        (when el-get-byte-compile
-          (el-get-byte-compile-file package-init-file))
+	(when el-get-byte-compile
+	  (el-get-byte-compile-file package-init-file))
 	(el-get-verbose-message "el-get: load %S" file-name-no-extension)
 	(load file-name-no-extension 'noerror)))))
 


### PR DESCRIPTION
Currently, on update, el-get byte compiles all my `init-<package>.el` files in the `el-get-user-package-directory` directory, regardless of the variable `el-get-byte-compile`. I believe this is wrong and this pull request fixes this.
