### PR TITLE
ruby-mode should use the builtin version on 24.x

### DIFF
--- a/recipes/ruby-mode.rcp
+++ b/recipes/ruby-mode.rcp
@@ -1,4 +1,5 @@
 (:name ruby-mode
+       :builtin 24
        :type http
        :description "Major mode for editing Ruby files."
        :url "http://bugs.ruby-lang.org/projects/ruby-trunk/repository/raw/misc/ruby-mode.el")


### PR DESCRIPTION
ruby-mode should use the builtin version on 24.x
