### PR TITLE
revive-plus recipe: add depends

### DIFF
--- a/recipes/revive-plus.rcp
+++ b/recipes/revive-plus.rcp
@@ -1,5 +1,6 @@
 (:name revive-plus
        :website "https://github.com/martialboniou/revive-plus"
        :description "Serialize your window configurations in Emacs"
+       :depends revive
        :type github
        :pkgname "martialboniou/revive-plus")


### PR DESCRIPTION
revive-plus doesn't include revive script anymore. revive-plus.rcp depends on revive.rcp.
