### PR TITLE
listparse recipe was incorrectly referencing xml-rpc-el recipe

### DIFF
--- a/recipes/lisppaste.rcp
+++ b/recipes/lisppaste.rcp
@@ -3,4 +3,4 @@
        :type http
        :url "http://www2.epcc.ed.ac.uk/~lmitche4/lisppaste.el"
        :features lisppaste
-       :depends (xml-rpc))
+       :depends xml-rpc-el)


### PR DESCRIPTION
listparse recipe was incorrectly referencing xml-rpc-el recipe.  
