### PR TITLE
Use original repository for smartchr recipe

### DIFF
--- a/recipes/smartchr.rcp
+++ b/recipes/smartchr.rcp
@@ -1,4 +1,5 @@
 (:name smartchr
-       :type emacsmirror
+       :type github
+       :pkgname "imakado/emacs-smartchr"
        :features smartchr
        :description "Emacs version of smartchr.vim")


### PR DESCRIPTION
It seems this recipe uses emacsmirror from the very beginning.
We should use the original repository if it is maintained.
See: 6f8126acb3257da303debf27e978c9823234e76e

---

Does anybody know why it is using emacsmirror?  I will let this PR open for a few days and merge it if there is no objection.
