### PR TITLE
add solarized-emacs

### DIFF
--- a/recipes/solarized-emacs.rcp
+++ b/recipes/solarized-emacs.rcp
@@ -1,0 +1,6 @@
+(:name solarized-emacs
+       :description "Emacs highlighting using Ethan Schoonover's Solarized color scheme"
+       :type github
+       :pkgname "bbatsov/solarized-emacs"
+       :prepare (progn
+                  (add-to-list 'custom-theme-load-path default-directory)))


### PR DESCRIPTION
This is the solarized theme using load-theme from Emacs 24 instead of color-theme. It works better on Emacs 24.
