### PR TITLE
fix install error when no "\r?\n\r?\n" pattern found in http downloaded ...

### DIFF
--- a/methods/el-get-http.el
+++ b/methods/el-get-http.el
@@ -39,6 +39,7 @@ Test url: http://repo.or.cz/w/ShellArchive.git?a=blob_plain;hb=HEAD;f=ack.el"
 	 (buffer-file-coding-system 'no-conversion)
 	 (require-final-newline nil))
     ;; prune HTTP headers before save
+    (goto-char 0)
     (re-search-forward "\r?\n\r?\n")
     (write-region (point) (point-max) part)
     (puthash package (sha1 (current-buffer)) el-get-http-checksums)


### PR DESCRIPTION
Hi,

add two args to re-search-forward to prevent 'search fail' when no pattern was found. (not so familiar with elisp, hope that's a right fix :P)

thanks 
