### PR TITLE
eclim: don't use removed 'vendor' directory

### DIFF
--- a/recipes/eclim.rcp
+++ b/recipes/eclim.rcp
@@ -3,7 +3,6 @@
        :description "This project brings some of the great eclipse features to emacs developers."
        :type github
        :pkgname "senny/emacs-eclim"
-       :load-path ("." "vendor")
        :features eclim
        :post-init (progn
                     (setq eclim-auto-save t)


### PR DESCRIPTION
There is no 'vendor' directory since senny/emacs-eclim@07b464774c746bd69.
