### PR TITLE
Update graphviz-dot-mode recipe

### DIFF
--- a/recipes/graphviz-dot-mode.rcp
+++ b/recipes/graphviz-dot-mode.rcp
@@ -1,5 +1,4 @@
 (:name graphviz-dot-mode
-       :type http
-       :website "http://www.graphviz.org/"
        :description "graphviz dot language mode"
-       :url "http://www.graphviz.org/Misc/graphviz-dot-mode.el")
+       :type github
+       :pkgname "ppareit/graphviz-dot-mode")


### PR DESCRIPTION
[The official source](http://www.graphviz.org/Misc/graphviz-dot-mode.el) is seven years old. [The other one I've found](https://github.com/ppareit/graphviz-dot-mode) was updated in Aug 2012 and provides better editing experience (at least, for me). 
