### PR TITLE
fix git remote URLs for auto-complete recipes

### DIFF
--- a/recipes/auto-complete.rcp
+++ b/recipes/auto-complete.rcp
@@ -1,6 +1,6 @@
 (:name auto-complete
-       :website "http://cx4a.org/software/auto-complete/"
+       :website "http://auto-complete.org/"
        :description "The most intelligent auto-completion extension."
        :type github
-       :pkgname "m2ym/auto-complete"
+       :pkgname "auto-complete/auto-complete"
        :depends (popup fuzzy))

--- a/recipes/fuzzy.rcp
+++ b/recipes/fuzzy.rcp
@@ -1,5 +1,5 @@
 (:name fuzzy
-       :website "https://github.com/m2ym/fuzzy-el"
+       :website "https://github.com/auto-complete/fuzzy-el"
        :description "Fuzzy matching utilities for GNU Emacs"
        :type github
-       :pkgname "m2ym/fuzzy-el")
+       :pkgname "auto-complete/fuzzy-el")

--- a/recipes/popup.rcp
+++ b/recipes/popup.rcp
@@ -1,5 +1,5 @@
 (:name popup
-       :website "https://github.com/m2ym/popup-el"
+       :website "https://github.com/auto-complete/popup-el"
        :description "Visual Popup Interface Library for Emacs"
        :type github
-       :pkgname "m2ym/popup-el")
+       :pkgname "auto-complete/popup-el")


### PR DESCRIPTION
The auto-complete, popup-el and fuzzy-el github repositories have
been relocated from /m2my to /auto-complete.

Additionally, the project page of auto-complete now is:

http://auto-complete.org/
