### PR TITLE
Add a failing test case: `:features` option for ELPA type recipe does not work

### DIFF
--- a/test/run-ert.sh
+++ b/test/run-ert.sh
@@ -3,6 +3,16 @@
 source "$(dirname $0)"/test-utils.sh
 ERT_TEST="$EL_GET_LIB_DIR/test/test.el"
 
+
+if [ -n "$DO_NOT_CLEAN" ]; then
+    echo "Running test without removing $TEST_HOME first";
+else
+    add_on_exit "rm -rf $TEST_HOME"
+    rm -rf "$TEST_HOME"
+fi
+mkdir -p "$TEST_HOME"/.emacs.d/el-get/
+
+
 HOME="$TEST_HOME" exec \
     "$EMACS" -Q -batch -L "$EL_GET_LIB_DIR" -l "$ERT_TEST" \
     -f ert-run-tests-batch-and-exit

--- a/test/test.el
+++ b/test/test.el
@@ -9,6 +9,44 @@
 
 (defconst testing-destination-dir "/tmp/emacs.d.testing")
 
+(defmacro* el-get-deftest (name () &body docstring-and-body)
+  "`ert-deftest' with predefined context for el-get test cases.
+
+Following variables are bound to temporal values during test:
+* `user-emacs-directory'
+* `el-get-dir'
+* `el-get-status-file'"
+  (declare (debug (&define :name test
+                           name sexp [&optional stringp]
+			   [&rest keywordp sexp] def-body))
+           (doc-string 3)
+           (indent 2))
+  (let ((docstring (car docstring-and-body))
+        (body (cdr docstring-and-body)))
+    (unless (stringp docstring)
+      (setq docstring nil)
+      (setq body docstring-and-body))
+    `(ert-deftest ,name ()
+       ,@(when docstring (list docstring))
+       (let* ((user-emacs-directory testing-destination-dir)
+              (el-get-dir (concat (file-name-as-directory user-emacs-directory)
+                                  "el-get"))
+              (el-get-status-file
+               (concat (file-name-as-directory el-get-dir) ".status.el")))
+         (unwind-protect
+             (progn
+               (make-directory el-get-dir t)
+               ,@body)
+           (delete-directory el-get-dir t))))))
+
+(put 'el-get-deftest 'lisp-indent-function 2)
+
+(font-lock-add-keywords
+ nil
+ '(("(\\(\\<el-get-deftest\\)\\>\\s *\\(\\sw+\\)?"
+    (1 font-lock-keyword-face nil t)
+    (2 font-lock-function-name-face nil t))))
+
 (ert-deftest el-get-recipe-dirs-test ()
   (let ((el-get-recipe-path
          `("/"
@@ -20,16 +58,11 @@
                          when (file-exists-p f)
                          collect f)))))
 
-(ert-deftest el-get-trivial-install-test ()
+(el-get-deftest el-get-trivial-install-test ()
   (let* ((pkg 'el-get-trivial-install-test)
          (pkg-name (symbol-name pkg))
          (pkg-file (concat pkg-name ".el"))
          (pkg-source (concat "/tmp/" pkg-file))
-         (user-emacs-directory testing-destination-dir)
-         (el-get-dir (concat (file-name-as-directory user-emacs-directory)
-                             "el-get"))
-         (el-get-status-file
-          (concat (file-name-as-directory el-get-dir) ".status.el"))
          (pkg-destination-dir (mapconcat
                                'file-name-as-directory
                                (list user-emacs-directory "el-get" pkg-name)
@@ -40,7 +73,6 @@
                                   :type http
                                   :url ,(concat "file://" pkg-source))))
 	 (el-get-packages (mapcar 'el-get-source-name el-get-sources)))
-    (make-directory el-get-dir t)
     (unwind-protect
         (progn
           (message "Checking %s is not loaded" pkg)

--- a/test/test.el
+++ b/test/test.el
@@ -99,5 +99,13 @@ Following variables are bound to temporal values during test:
           (should-not (file-exists-p pkg-destination)))
       (delete-file pkg-source))))
 
+(el-get-deftest el-get-elpa-feature ()
+  "`:features' option should work for ELPA type recipe."
+  (let* ((pkg 'wrap-region)              ; some package from elpa
+         (el-get-sources `((:name ,pkg :features ,pkg))))
+    (should-not (featurep pkg))
+    (el-get 'sync (mapcar 'el-get-source-name el-get-sources))
+    (should (featurep pkg))))
+
 ;(featurep 'el-get-trivial-install-test)
 ;(unload-feature 'el-get-trivial-install-test)


### PR DESCRIPTION
* First commit is a minor fix for ERT-based test runner.
* Second commit refractors ERT-based test.
* Third commit adds the failing test for the title.

This test needs network connection and thus it is far from optional.  Is there a way to install package using package.el without network connection?  I will try to find a better way later but please tell me if somebody knows a good way to do it.  Anyway, I thought it's better to file this issue first.
