### PR TITLE
new version of inf-ruby, compatible with enh-ruby-mode

### DIFF
--- a/recipes/inf-ruby.rcp
+++ b/recipes/inf-ruby.rcp
@@ -1,4 +1,4 @@
 (:name inf-ruby
-       :type http
        :description "Inferior Ruby Mode - ruby process in a buffer."
-       :url "http://bugs.ruby-lang.org/projects/ruby-trunk/repository/raw/misc/inf-ruby.el")
+       :type github
+       :pkgname "danielsz/inf-ruby")


### PR DESCRIPTION
This bring the inf-ruby in line with nonsequitur's newer (much newer than the one previously defined in this recipe), and my version has been patched for compatibility with enh-ruby-mode recipe. Nonsequitur's version works only with ruby-mode, mine works with both. I issued a pull request on Nonsequitur's version for my patch. If accepted, I will update this recipe to point to his repo.
