### PR TITLE
Add failing tests for the issue #835

### DIFF
--- a/test/el-get-issue-835-build.el
+++ b/test/el-get-issue-835-build.el
@@ -1,0 +1,27 @@
+(require 'cl)
+(el-get-register-method-alias :test :builtin)
+
+(let ((debug-on-error t)
+      (el-get-default-process-sync t)
+      (el-get-verbose t)
+      (el-get-auto-update-cached-recipes t)
+      (a-rcp-1
+       '(:name a
+               :type test
+               :before (message "Before A")
+               :after (message "After A")
+               :build ("echo building...")))
+      (a-rcp-2
+       '(:name a
+               :type test
+               :before (message "Before A (changed)")
+               :after (message "After A (changed)")))
+      (test
+       (lambda (func rcp)
+         (let ((el-get-sources (list rcp)))
+           (funcall func 'a)
+           (assert (equal (el-get-package-status-recipes) el-get-sources)
+                   nil "Cached recipe is different from given source.")))))
+
+  (funcall test #'el-get-install a-rcp-1)
+  (funcall test #'el-get-update a-rcp-2))

--- a/test/el-get-issue-835-depends.el
+++ b/test/el-get-issue-835-depends.el
@@ -1,0 +1,27 @@
+(require 'cl)
+(el-get-register-method-alias :test :builtin)
+
+(let ((debug-on-error t)
+      (el-get-default-process-sync t)
+      (el-get-verbose t)
+      (el-get-auto-update-cached-recipes t)
+      (a-rcp-1
+       '(:name a
+               :type test
+               :before (message "Before A")
+               :after (message "After A")
+               :depends b))
+      (a-rcp-2
+       '(:name a  ; dependency on b removed.
+               :type test
+               :before (message "Before A (changed)")
+               :after (message "After A (changed)")))
+      (test
+       (lambda (func rcp)
+         (let ((el-get-sources (list rcp '(:name b :type test))))
+           (funcall func 'a)
+           (assert (equal (el-get-package-status-recipes) el-get-sources)
+                   nil "Cached recipe is different from given source.")))))
+
+  (funcall test #'el-get-install a-rcp-1)
+  (funcall test #'el-get-update a-rcp-2))


### PR DESCRIPTION
I added two test files:
- test/el-get-issue-835-build.el
- test/el-get-issue-835-depends.el

Is it better to rename them to `el-get-issue-NUM.el`?

See: #835
