### PR TITLE
Fix test/el-get-issue-659.el

### DIFF
--- a/test/el-get-issue-659.el
+++ b/test/el-get-issue-659.el
@@ -25,7 +25,8 @@
                                     "\n")))))
                 :prepare (message "Preparing A")
                 :post-init (message "Post-init A")
-                :lazy nil)))
+                :lazy nil)
+         (:name b :type test)))
       (update-source
        '(:name a
                :before (message "Before A")
@@ -49,7 +50,7 @@
                :type test
                :features a
                ;; Not allowed to update this
-               :post-init (message "New post-init A"))))
+               :depends b)))
   ;; Install A
   (el-get 'sync 'a)
   (require 'a)


### PR DESCRIPTION
The bug was introduced in #836.

Another possible fix is to remove `:post-init` and `:prepare` from `el-get-status-recipe-update-whitelist`.

@DarwinAwardWinner Why did not you put them in the whitelist?  Probably it's better to remove them?

I thought I'd add them as I want status cache to be updated when I change my private recipe files.
