### PR TITLE
Use ProofGeneral-4.2pre120814.tgz (fixes compilation error in PG)

### DIFF
--- a/recipes/ProofGeneral.rcp
+++ b/recipes/ProofGeneral.rcp
@@ -3,7 +3,7 @@
        :description "Proof General is a generic front-end for proof assistants (also known as interactive theorem provers)"
        :type http-tar
        :options ("xzf")
-       :url "http://proofgeneral.inf.ed.ac.uk/releases/ProofGeneral-4.2pre111207.tgz"
+       :url "http://proofgeneral.inf.ed.ac.uk/releases/ProofGeneral-4.2pre120814.tgz"
        :build ("cd ProofGeneral && make clean" "cd ProofGeneral && make compile")
        :load  ("ProofGeneral/generic/proof-site.el")
        :info "./ProofGeneral/doc/")


### PR DESCRIPTION
The version of ProofGeneral downloaded in the current recipe fails to compile with Emacs 24.2.1 (on OSX 10.7.4 though I don't think this matters). The latest prerelease succeeds, so I've updated the URL in the recipe.

It is not an el-get issue, but here is the compilation error, for reference and searchability:

```
In toplevel form:
generic/proof-toolbar.el:106:21:Error: assignment to free variable `image-load-path'
```
