### PR TITLE
recipes/offlineimap: does not depend on nognus.

### DIFF
--- a/recipes/offlineimap.rcp
+++ b/recipes/offlineimap.rcp
@@ -2,5 +2,4 @@
        :description "Run OfflineIMAP from Emacs"
        :type git
        :url "git://git.naquadah.org/offlineimap-el.git"
-       :features offlineimap
-       :depends nognus) ; or you don't have (require 'gnus-load)
+       :features offlineimap)


### PR DESCRIPTION
@jd s Offlineimap does not seem to depend on nognus. No require or mention
of gnus in the code.

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
