### PR TITLE
Recipe points back to official, upstream package

### DIFF
--- a/recipes/inf-ruby.rcp
+++ b/recipes/inf-ruby.rcp
@@ -1,4 +1,4 @@
 (:name inf-ruby
        :description "Inferior Ruby Mode - ruby process in a buffer."
        :type github
-       :pkgname "danielsz/inf-ruby")
+       :pkgname "nonsequitur/inf-ruby")


### PR DESCRIPTION
This pull request restores the package inf-ruby to point back to its official, maintained upstream address.

It pointed to a temporary fork that addressed issues not relevant anymore.

Thanks.
