### PR TITLE
add recipe for rbenv.el

### DIFF
--- a/recipes/rbenv.rcp
+++ b/recipes/rbenv.rcp
@@ -1,0 +1,7 @@
+(:name rbenv
+       :description "Emacs integration for rbenv"
+       :type github
+       :features rbenv
+       :pkgname "senny/rbenv.el"
+       :compile "rbenv.el"
+       :post-init (rbenv-use-global))


### PR DESCRIPTION
I created rbenv.el a small package to manage to configure Emacs to use your rbenv ruby versions. This PR adds a simple recipe to install the package.

https://github.com/senny/rbenv.el
