### PR TITLE
Removed quotes in DEPEND of elpy.rcp 

### DIFF
--- a/recipes/elpy.rcp
+++ b/recipes/elpy.rcp
@@ -3,8 +3,8 @@
        :description "Emacs Python Development Environment"
        :type github
        :pkgname "jorgenschaefer/elpy"
-       :depends ("auto-complete" "yasnippet" "virtualenv"
-                 "highlight-indentation" "find-file-in-project"
-                 "idomenu" "iedit"
-                 ;; "nose" - not on el-get
+       :depends (auto-complete yasnippet virtualenv
+                 highlight-indentation find-file-in-project
+                 idomenu iedit
+                 ;; nose - not on el-get
                  ))


### PR DESCRIPTION
I am very new to el-get and even emacs lisp in general.
However, removing the quotes in depend lets el-get download elpy (instead of halting on a syntax error message)
