### PR TITLE
Use git:// protocol for evil recipe

### DIFF
--- a/recipes/evil.rcp
+++ b/recipes/evil.rcp
@@ -4,7 +4,7 @@
        emulates the main features of Vim, and provides facilities
        for writing custom extensions."
        :type git
-       :url "https://git.gitorious.org/evil/evil.git"
+       :url "git://gitorious.org/evil/evil.git"
        :features evil
        :depends undo-tree
        :build (("make" "all" "info"))


### PR DESCRIPTION
Cloning repo over http for a gitorious repo might be slow.
This commit simply change http:// to git://
