### PR TITLE
use GNU Make on BSD-derivatives instead of BSD Make

### DIFF
--- a/recipes/edict.rcp
+++ b/recipes/edict.rcp
@@ -3,5 +3,6 @@
        :description "emacs interface for edict"
        :type hg
        :build '(("make" "-f" "Makefile.GNU"))
+       :build/berkeley-unix '(("gmake" "-f" "Makefile.GNU"))
        :url "https://bitbucket.org/xemacs/edict"
        :features edict)

--- a/recipes/elim.rcp
+++ b/recipes/elim.rcp
@@ -4,6 +4,7 @@
        :type git
        :url "git://git.sv.gnu.org/elim.git"
        :build ("make")
+       :build/berkeley-unix ("gmake")
        :load-path ("./elisp")
        :prepare (setq elim-executable
                       (expand-file-name

--- a/recipes/emms.rcp
+++ b/recipes/emms.rcp
@@ -10,4 +10,9 @@
                  ,(format "SITEFLAG=\\\"--no-site-file -L %s/emacs-w3m/ \\\""
                           el-get-dir)
                  "autoloads" "lisp" "docs"))
+       :build/berkeley-unix `(("mkdir" "-p" ,(expand-file-name (format "%s/emms" user-emacs-directory)))
+                ("gmake" ,(format "EMACS=%s" el-get-emacs)
+                 ,(format "SITEFLAG=\\\"--no-site-file -L %s/emacs-w3m/ \\\""
+                          el-get-dir)
+                 "autoloads" "lisp" "docs"))
        :depends emacs-w3m)

--- a/recipes/evil.rcp
+++ b/recipes/evil.rcp
@@ -8,4 +8,5 @@
        :features evil
        :depends undo-tree
        :build (("make" "all" "info"))
+       :build/berkeley-unix (("gmake" "all" "info"))
        :info "doc")

--- a/recipes/jedi.rcp
+++ b/recipes/jedi.rcp
@@ -3,5 +3,6 @@
        :type github
        :pkgname "tkf/emacs-jedi"
        :build (("make" "requirements"))
+       :build/berkeley-unix (("gmake" "requirements"))
        :submodule nil
        :depends (epc auto-complete))

--- a/recipes/nterm.rcp
+++ b/recipes/nterm.rcp
@@ -3,4 +3,5 @@
        :type github
        :pkgname "cbbrowne/nterm"
        :info "."
-       :build ("make"))
+       :build ("make")
+       :build/berkeley-unix ("gmake"))

--- a/recipes/planner.rcp
+++ b/recipes/planner.rcp
@@ -4,5 +4,6 @@
        :url "http://repo.or.cz/r/planner-el.git"
        :shallow nil
        :build ("make")
+       :build/berkeley-unix ("gmake")
        :features planner-autoloads
        )

--- a/recipes/remember.rcp
+++ b/recipes/remember.rcp
@@ -4,5 +4,6 @@
        :url "http://repo.or.cz/r/remember-el.git"
        :shallow nil
        :build ("make")
+       :build/berkeley-unix ("gmake")
        :features remember-autoloads
        )

--- a/recipes/slime.rcp
+++ b/recipes/slime.rcp
@@ -7,4 +7,5 @@
        :load-path ("." "contrib")
        :compile (".")
        :build '(("make" "-C" "doc" "slime.info"))
+       :build/berkeley-unix '(("gmake" "-C" "doc" "slime.info"))
        :post-init (slime-setup))


### PR DESCRIPTION
Some recipes don't work on BSD derivatives, because these have GNU extended Makefile.
To deal with these, use `gmake` on `berkeley-unix` instead of `make`.
