### PR TITLE
Remove org-install it is deprecated

### DIFF
--- a/recipes/org-mode.rcp
+++ b/recipes/org-mode.rcp
@@ -12,5 +12,4 @@
                  (lambda (target)
                    (list "make" target (concat "EMACS=" (shell-quote-argument el-get-emacs))))
                  '("oldorg"))
-       :load-path ("." "lisp" "contrib/lisp")
-       :autoloads nil)
+       :load-path ("." "lisp" "contrib/lisp"))


### PR DESCRIPTION
Using org-install is deprecated in newer versions of Org. Having it listed as a feature was causing a warning every time emacs started.  Org mode still seems to work on my system without it.
