### PR TITLE
Recipe for cljsbuild-mode

### DIFF
--- a/recipes/cljsbuild-mode.rcp
+++ b/recipes/cljsbuild-mode.rcp
@@ -1,0 +1,4 @@
+(:name cljsbuild-mode 
+       :description "Minor mode for the ClojureScript 'lein cljsbuild' command"
+       :type github
+       :pkgname "kototama/cljsbuild-mode")


### PR DESCRIPTION
This is a recipe for the cljsbuild minor mode. It is a minor mode for the ClojureScript 'lein cljsbuild' command.
