### PR TITLE
Added ac-nrepl recipe

### DIFF
--- a/recipes/ac-nrepl.rcp
+++ b/recipes/ac-nrepl.rcp
@@ -1,0 +1,6 @@
+(:name ac-nrepl
+       :description "Nrepl completion source for Emacs auto-complete package"
+       :type github
+       :pkgname "purcell/ac-nrepl"
+       :depends nrepl
+       :features ac-nrepl)


### PR DESCRIPTION
Hey, I've added a new recipe - ac-nrepl. It is an auto-complete config for nrepl  (which is a minor mode used together with clojure-mode).

Since ac-nrepl is on github I believe that it's a straightforward task.

Cheers,
Igor
