### PR TITLE
Bootstrap fails because of spaces in exe path, fixed with :shell nil

### DIFF
--- a/el-get-build.el
+++ b/el-get-build.el
@@ -115,7 +115,7 @@ recursion.
 		      `(:command-name ,name
 				      :buffer-name ,buf
 				      :default-directory ,wdir
-				      :shell nil
+				      :shell t
 				      :sync ,sync
 				      :program ,program
 				      :args (,@args)

--- a/el-get-core.el
+++ b/el-get-core.el
@@ -356,8 +356,10 @@ makes it easier to conditionally splice a command into the list.
                (cbuf    (plist-get c :buffer-name))
                (killed  (when (get-buffer cbuf) (kill-buffer cbuf)))
                (filter  (plist-get c :process-filter))
-               (program (plist-get c :program))
                (shell   (plist-get c :shell))
+               (program (if shell
+                            (shell-quote-argument (plist-get c :program))
+                          (plist-get c :program)))
                (args    (if shell
 			    (mapcar #'shell-quote-argument (plist-get c :args))
 			  (plist-get c :args)))


### PR DESCRIPTION
The bootstrap install fails on Windows when `install-info` is under `C:\Program File\GnuWin32\bin` (the default) because of the space in the path. The problem appears to be that `el-get-build` always passes `:shell t` to `el-get-start-process` which I think is unneeded since all it does it tell `el-get-start-process` to use `start-process-shell-command` which simply prepends `shell-file-name` and `shell-command-switch` to the arg list but this is already done by `el-get-build` in the `stringp` case.

Message in `*el-get-build: el-get*`:

```
'c:/Program' is not recognized as an internal or external command,
operable program or batch file.
```

Excerpt from `*Backtrace*`:

```
el-get-start-process-list("el-get" ((:command-name "c:/Program Files/GnuWin32/bin/install-info.exe" :buffer-name "*el-get-build: el-get*" :default-directory "c:/Users/npostavs/.emacs.d/el-get/el-get/." :shell t :sync t :program "c:/Program Files/GnuWin32/bin/install-info.exe" :args ("c:/Users/npostavs/.emacs.d/el-get/el-get/./el-get.info" "dir") ...)))
...
el-get-build("el-get" (("c:/Program Files/GnuWin32/bin/install-info.exe" "c:/Users/npostavs/.emacs.d/el-get/el-get/./el-get.info" "dir")) "." t nil t)
```
