### PR TITLE
Change to antifuchs slime mirror

### DIFF
--- a/recipes/slime.rcp
+++ b/recipes/slime.rcp
@@ -3,7 +3,7 @@
        :type github
        :autoloads "slime-autoloads"
        :info "doc"
-       :pkgname "nablaone/slime"
+       :pkgname "antifuchs/slime"
        :load-path ("." "contrib")
        :compile (".")
        :build '(("make" "-C" "doc" "slime.info"))


### PR DESCRIPTION
The previous slime github mirror hasn't updated since 12/2012. antifuchs/slime is current and is the repo being used by the melpa package.
