### PR TITLE
bookmark+ should use  :type github instead of emacsmirror

### DIFF
--- a/recipes/bookmark+.rcp
+++ b/recipes/bookmark+.rcp
@@ -1,6 +1,6 @@
 (:name bookmark+
-       :pkgname "bookmark-plus"
+       :pkgname "emacsmirror/bookmark-plus"
        :website "http://www.emacswiki.org/emacs/BookmarkPlus"
-       :type emacsmirror
+       :type github
        :description "Extensions to standard library `bookmark.el'"
        :features bookmark+)


### PR DESCRIPTION
bookmark+ should use  :type github instead of emacsmirror
