### PR TITLE
Corrected typo in jshint-mode.rcp

### DIFF
--- a/recipes/jshint-mode.rcp
+++ b/recipes/jshint-mode.rcp
@@ -2,5 +2,5 @@
  :website "https://github.com/daleharvey/jshint-mode"
  :description "Integrate JSHint into Emacs via a node.js server. JSHint (http://www.jshint.com/) is a static code analysis tool for JavaScript."
  :type github
- :url "daleharvey/jshint-mode.git"
+ :pkgname "daleharvey/jshint-mode"
 )


### PR DESCRIPTION
This is a follow-up to pull request # 671.  I noticed a typo in jshint-mode.rcp.  
