### PR TITLE
Added recipe for org-jekyll

### DIFF
--- a/recipes/org-jekyll.rcp
+++ b/recipes/org-jekyll.rcp
@@ -1,0 +1,6 @@
+(:name org-jekyll
+       :description "Blog from org-mode using jekyll"
+       :type github
+       :pkgname "juanre/org-jekyll"
+       :features org-jekyll)
+


### PR DESCRIPTION
Thank you for el-get.  I've moved to it a 15-year-old-and-counting emacs configuration mess with great success.  I have added a recipe for org-jekyll, a module to produce jekyll-ready blogs from org-mode.

Best regards,

jm
