### PR TITLE
Fix auto-install .emacs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,14 +140,13 @@ Here is the basic setup to add to your `user-init-file` (`.emacs`):
 ```lisp
 (add-to-list 'load-path "~/.emacs.d/el-get/el-get")
 
-(unless (require 'el-get nil t)
+(if (require 'el-get nil t)
+    (el-get 'sync)
   (url-retrieve
    "https://raw.github.com/dimitri/el-get/master/el-get-install.el"
    (lambda (s)
      (goto-char (point-max))
      (eval-print-last-sexp))))
-
-(el-get 'sync)
 ```
 
 And for those who prefer the master branch, please use the code below
@@ -155,15 +154,14 @@ And for those who prefer the master branch, please use the code below
 ```lisp
 (add-to-list 'load-path "~/.emacs.d/el-get/el-get")
 
-(unless (require 'el-get nil t)
+(if (require 'el-get nil t)
+    (el-get 'sync)
   (url-retrieve
    "https://raw.github.com/dimitri/el-get/master/el-get-install.el"
    (lambda (s)
      (let (el-get-master-branch)
        (goto-char (point-max))
        (eval-print-last-sexp)))))
-
-(el-get 'sync)
 ```
 
 ## Package Setup


### PR DESCRIPTION
The code as written causes errors the first time around, because `(el-get 'sync)` fails when el-get isn't already installed
