### PR TITLE
Recipe checker

### DIFF
--- a/el-get-recipes.el
+++ b/el-get-recipes.el
@@ -255,4 +255,61 @@ Use this to modify environment variable such as $PATH or $PYTHONPATH."
                                   :test #'string= :from-end t)
                ":")))
 
+(defun el-get-check-recipe (file-or-buffer)
+  "Check the format of the recipe.
+Please run this command before sending a pull request.
+Usage: M-x el-get-check-recipe RET
+
+You can run this function from checker script like this:
+    test/check-recipe.el PATH/TO/RECIPE.rcp
+
+When used as a lisp function, FILE-OR-BUFFER must be a buffer
+object or a file path."
+  (interactive (list (current-buffer)))
+  (if (bufferp file-or-buffer)
+      (with-current-buffer file-or-buffer
+        (el-get-check-recipe-in-current-buffer))
+    (with-temp-buffer
+      (erase-buffer)
+      (insert-file-contents file-or-buffer)
+      (el-get-check-recipe-in-current-buffer))))
+
+(defun el-get-check-recipe-in-current-buffer ()
+  (let ((recipe (save-excursion
+                  (goto-char (point-min))
+                  (read (current-buffer))))
+        (numerror 0)
+        (buffer (get-buffer-create "*el-get check recipe*")))
+    (display-buffer buffer)
+    (with-current-buffer buffer
+      (erase-buffer)
+      ;; Check if userspace property is used.
+      (loop for key in '(:before :after)
+            for alt in '(:prepare :post-init)
+            when (plist-get recipe key)
+            do (progn
+                 (insert (format
+                          "* Property %S is for user.  Use %S instead.\n"
+                          key alt))
+                 (incf numerror)))
+      (destructuring-bind (&key type url autoloads features
+                                &allow-other-keys)
+          recipe
+        ;; Is github type used?
+        (when (and (eq type 'git) (string-match "//github.com/" url))
+          (insert "* Use `:type github' for github type recipe\n")
+          (incf numerror))
+        ;; Warn when `:autoloads nil' is specified.
+        (when (and (null autoloads) (plist-member recipe :autoloads))
+          (insert "* WARNING: Are you sure you don't need autoloads?
+  This property should be used only when the library takes care of
+  the autoload.\n"))
+        ;; Warn when `:features t' is specified
+        (when features
+          (insert "* WARNING: Are you sure you need features?
+  If this library has `;;;###autoload' comment (a.k.a autoload cookie),
+  you don't need `:features'.\n")))
+      (insert (format "%s error(s) found." numerror)))
+    numerror))
+
 (provide 'el-get-recipes)

--- a/el-get.info
+++ b/el-get.info
@@ -1,4 +1,4 @@
-This is el-get.info, produced by makeinfo version 4.8 from el-get.texi.
+This is el-get.info, produced by makeinfo version 4.13 from el-get.texi.
 
 INFO-DIR-SECTION Emacs
 START-INFO-DIR-ENTRY
@@ -88,8 +88,7 @@ project, getting a commit bit and some management duties. He manages
 tests and issues on github as much as he can spares time to El-Get.
 
    Dave Abrahams contributed lots of code and efforts to make things
-right™. He's still using El-Get, but decided to retire from the
-project.
+right™. He's still using El-Get, but decided to retire from the project.
 
    Lots of people (more than we can list here) did contribute to El-Get
 either recipes, bug fixes or ideas to implement, often with code. That
@@ -677,6 +676,10 @@ Emacs Lisp code and distribution you can find out there in the wild, so
 the list of features supported is quite large. Simple cases are very
 simple, though.
 
+   If you want to submit recipes as pull request, please make sure to
+run recipe checker (*note Recipe checker::) and paste the result in the
+pull request comment.
+
 * Menu:
 
 * Recipe format::
@@ -684,6 +687,7 @@ simple, though.
 * Byte Compilation::
 * Autoloads::
 * Build::
+* Recipe checker::
 
 
 File: el-get.info,  Node: Recipe format,  Next: Dependencies,  Up: Authoring Recipes
@@ -968,7 +972,7 @@ authors whereas `:before' is meant for user customisations. See *Note
 Before and After properties::.
 
 
-File: el-get.info,  Node: Build,  Prev: Autoloads,  Up: Authoring Recipes
+File: el-get.info,  Node: Build,  Next: Recipe checker,  Prev: Autoloads,  Up: Authoring Recipes
 
 9.5 Build
 =========
@@ -994,39 +998,57 @@ build commands as Emacs Lisp list. See the magit recipe for an example:
             :build (("make" "all"))
             :build/darwin `(,(concat "make EMACS=" el-get-emacs " all")))
 
+
+File: el-get.info,  Node: Recipe checker,  Prev: Build,  Up: Authoring Recipes
+
+9.6 Recipe checker
+==================
+
+There are two ways to run recipe checker.  One is to run it as an Emacs
+command. Run `el-get-check-recipe' in the buffer opening the recipe to
+be checked.  You can also use a script to run the checker.  This is
+convenient if you want to check multiple recipes at once.
+
+     test/check-recipe.el PATH/TO/RECIPE.rcp ANOTHER/RECIPE.rcp ...
+
+   MS Windows user may need to call the script like this:
+
+     emacs -batch -Q -l test/check-recipe.el  PATH/TO/RECIPE.rcp ...
+
 
 
 Tag Table:
-Node: Top762
-Node: Introduction1227
-Node: Acknowledgments2302
-Node: Glossary3752
-Ref: Glossary - Init4848
-Ref: Glossary - Install5150
-Ref: Glossary - Recipe6237
-Ref: Glossary - Status6661
-Ref: Glossary - Update6919
-Node: Installing7157
-Node: Install the developper version8030
-Node: Skip Emacswiki recipes when installing8775
-Node: Usage9611
-Node: Setup11900
-Node: Basic Setup12296
-Node: The el-get function13535
-Node: Distributed Setup14811
-Node: Setup Customization16705
-Node: User Init17851
-Node: Before and After properties18538
-Node: Initialization files20046
-Node: Recipes20699
-Node: Organizing recipes21174
-Node: Getting more recipes22689
-Node: Overriding package files23387
-Node: Authoring Recipes23770
-Node: Recipe format24201
-Node: Dependencies33860
-Node: Byte Compilation34206
-Node: Autoloads34772
-Node: Build35898
+Node: Top763
+Node: Introduction1228
+Node: Acknowledgments2303
+Node: Glossary3753
+Ref: Glossary - Init4849
+Ref: Glossary - Install5151
+Ref: Glossary - Recipe6238
+Ref: Glossary - Status6662
+Ref: Glossary - Update6920
+Node: Installing7158
+Node: Install the developper version8031
+Node: Skip Emacswiki recipes when installing8776
+Node: Usage9612
+Node: Setup11901
+Node: Basic Setup12297
+Node: The el-get function13536
+Node: Distributed Setup14812
+Node: Setup Customization16706
+Node: User Init17852
+Node: Before and After properties18539
+Node: Initialization files20047
+Node: Recipes20700
+Node: Organizing recipes21175
+Node: Getting more recipes22690
+Node: Overriding package files23388
+Node: Authoring Recipes23771
+Node: Recipe format24386
+Node: Dependencies34045
+Node: Byte Compilation34391
+Node: Autoloads34957
+Node: Build36083
+Node: Recipe checker37055
 
 End Tag Table

--- a/el-get.texi
+++ b/el-get.texi
@@ -670,12 +670,17 @@ Emacs Lisp code and distribution you can find out there in the wild,
 so the list of features supported is quite large. Simple cases are
 very simple, though.
 
+If you want to submit recipes as pull request, please make sure to run
+recipe checker (@pxref{Recipe checker}) and paste the result in the pull
+request comment.
+
 @menu
 * Recipe format::
 * Dependencies::
 * Byte Compilation::
 * Autoloads::
 * Build::
+* Recipe checker::
 @end menu
 
 @node Recipe format
@@ -983,6 +988,24 @@ example:
        :autoloads ("50magit")
        :build (("make" "all"))
        :build/darwin `(,(concat "make EMACS=" el-get-emacs " all")))
+@end example
+
+@node Recipe checker
+@section Recipe checker
+
+There are two ways to run recipe checker.  One is to run it as an Emacs
+command. Run @command{el-get-check-recipe} in the buffer opening the
+recipe to be checked.  You can also use a script to run the checker.
+This is convenient if you want to check multiple recipes at once.
+
+@example
+test/check-recipe.el PATH/TO/RECIPE.rcp ANOTHER/RECIPE.rcp ...
+@end example
+
+MS Windows user may need to call the script like this:
+
+@example
+emacs -batch -Q -l test/check-recipe.el  PATH/TO/RECIPE.rcp ...
 @end example
 
 @bye

--- a/test/check-recipe.el
+++ b/test/check-recipe.el
@@ -1,0 +1,23 @@
+#! /bin/sh
+":"; exec ${EMACS:-emacs} -batch -Q -l "$0" "$@" # -*-emacs-lisp-*-
+
+;; Usage:
+;;     test/check-recipe.el PATH/TO/RECIPE.rcp
+
+(eval-when-compile (require 'cl))
+(add-to-list 'load-path (expand-file-name
+                         ".."
+                         (file-name-directory load-file-name)))
+(require 'el-get)
+
+(loop with sumerror = 0
+      for file in command-line-args-left
+      for numerror = (el-get-check-recipe file)
+      when (/= numerror 0)
+      do (with-current-buffer (get-buffer-create "*el-get check recipe*")
+           (princ (format "Error in %s\n" file))
+           (princ (buffer-string))
+           (princ "\n\n"))
+      sum numerror into sumerror
+      finally (when (/= sumerror 0)
+                (error "%s error(s) found in total." sumerror)))


### PR DESCRIPTION
The idea is to ask recipe author to run this checker before submitting the PR (see the info document I added).

Here is the example output (we need to fix them).

```
% test/check-recipe.el recipes/*.rcp
`flet' is an obsolete macro (as of 24.3); use either `cl-flet' or `cl-letf'.
`flet' is an obsolete macro (as of 24.3); use either `cl-flet' or `cl-letf'.
Error in recipes/ac-R.rcp
* Use `:type github' for github type recipe
1 error(s) found.

Error in recipes/cmake-mode.rcp
* Property :before is for user.  Use :prepare instead.
1 error(s) found.

Error in recipes/durendal.rcp
* Use `:type github' for github type recipe
1 error(s) found.

Error in recipes/flymake-html-validator.rcp
* Use `:type github' for github type recipe
* WARNING: Are you sure you need features?
  If this library has `;;;###autoload' comment (a.k.a autoload cookie),
  you don't need `:features'.
1 error(s) found.

Error in recipes/highlight-indentation.rcp
* Use `:type github' for github type recipe
1 error(s) found.

Error in recipes/hl-tags-mode.rcp
* Use `:type github' for github type recipe
* WARNING: Are you sure you need features?
  If this library has `;;;###autoload' comment (a.k.a autoload cookie),
  you don't need `:features'.
1 error(s) found.

Error in recipes/html5.rcp
* Use `:type github' for github type recipe
* WARNING: Are you sure you need features?
  If this library has `;;;###autoload' comment (a.k.a autoload cookie),
  you don't need `:features'.
1 error(s) found.

Error in recipes/ioccur.rcp
* Use `:type github' for github type recipe
* WARNING: Are you sure you need features?
  If this library has `;;;###autoload' comment (a.k.a autoload cookie),
  you don't need `:features'.
1 error(s) found.

Error in recipes/lua-mode.rcp
* Use `:type github' for github type recipe
1 error(s) found.

Error in recipes/markdown-mode.rcp
* Property :before is for user.  Use :prepare instead.
1 error(s) found.

Error in recipes/pony-mode.rcp
* Use `:type github' for github type recipe
1 error(s) found.

Error in recipes/shadow.rcp
* Use `:type github' for github type recipe
* WARNING: Are you sure you need features?
  If this library has `;;;###autoload' comment (a.k.a autoload cookie),
  you don't need `:features'.
1 error(s) found.

12 error(s) found in total.
```
