### PR TITLE
Use static http url for markdown-mode since git://jblevins.org is currently down

### DIFF
--- a/recipes/markdown-mode.rcp
+++ b/recipes/markdown-mode.rcp
@@ -1,6 +1,6 @@
 (:name markdown-mode
        :description "Major mode to edit Markdown files in Emacs"
-       :type git
-       :url "git://jblevins.org/git/markdown-mode.git"
+       :type http
+       :url "http://jblevins.org/git/markdown-mode.git/plain/markdown-mode.el"
        :before (add-to-list 'auto-mode-alist
                             '("\\.\\(md\\|mdown\\|markdown\\)\\'" . markdown-mode)))


### PR DESCRIPTION
Could just be a temporary glitch, but just in case it doesn't come back up, this patch uses the static url from http://jblevins.org/projects/markdown-mode/.
