### PR TITLE
expand-region recipe doesn't load it properly

### DIFF
--- a/recipes/expand-region.rcp
+++ b/recipes/expand-region.rcp
@@ -3,4 +3,4 @@
        :pkgname "magnars/expand-region.el"
        :description "Expand region increases the selected region by semantic units. Just keep pressing the key until it selects what you want."
        :website "https://github.com/magnars/expand-region.el#readme"
-       :prepare (autoload 'er/expand-region "expand-region" nil t))
+       :features expand-region)


### PR DESCRIPTION
Hi,

If I "manually" require the library as described in its README:

``` lisp
(require 'expand-region)
(global-set-key (kbd "C-=") 'er/expand-region)
```

it works fine, i.e., when Emacs finishes loading itself, all core `er/*` functions are available. When I load a Ruby file, it correctly loads `ruby-mode` extensions for `expand-region` _and_ actually uses them when `er/expand-region` function is called.

Now, when I try to load `expand-region` via recipe provided by el-get, when Emacs finishes loading, only `er/expand-region` function is available. When I call this function, the other functions from the core module become available. When I load a Ruby file it does _not_ load mode-specific extensions. If I load them manually (`(require 'ruby-mode-expansions)`) functions provided by this extension are available, but they are not actually used when I call `er/expand-region`.

I'm not sure if it's something wrong with the recipe or the package itself. I'm using the latest el-get version from master branch  (8e68e637de2a58b011681ecb4e6a8e317eb1edc7) and Emacs 24.1 on OS X.
