### PR TITLE
Use trailing space with yes-or-no-p

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -820,7 +820,7 @@ itself.")
   (interactive)
   (when (or no-prompt
             (yes-or-no-p
-             "Do you really want to update all installed packages?"))
+             "Do you really want to update all installed packages? "))
     ;; The let and flet forms here ensure that
     ;; `package-refresh-contents' is only called once, regardless of
     ;; how many ELPA-type packages need to be installed. Without this,


### PR DESCRIPTION
The documentation of the built-in function yes-or-no-p says that the
argument "should end in a space".
