### PR TITLE
Use current scala-mode repository.

### DIFF
--- a/recipes/scala-mode.rcp
+++ b/recipes/scala-mode.rcp
@@ -1,7 +1,7 @@
 (:name scala-mode
        :description "Major mode for editing Scala code."
-       :type svn
-       :url "http://lampsvn.epfl.ch/svn-repos/scala/scala-tool-support/trunk/src/emacs/"
-       :build `(("make" ,(concat "ELISP_COMMAND=" el-get-emacs)))
-       :load-path (".")
+       :type git
+       :url "https://github.com/scala/scala-dist.git"
+       :build `(("make -C tool-support/src/emacs" ,(concat "ELISP_COMMAND=" el-get-emacs)))
+       :load-path ("tool-support/src/emacs")
        :features scala-mode-auto)


### PR DESCRIPTION
The svn repo hasn't been updated in almost two years. The scala-dist
git repo contains the latest scala-mode.
