### PR TITLE
Add a recipe for ack-menu and its dependencies

### DIFF
--- a/recipes/ack-menu.rcp
+++ b/recipes/ack-menu.rcp
@@ -1,0 +1,5 @@
+(:name ack-menu
+       :description "A menu-based front-end for ack"
+       :type github
+       :pkgname "chumpage/ack-menu"
+       :depends (mag-menu))

--- a/recipes/chumpy-windows.rcp
+++ b/recipes/chumpy-windows.rcp
@@ -1,0 +1,4 @@
+(:name chumpy-windows
+       :description "Emacs window management utilities: window-jump.el, spaces.el, splitter.el"
+       :type github
+       :pkgname "chumpage/chumpy-windows")

--- a/recipes/mag-menu.rcp
+++ b/recipes/mag-menu.rcp
@@ -1,0 +1,5 @@
+(:name mag-menu
+       :description "Intuitive keyboard-centric menu system"
+       :type github
+       :pkgname "chumpage/mag-menu"
+       :depends (splitter))

--- a/recipes/spaces.rcp
+++ b/recipes/spaces.rcp
@@ -1,0 +1,8 @@
+(:name spaces
+       :description "Create and switch between named window configurations."
+       :website "https://github.com/chumpage/chumpy-windows"
+       :type builtin
+       ;; This is a "pseudo" package.  Actual elisp file is installed
+       ;; by the package chumpy-windows.
+       ;; See ./chumpy-windows.rcp and issue #1034.
+       :depends (chumpy-windows))

--- a/recipes/splitter.rcp
+++ b/recipes/splitter.rcp
@@ -1,0 +1,8 @@
+(:name splitter
+       :description "Manage window splits"
+       :website "https://github.com/chumpage/chumpy-windows"
+       :type builtin
+       ;; This is a "pseudo" package.  Actual elisp file is installed
+       ;; by the package chumpy-windows.
+       ;; See ./chumpy-windows.rcp and issue #1034.
+       :depends (chumpy-windows))

--- a/recipes/window-jump.rcp
+++ b/recipes/window-jump.rcp
@@ -1,0 +1,8 @@
+(:name window-jump
+       :description "Move left/right/up/down through your windows."
+       :website "https://github.com/chumpage/chumpy-windows"
+       :type builtin
+       ;; This is a "pseudo" package.  Actual elisp file is installed
+       ;; by the package chumpy-windows.
+       ;; See ./chumpy-windows.rcp and issue #1034.
+       :depends (chumpy-windows))


### PR DESCRIPTION
I wrote recipes for ack-menu and I have a problem.  One of the dependency (splitter.el) is in a repository called chumpy-windows which contains three independent libraries.

In MEPLA, it is in different package.  See:
- https://github.com/milkypostman/melpa/pull/435
- http://melpa.milkbox.net/

Choices I can think of:
1. Keep it as-is.
2. Put splitter.el in a separated package.  The problem is that other files in the same repository will be in load-path.
3. Fetch splitter.el using http access.

Opinions?
