### PR TITLE
Recipe for Pabbrev

### DIFF
--- a/recipes/pabbrev.rcp
+++ b/recipes/pabbrev.rcp
@@ -1,0 +1,4 @@
+(:name pabbrev
+       :description "Simple predictive abbreviation"
+       :type http
+       :url "http://homepages.cs.ncl.ac.uk/phillip.lord/download/emacs/pabbrev.el")


### PR DESCRIPTION
This recipe downloads the newest pabbrev.el while the emacswiki version
may lag behind.
The version available on emacswiki does not work on Emacs 24
