### PR TITLE
Change auto-complete recipe to use organization repo

### DIFF
--- a/recipes/auto-complete.rcp
+++ b/recipes/auto-complete.rcp
@@ -2,5 +2,5 @@
        :website "http://cx4a.org/software/auto-complete/"
        :description "The most intelligent auto-completion extension."
        :type github
-       :pkgname "m2ym/auto-complete"
+       :pkgname "auto-complete/auto-complete"
        :depends (popup fuzzy))

--- a/recipes/fuzzy.rcp
+++ b/recipes/fuzzy.rcp
@@ -1,5 +1,5 @@
 (:name fuzzy
-       :website "https://github.com/m2ym/fuzzy-el"
+       :website "https://github.com/auto-complete/fuzzy-el"
        :description "Fuzzy matching utilities for GNU Emacs"
        :type github
-       :pkgname "m2ym/fuzzy-el")
+       :pkgname "auto-complete/fuzzy-el")

--- a/recipes/popup.rcp
+++ b/recipes/popup.rcp
@@ -1,5 +1,5 @@
 (:name popup
-       :website "https://github.com/m2ym/popup-el"
+       :website "https://github.com/auto-complete/popup-el"
        :description "Visual Popup Interface Library for Emacs"
        :type github
-       :pkgname "m2ym/popup-el")
+       :pkgname "auto-complete/popup-el")


### PR DESCRIPTION
ac is now an organization so m2ym doesn't have to deal with user admin. Change the recipe to deal with this.
