### PR TITLE
Fix compile error in reftex on OSX

### DIFF
--- a/recipes/reftex.rcp
+++ b/recipes/reftex.rcp
@@ -3,7 +3,9 @@
        :type cvs
        :module "reftex"
        :url ":pserver:anonymous@cvs.sv.gnu.org:/sources/auctex"
-       :build '(("make") ("make" "info"))
+       :build `(("make"
+                 ,(concat "EMACS=" el-get-emacs))
+                ("make" "info"))
        :features reftex
        :load-path ("lisp")
        :info "doc")


### PR DESCRIPTION
With emacs from emacsformacosx.com, installing reftex causes "can not open load file: subst-ksc".
Passing EMACS to make fixes this error.
