### PR TITLE
recipes/swank-js: Recipe broken: swank-js.el is now slime-js.el

### DIFF
--- a/recipes/swank-js.rcp
+++ b/recipes/swank-js.rcp
@@ -1,5 +1,5 @@
 (:name swank-js
        :description "SLIME REPL and other development tools for in-browser JavaScript and Node.JS"
        :type github
-       :pkgname "fukamachi/swank-js"
+       :pkgname "swank-js/swank-js"
        :features nil)


### PR DESCRIPTION
The package does not contain a swank-js.el and the Emacs lisp part is
in slime-js.el.  But the package should not be loaded by el-get but
instead by using `slime-setup'.  That's why the :features should be
nil.  I do not know if there is a way to add swank-js to the
`slime-setup-contribs' without modifying the slime setup.

With the current configuration swank-js can be loaded with the
following entries in `el-get-sources':

```
(:name swank-js
       :after (progn (add-to-list 'slime-setup-contribs 'slime-js)))

(:name slime
       :after (progn
                (setq slime-setup-contribs
                      (append slime-setup-contribs
                              '(slime-banner slime-references slime-fancy)))
                (slime-setup slime-setup-contribs)))
```

This is certainly not the best way to do it and it requires that
swank-js does _not_ depend on slime.

I also removed :website because it is no longer needed by the github
recipe type.

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
