### PR TITLE
Add less-css-mode recipe from ELPA

### DIFF
--- a/recipes/less-css-mode.rcp
+++ b/recipes/less-css-mode.rcp
@@ -1,0 +1,4 @@
+(:name less-css-mode
+       :description "Major mode for editing LESS CSS files (lesscss.org)"
+       :features less-css-mode
+       :type elpa)


### PR DESCRIPTION
Add recipe for less-css-mode, a major mode for editing LESS CSS files (lesscss.org).
