### PR TITLE
Add a new recipe for nrepl-ritz.el.

### DIFF
--- a/recipes/nrepl-ritz.rcp
+++ b/recipes/nrepl-ritz.rcp
@@ -1,0 +1,6 @@
+(:name nrepl-ritz
+       :description "A nREPL extension for Ritz."
+       :type http
+       :url "https://raw.github.com/pallet/ritz/develop/nrepl/elisp/nrepl-ritz.el"
+       :depends (nrepl fringe-helper)
+       :website "https://github.com/pallet/ritz/tree/develop/nrepl")


### PR DESCRIPTION
nrepl-ritz.el is a Clojure debugger frontend that extends and cooperates with nrepl.el.

Its recipe depends on the following recipes:
- nrepl
- fringe-helper
