### PR TITLE
change build/darwin to build when the only difference is to pass el-get-emacs to build

### DIFF
--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -5,8 +5,7 @@
        :pkgname "magit/magit"
        :info "."
        :autoloads ("50magit")
-       :build (("make" "all"))
-       :build/berkeley-unix (("touch" "`find . -name Makefile`") ("gmake"))
-       :build/darwin `(("make"
-                        ,(format "EMACS=%s" el-get-emacs)
-                        "all")))
+       :build `(("make"
+                 ,(format "EMACS=%s" el-get-emacs)
+                 "all"))
+       :build/berkeley-unix (("touch" "`find . -name Makefile`") ("gmake")))

--- a/recipes/scala-mode.rcp
+++ b/recipes/scala-mode.rcp
@@ -2,7 +2,6 @@
        :description "Major mode for editing Scala code."
        :type svn
        :url "http://lampsvn.epfl.ch/svn-repos/scala/scala-tool-support/trunk/src/emacs/"
-       :build ("make")
-       :build/darwin `(,(concat "make ELISP_COMMAND=" el-get-emacs))
+       :build `(("make" ,(concat "ELISP_COMMAND=" el-get-emacs)))
        :load-path (".")
        :features scala-mode-auto)


### PR DESCRIPTION
As par discussion in #968, move "build/dawrin" to "build" when the only OSX-specific thing is to pass "el-get-emacs" to build command.  Tested in Debian Sid, and installation was successful.

Also, I get rid of shell-interpolation warning from scala-mode.rcp.
