### PR TITLE
Fix auto-complete.rcp

### DIFF
--- a/recipes/auto-complete.rcp
+++ b/recipes/auto-complete.rcp
@@ -3,5 +3,4 @@
        :description "The most intelligent auto-completion extension."
        :type github
        :username "auto-complete"
-       :features auto-complete
        :depends (popup fuzzy))


### PR DESCRIPTION
Now points to the repository at
git://github.com/auto-complete/auto-complete.git. Also 'require's
auto-complete as that did not seem to happen automatically
