### PR TITLE
Clear status cache before init/install/update, etc. (take 2)

### DIFF
--- a/el-get-status.el
+++ b/el-get-status.el
@@ -95,6 +95,10 @@
 (defvar el-get-status-cache nil
   "Cache used by `el-get-read-status-file'.")
 
+(defun el-get-clear-status-cache ()
+  "Clear in-memory cache for status file."
+  (setq el-get-status-cache nil))
+
 (defun el-get-read-status-file ()
   "read `el-get-status-file' and return an alist of plist like:
    (PACKAGE . (status \"status\" recipe (:name ...)))"

--- a/el-get.el
+++ b/el-get.el
@@ -455,7 +455,9 @@ which defaults to the first element in `el-get-recipe-path'."
 (defun el-get-init (package &optional package-status-alist)
   "Make the named PACKAGE available for use, first initializing any
    dependency of the PACKAGE."
-  (interactive (list (el-get-read-package-with-status "Init" "installed")))
+  (interactive (progn
+                 (el-get-clear-status-cache)
+                 (list (el-get-read-package-with-status "Init" "installed"))))
   (el-get-verbose-message "el-get-init: %s" package)
   (let* ((init-deps   (el-get-dependencies (el-get-as-symbol package))))
     (el-get-verbose-message "el-get-init: " init-deps)
@@ -566,7 +568,9 @@ called by `el-get' (usually at startup) for each installed package."
 dependencies (if any).
 
 PACKAGE may be either a string or the corresponding symbol."
-  (interactive (list (el-get-read-package-name "Install")))
+  (interactive (progn
+                 (el-get-clear-status-cache)
+                 (list (el-get-read-package-name "Install"))))
   (setq el-get-next-packages (el-get-dependencies (el-get-as-symbol package)))
   (el-get-verbose-message "el-get-install %s: %S" package el-get-next-packages)
   (add-hook 'el-get-post-init-hooks 'el-get-install-next-packages)
@@ -659,7 +663,9 @@ PACKAGE may be either a string or the corresponding symbol."
 (defun el-get-reload (package &optional package-status-alist)
   "Reload PACKAGE."
   (interactive
-   (list (el-get-read-package-with-status "Reload" "installed")))
+   (progn
+     (el-get-clear-status-cache)
+     (list (el-get-read-package-with-status "Reload" "installed"))))
   (el-get-verbose-message "el-get-reload: %s" package)
   (el-get-with-status-sources package-status-alist
     (let* ((all-features features)
@@ -764,7 +770,9 @@ itself.")
 (defun el-get-update (package)
   "Update PACKAGE."
   (interactive
-   (list (el-get-read-package-with-status "Update" "required" "installed")))
+   (progn
+     (el-get-read-status-file-force)
+     (list (el-get-read-package-with-status "Update" "required" "installed"))))
   (el-get-error-unless-package-p package)
   (if (el-get-update-requires-reinstall package)
       (el-get-reinstall package)
@@ -850,7 +858,9 @@ itself.")
 (defun el-get-remove (package &optional package-status-alist)
   "Remove any PACKAGE that is know to be installed or required."
   (interactive
-   (list (el-get-read-package-with-status "Remove" "required" "installed")))
+   (progn
+     (el-get-clear-status-cache)
+     (list (el-get-read-package-with-status "Remove" "required" "installed"))))
   ;; If the package has a recipe saved in the status file, that will
   ;; be used. But if not, we still want to try to remove it, so we
   ;; fall back to the recipe file, and if even that doesn't provide


### PR DESCRIPTION
take 1: #862

The cache is cleared before running these functions _interactively_:
- el-get-init
- el-get-install
- el-get-reload
- el-get-update
- el-get-remove
