### PR TITLE
update for circe.rcp (new, improved, shorter!)

### DIFF
--- a/recipes/circe.rcp
+++ b/recipes/circe.rcp
@@ -3,4 +3,5 @@
        :description "Circe is a Client for IRC in Emacs with sane defaults"
        :type github
        :pkgname "jorgenschaefer/circe"
+       :depends cl-lib
        :load-path ("lisp"))


### PR DESCRIPTION
OK, one way that seems to work is go back to relying on el-get to byte-compile, and
to only add the depends on cl-lib
