### PR TITLE
Update recipes/session.rcp

### DIFF
--- a/recipes/session.rcp
+++ b/recipes/session.rcp
@@ -3,6 +3,6 @@
        :type http-tar
        :options ("xzf")
        :load-path ("lisp")
-       :url "http://downloads.sourceforge.net/project/emacs-session/session/2.2a/session-2.2a.tar.gz"
+       :url "http://downloads.sourceforge.net/project/emacs-session/session/session-2.3a.tar.gz"
        :autoloads nil
        )


### PR DESCRIPTION
Looks like the 2.2a is broken (install-time error on "session-initialize" variable). Updating this to 2.3a fixes the issue
