### PR TITLE
Use gmake for building Magit on BSD systems

### DIFF
--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -6,6 +6,7 @@
        :info "."
        :autoloads ("50magit")
        :build (("make" "all"))
+       :build/berkeley-unix (("touch" "`find . -name Makefile`") ("gmake"))
        :build/darwin `(("make"
                         ,(format "EMACS=%s" el-get-emacs)
                         "all")))


### PR DESCRIPTION
Magit does not seem to build in FreeBSD and complains:
"don't know how to make magit-svn.elc".  Using gmake fixes the issue.

I copied the solution used in a similar issue on pull request #755.  You get a warning about shell interpolation so not sure if there is a better way to do this - it works though.
