### PR TITLE
methods/el-get-github: change the default url type to https

### DIFF
--- a/methods/el-get-github.el
+++ b/methods/el-get-github.el
@@ -22,7 +22,7 @@
         'ssh "git@github.com:%USER%/%REPO%.git")
   "Plist mapping Github types to their URL format strings.")
 
-(defcustom el-get-github-default-url-type 'http
+(defcustom el-get-github-default-url-type 'https
   "The kind of URL to use for Github repositories.
 
 Choices are `http', `https', `git'. This is effectively the


### PR DESCRIPTION
All git repositories should be fetched over HTTPS by default, to allow
authenticated pushes to the user's own repositories.

Signed-off-by: Ramkumar Ramachandra artagnon@gmail.com
