### PR TITLE
Update haskell-mode recipe to build autoloads file

### DIFF
--- a/recipes/haskell-mode.rcp
+++ b/recipes/haskell-mode.rcp
@@ -2,8 +2,7 @@
        :description "A Haskell editing mode"
        :type github
        :pkgname "haskell/haskell-mode"
-       :build ("make all")
-       :load "haskell-site-file.el"
+       :load "haskell-mode-autoloads.el"
        :build (("make" "all"))
        :post-init (progn
                     (add-hook 'haskell-mode-hook 'turn-on-haskell-doc-mode)


### PR DESCRIPTION
"haskell-site-file.el" was recently [removed](https://github.com/haskell/haskell-mode/commit/ae7cee055775c37fc24ed90088aca4445df042b0) from  [haskell-mode repository](https://github.com/haskell/haskell-mode), explicit :build step is now needed for recipe to work
