### PR TITLE
Make EIN depend on auto-complete

### DIFF
--- a/recipes/ein.rcp
+++ b/recipes/ein.rcp
@@ -2,7 +2,7 @@
        :description "IPython notebook client in Emacs"
        :type github
        :pkgname "tkf/emacs-ipython-notebook"
-       :depends (websocket nxhtml)
+       :depends (websocket auto-complete)
        :load-path ("lisp")
        :submodule nil
        :features ein)


### PR DESCRIPTION
MuMaMo (nxhtml) dependency is optional now, thus removing it.
