### PR TITLE
Add recipe for rcodetools.

### DIFF
--- a/recipes/rcodetools.rcp
+++ b/recipes/rcodetools.rcp
@@ -1,0 +1,4 @@
+(:name rcodetools
+       :description "rcodetools is a collection of Ruby code manipulation tools."
+       :type github
+       :pkgname "tnoda/rcodetools")


### PR DESCRIPTION
For dependencies of autocomplete-ruby, it is there for three months.
It is [Issue #776](https://github.com/dimitri/el-get/issues/776).
