### PR TITLE
update for circe.rcp

### DIFF
--- a/recipes/circe.rcp
+++ b/recipes/circe.rcp
@@ -3,4 +3,7 @@
        :description "Circe is a Client for IRC in Emacs with sane defaults"
        :type github
        :pkgname "jorgenschaefer/circe"
+       :depends cl-lib
+       :build ("./build.sh")
+       :load-path "build"
        :load-path ("lisp"))


### PR DESCRIPTION
- byte compile
- add compiled lisp to load path
- depend on cl-lib because circe-fix-minibuffer.el requires it.
