### PR TITLE
Pull cedet from bzr the git repo no longer exists

### DIFF
--- a/recipes/cedet.rcp
+++ b/recipes/cedet.rcp
@@ -1,8 +1,8 @@
 (:name cedet
   :website "http://cedet.sourceforge.net/"
   :description "CEDET is a Collection of Emacs Development Environment Tools written with the end goal of creating an advanced development environment in Emacs."
-  :type git
-  :url "http://git.randomsample.de/cedet.git"
+  :type bzr
+  :url "bzr://cedet.bzr.sourceforge.net/bzrroot/cedet/code/trunk"
   :build
   ;; `((,el-get-emacs "-batch" "-Q" "-l" "cedet-build.el" "-f" "cedet-build"))
   `(("sh" "-c" "touch `find . -name Makefile`")


### PR DESCRIPTION
The upstream cedet git repo has been removed because their import from bzr broke, http://permalink.gmane.org/gmane.emacs.cedet/5988.

So, I've switched the recipe to bzr.
