### PR TITLE
ne2wm depends on magit

### DIFF
--- a/recipes/ne2wm.rcp
+++ b/recipes/ne2wm.rcp
@@ -2,5 +2,5 @@
        :description "Perspectives, plugins, functions and commands for e2wm"
        :type github
        :pkgname "tkf/ne2wm"
-       :depends e2wm
+       :depends (e2wm magit)
        :features ne2wm-setup)


### PR DESCRIPTION
ne2wm will not load without magit installed
