### PR TITLE
remove :features and :autoloads from org-mode recipe

### DIFF
--- a/recipes/org-mode.rcp
+++ b/recipes/org-mode.rcp
@@ -12,6 +12,4 @@
                  (lambda (target)
                    (list "make" target (concat "EMACS=" (shell-quote-argument el-get-emacs))))
                  '("oldorg"))
-       :load-path ("." "lisp" "contrib/lisp")
-       :autoloads nil
-       :features org-install)
+       :load-path ("." "lisp" "contrib/lisp"))


### PR DESCRIPTION
This should correctly implement pull request #919.
(sorry, I just would like to see this issue fixed)
