### PR TITLE
fix compile error in scala-mode on OSX

### DIFF
--- a/recipes/scala-mode.rcp
+++ b/recipes/scala-mode.rcp
@@ -3,5 +3,6 @@
        :type svn
        :url "http://lampsvn.epfl.ch/svn-repos/scala/scala-tool-support/trunk/src/emacs/"
        :build ("make")
+       :build/darwin `(,(concat "make ELISP_COMMAND=" el-get-emacs))
        :load-path (".")
        :features scala-mode-auto)


### PR DESCRIPTION
install scala-mode causes "can not open load file: subst-ksc".
specify ELISP_COMMAND to avoid the error.
