### PR TITLE
Colorize output of run-*test.sh.

### DIFF
--- a/test/run-all-tests.sh
+++ b/test/run-all-tests.sh
@@ -2,4 +2,4 @@
 
 cd "$(dirname "$0")"
 
-exec ./run-test.sh el-get-*.el 2>/dev/null | { ack --passthru FAILED 2>/dev/null || cat; }
+exec ./run-test.sh el-get-*.el 2>/dev/null

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -38,9 +38,9 @@ run_test () {
       -l "$testfile"
     result="$?"
     if [ "$result" = 0 ]; then
-      echo "*** SUCCESS $testfile ***"
+      echo "*** ${EL_GET_SUCCESS_COLOR}SUCCESS${EL_GET_END} $testfile ***"
     else
-      echo "*** FAILED $testfile ***"
+      echo "*** ${EL_GET_FAILURE_COLOR}FAILED${EL_GET_END} $testfile ***"
       FAILED_TESTS="$(expr $FAILED_TESTS + 1)"
     fi
     ALL_TESTS="$(expr $ALL_TESTS + 1)"

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -29,3 +29,9 @@ set_default TMPDIR "$(dirname "$(mktemp --dry-run)")"
 set_default TEST_HOME "$TMPDIR/el-get-test-home"
 set_default EMACS "$(which emacs)"
 set_default TEST_DIR "$(dirname $0)"
+
+if [[ -t 1 ]]; then
+    EL_GET_END="$(tput sgr0)"
+    set_default EL_GET_FAILURE_COLOR "$(tput setaf 1)" # red
+    set_default EL_GET_SUCCESS_COLOR "$(tput setaf 2)" # green
+fi


### PR DESCRIPTION
Remove the use of ack in run-all-tests.sh.

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
