### PR TITLE
Replace deprecated flet with cl-flet

### DIFF
--- a/el-get-dependencies.el
+++ b/el-get-dependencies.el
@@ -54,7 +54,7 @@ list of objects sorted toplogically.  The second is a boolean
 indicating whether all of the objects in the input graph are present
 in the topological ordering (i.e., the first value)."
   (let ((entries (make-hash-table :test test)))
-    (flet ((entry (v)
+    (cl-flet ((entry (v)
              "Return the entry for vertex.  Each entry is a cons whose
               car is the number of outstanding dependencies of vertex
               and whose cdr is a list of dependants of vertex."

--- a/el-get.el
+++ b/el-get.el
@@ -829,7 +829,7 @@ itself.")
     (let ((refreshed nil)
           (orig-package-refresh-contents
            (ignore-errors (symbol-function 'package-refresh-contents))))
-      (flet ((package-refresh-contents
+      (cl-flet ((package-refresh-contents
               ;; This is the only way to get sane auto-indentation
               (cdr (lambda (&rest args)
                      (unless refreshed


### PR DESCRIPTION
Gets rid of some warnings in emacs 24.3.
