### PR TITLE
el-get: flet is deprecated; use cl-flet instead

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -829,7 +829,7 @@ itself.")
     (let ((refreshed nil)
           (orig-package-refresh-contents
            (ignore-errors (symbol-function 'package-refresh-contents))))
-      (flet ((package-refresh-contents
+      (cl-flet ((package-refresh-contents
               ;; This is the only way to get sane auto-indentation
               (cdr (lambda (&rest args)
                      (unless refreshed


### PR DESCRIPTION
flet is deprecated in Emacs 24.3.  Use cl-flet instead, for a Common
Lisp style flet.

Signed-off-by: Ramkumar Ramachandra artagnon@gmail.com
