### PR TITLE
Fixed Opa-mode and added Opa-Js-mode

### DIFF
--- a/recipes/opa-js-mode.rcp
+++ b/recipes/opa-js-mode.rcp
@@ -1,0 +1,5 @@
+(:name opa-js-mode
+       :website "https://opalang.org"
+       :description "Major mode for editing Opa-Js programs"
+       :type http
+       :url "https://raw.github.com/MLstate/opalang/master/tools/editors/emacs/opa-js-mode.el")

--- a/recipes/opa-mode.rcp
+++ b/recipes/opa-mode.rcp
@@ -1,5 +1,5 @@
 (:name opa-mode
        :website "https://opalang.org"
-       :description "Major mode for editing OPA programs"
+       :description "Major mode for editing OPA-Classic programs"
        :type http
-       :url "https://raw.github.com/MLstate/opalang/master/utils/emacs/opa-mode.el")
+       :url "https://raw.github.com/MLstate/opalang/master/tools/editors/emacs/opa-mode.el")


### PR DESCRIPTION
Replaced the http address in opa-mode.el to point to the correct location, and added opa-js-mode as opa-mode is now only used for opa-classic files.
