### PR TITLE
Respect the customization of user-emacs-directory

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -180,7 +180,7 @@
 
 (defconst el-get-script (or load-file-name buffer-file-name))
 
-(defcustom el-get-dir "~/.emacs.d/el-get/"
+(defcustom el-get-dir (concat (file-name-as-directory user-emacs-directory) "el-get")
   "Path where to install the packages."
   :group 'el-get
   :type 'directory)


### PR DESCRIPTION
This allow developer to switch easily between multiple installations
directories, using e.g.:

emacs -q --eval '(setq user-emacs-directory "~/tmp/emacs-test-el-get")'
