### PR TITLE
Recipe: Fixed eshell-manual repo.

### DIFF
--- a/recipes/eshell-manual.rcp
+++ b/recipes/eshell-manual.rcp
@@ -1,7 +1,7 @@
 (:name eshell-manual
        :description "eshell is great but lacks a good manual, someone wrote one."
        :type github
-       :pkgname "aidalgol/eshell-manual"
+       :pkgname "nicferrier/eshell-manual"
        :build (("make" "eshell.info"))
        :compile nil
        :info "eshell.info")


### PR DESCRIPTION
https://github.com/nicferrier/eshell-manual seems to be the official
repo now.

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
