### PR TITLE
Ensime recipe uses `dist/elisp' directory for load-path.

### DIFF
--- a/recipes/ensime.rcp
+++ b/recipes/ensime.rcp
@@ -2,10 +2,11 @@
        :description "ENhanced Scala Interaction Mode for Emacs"
        :type github
        :pkgname "aemoncannon/ensime"
-       :build ("sbt update stage")
+       :build '(("sbt update stage")
+                ("ln -s $(ls -1 | grep '^dist' | sort | head -1) dist"))
        :depends scala-mode
        :features ensime
-       :load-path ("./src/main/elisp")
+       :load-path ("./dist/elisp")
        :post-init (progn
                     (require 'ensime)
                     ;; scala-mode can be found in the scala distribution:


### PR DESCRIPTION
Related to #892.

I had a couple of ideas how to fix ensime recipe:
- I tried `:load-path ,(progn ...)`; turns out el-get expects stringp
- I tried `(el-get-add-path-to-list 'ensime 'load-path (car (directory-files ...)))` in :post-init; turns-out that is a little to late because `(require 'ensime)` precedes :load-path
- and a couple of others; learning something about el-get internals along the way :)

In the end, this implementation is the most straightforward even though it is OS dependent.

Anyway, hope that helps.
