### PR TITLE
Clear status cache before init/install/update

### DIFF
--- a/el-get-status.el
+++ b/el-get-status.el
@@ -95,6 +95,10 @@
 (defvar el-get-status-cache nil
   "Cache used by `el-get-read-status-file'.")
 
+(defun el-get-clear-status-cache ()
+  "Clear in-memory cache for status file."
+  (setq el-get-status-cache nil))
+
 (defun el-get-read-status-file ()
   "read `el-get-status-file' and return an alist of plist like:
    (PACKAGE . (status \"status\" recipe (:name ...)))"

--- a/el-get.el
+++ b/el-get.el
@@ -456,6 +456,7 @@ which defaults to the first element in `el-get-recipe-path'."
   "Make the named PACKAGE available for use, first initializing any
    dependency of the PACKAGE."
   (interactive (list (el-get-read-package-with-status "Init" "installed")))
+  (el-get-clear-status-cache)
   (el-get-verbose-message "el-get-init: %s" package)
   (let* ((init-deps   (el-get-dependencies (el-get-as-symbol package))))
     (el-get-verbose-message "el-get-init: " init-deps)
@@ -567,6 +568,7 @@ dependencies (if any).
 
 PACKAGE may be either a string or the corresponding symbol."
   (interactive (list (el-get-read-package-name "Install")))
+  (el-get-clear-status-cache)
   (setq el-get-next-packages (el-get-dependencies (el-get-as-symbol package)))
   (el-get-verbose-message "el-get-install %s: %S" package el-get-next-packages)
   (add-hook 'el-get-post-init-hooks 'el-get-install-next-packages)
@@ -660,6 +662,7 @@ PACKAGE may be either a string or the corresponding symbol."
   "Reload PACKAGE."
   (interactive
    (list (el-get-read-package-with-status "Reload" "installed")))
+  (el-get-clear-status-cache)
   (el-get-verbose-message "el-get-reload: %s" package)
   (el-get-with-status-sources package-status-alist
     (let* ((all-features features)
@@ -766,6 +769,7 @@ itself.")
   (interactive
    (list (el-get-read-package-with-status "Update" "required" "installed")))
   (el-get-error-unless-package-p package)
+  (el-get-clear-status-cache)
   (if (el-get-update-requires-reinstall package)
       (el-get-reinstall package)
     (let* ((package (el-get-as-symbol package))
@@ -851,6 +855,7 @@ itself.")
   "Remove any PACKAGE that is know to be installed or required."
   (interactive
    (list (el-get-read-package-with-status "Remove" "required" "installed")))
+  (el-get-clear-status-cache)
   ;; If the package has a recipe saved in the status file, that will
   ;; be used. But if not, we still want to try to remove it, so we
   ;; fall back to the recipe file, and if even that doesn't provide
@@ -997,6 +1002,7 @@ the packages you use are welcome to use `autoload' too.
 PACKAGES is expected to be a list of packages you want to install
 or init.  When PACKAGES is omited (the default), the list of
 already installed packages is considered."
+  (el-get-clear-status-cache)
   ;; If there's no autoload file, everything needs to be regenerated.
   (unless (file-exists-p el-get-autoload-file) (el-get-invalidate-autoloads))
 


### PR DESCRIPTION
Current caching doesn't work well with running multiple Emacs processes.  This PR is intended to fix that.

The cache is cleared before running these functions:
- el-get-init
- el-get-install
- el-get-reload
- el-get-update
- el-get-remove
- el-get

The other more restricting way I have in mind is something like this:

``` cl
(defvar el-get-status-cache 'nocache
  "Cache used by `el-get-read-status-file'.
To suppress caching, set `nocache' to it.")

(defun el-get-read-status-file ()
  (cond
   ;; Cached
   ((and el-get-status-cache (listp el-get-status-cache))
    el-get-status-cache)
   ;; Read from file
   (el-get-status-cache
    (el-get-read-status-file-force))
   ;; Read from file and cache it
   (t (setq el-get-status-cache (el-get-read-status-file-force)))))

(defun el-get (&optional sync &rest packages)
  (let (...
        el-get-status-cache)  ; enable caching
    ...))
```
