### PR TITLE
emacs-jabber.rcp: avoid shell-interpolation in :build commands

### DIFF
--- a/recipes/emacs-jabber.rcp
+++ b/recipes/emacs-jabber.rcp
@@ -5,4 +5,4 @@
        :info "."
        :load-path (".")
        :features jabber-autoloads
-       :build ("autoreconf -i" "./configure" "make" "mv jabber.info emacs-jabber.info" ))
+       :build (("autoreconf" "-i") "./configure" "make" ("mv" "jabber.info" "emacs-jabber.info")))


### PR DESCRIPTION
Fixes these warnings during emacs-jabber installation:

```
Warning (emacs): Build command "autoreconf -i" in package "emacs-jabber" will be shell-interpolated. To bypass shell interpolation, the recipe for "emacs-jabber" should specify build commands as lists of strings instead.
Warning (emacs): Build command "mv jabber.info emacs-jabber.info" in package "emacs-jabber" will be shell-interpolated. To bypass shell interpolation, the recipe for "emacs-jabber" should specify build commands as lists of strings instead.

```
