### PR TITLE
recipe: browse-kill-ring is moved to a github organization

### DIFF
--- a/recipes/browse-kill-ring.rcp
+++ b/recipes/browse-kill-ring.rcp
@@ -1,4 +1,5 @@
 (:name browse-kill-ring
        :description "Interactively insert items from kill-ring"
-       :type emacswiki
+       :type github
+       :pkgname "browse-kill-ring/browse-kill-ring"
        :features browse-kill-ring)


### PR DESCRIPTION
update recipe browse-kill-ring
it is moved to a github organization
