### PR TITLE
Emacs dirtree recipe

### DIFF
--- a/recipes/emacs-dirtree.rcp
+++ b/recipes/emacs-dirtree.rcp
@@ -1,4 +1,4 @@
-(:name edirtree
+(:name emacs-dirtree
        :type github
        :description "Directory Tree Views in Emacs"
        :pkgname "zkim/emacs-dirtree"


### PR DESCRIPTION
The dirtree currently in el-get does not give you a tree view of directories.  This does, and in the documentation about it they are all referred to as dirtree which is confusing.  I hope the description will make it clear what this one is for.

Thanks, and I hope this helps others who have been searching for a directory tree in emacs.

And thanks to Ye Wenbin for creating it and zkim on github for having an accessible repo.

Just found the in the info file bit in the recipe pull requests about running recipe test.  Here is the output:
- WARNING: Are you sure you need features?
  If this library has `;;;###autoload' comment (a.k.a autoload cookie),
  you don't need`:features'.
  0 error(s) found.

The library itself does not have ###autoload in the file.
