### PR TITLE
git clone should ignore el-get-git-shallow-clone when using http transport.

### DIFF
--- a/methods/el-get-git.el
+++ b/methods/el-get-git.el
@@ -51,8 +51,9 @@ found."
                                     (not submodule-prop)))
          (checkout (or (plist-get source :checkout)
 		       (plist-get source :checksum)))
-         (shallow (el-get-plist-get-with-default source :shallow
-                                                 el-get-git-shallow-clone))
+         (shallow (unless (string-prefix-p "http" url)
+                    (el-get-plist-get-with-default source :shallow
+                                                   el-get-git-shallow-clone)))
 	 (clone-args (append '("--no-pager" "clone")
                              (when shallow '("--depth" "1"))
 			     (cond

--- a/test/el-get-issue-1028.el
+++ b/test/el-get-issue-1028.el
@@ -1,0 +1,10 @@
+;; https://github.com/dimitri/el-get/issues/1028
+;;
+;; Git clone should ignore depth flag when using http protocol
+
+
+(setq debug-on-error t
+      el-get-verbose t
+      el-get-git-shallow-clone t)
+
+(el-get 'sync 'undo-tree)


### PR DESCRIPTION
I have set `el-get-git-shallow-clone` to `t` on my ~/.emacs.d/init.el file, as I dont want git clones to fetch full history, this however is causing the following error when trying to install `undo-tree` as it uses git http dumb transport.

```
"Cloning into 'undo-tree'...
fatal: dumb http transport does not support --depth
```

The following test proves the error.

``` elisp
(setq debug-on-error t
      el-get-verbose t
      el-get-git-shallow-clone t)

(el-get 'sync 'undo-tree)
```

I'm working on fixing this, expect a pull-request with test case and fix. 
