### PR TITLE
fix a error in haskell-mode recipe

### DIFF
--- a/recipes/haskell-mode.rcp
+++ b/recipes/haskell-mode.rcp
@@ -2,6 +2,7 @@
        :description "A Haskell editing mode"
        :type github
        :pkgname "haskell/haskell-mode"
+       :build ("make all")
        :load "haskell-site-file.el"
        :post-init (progn
                     (add-hook 'haskell-mode-hook 'turn-on-haskell-doc-mode)


### PR DESCRIPTION
haskell-site-file.el is generated by 'make all', without which,
haskell-mode can not work well.
