### PR TITLE
add github type recipe for eval-sexp-fu

### DIFF
--- a/recipes/eval-sexp-fu.rcp
+++ b/recipes/eval-sexp-fu.rcp
@@ -1,0 +1,7 @@
+(:name eval-sexp-fu
+       :auto-generated t
+       :type github
+       :pkgname "hchbaw/eval-sexp-fu.el"
+       :depends (highlight)
+       :description "Tiny functionality enhancements for evaluating sexps."
+       :website "https://github.com/hchbaw/eval-sexp-fu.el")


### PR DESCRIPTION
emacswiki type eval-sexp-fu recipe have error. so i add github type recipe. 
