### PR TITLE
el-get-source-name should handle nil correctly

### DIFF
--- a/el-get-core.el
+++ b/el-get-core.el
@@ -133,7 +133,7 @@ returning a list that contains it (and only it)."
 (defun el-get-source-name (source)
   "Return the package name (stringp) given an `el-get-sources'
 entry."
-  (if (listp source)
+  (if (and source (listp source))
       (format "%s" (or (plist-get source :name)
                        (error "Source does not have a :name property: %S" source)))
     (symbol-name source)))


### PR DESCRIPTION
When passed in nil el-get-source-name fails as (listp nil) is true.
