### PR TITLE
Add a recipe for the Leuven color theme

### DIFF
--- a/recipes/color-theme-leuven.rcp
+++ b/recipes/color-theme-leuven.rcp
@@ -1,0 +1,7 @@
+(:name color-theme-leuven
+       :description "An elegant theme for light backgrounds, with built-in style for many components such as Org-mode, Gnus, Dired+ and EDiff"
+       :type github
+       :pkgname "fniessen/color-theme-leuven"
+       :depends color-theme
+       :prepare (autoload 'color-theme-leuven "color-theme-leuven"
+                  "color-theme: leuven" t))


### PR DESCRIPTION
This colorscheme, mentioned in the org-mode manual and with great org support is missing from the recipes. Please add.
