### PR TITLE
Fix emms compilation without pre-existing emms dir.

### DIFF
--- a/recipes/emms.rcp
+++ b/recipes/emms.rcp
@@ -5,7 +5,7 @@
        :info "doc"
        :load-path ("./lisp")
        :features emms-setup
-       :build `(("mkdir" "-p" ,(format "%s/emms" user-emacs-directory))
+       :build `(("mkdir" "-p" ,(expand-file-name (format "%s/emms" user-emacs-directory)))
                 ("make" ,(format "EMACS=%s" el-get-emacs)
                  ,(format "SITEFLAG=\\\"--no-site-file -L %s/emacs-w3m/ \\\""
                           el-get-dir)


### PR DESCRIPTION
Without this change, emms compilation fails and I wind up with a directory named ~/.emacs.d/emms within the build area. Looks like fallout from killing the shell expansion.
