### PR TITLE
mode-compile.el: Change fetch url to github mirror

### DIFF
--- a/recipes/mode-compile.rcp
+++ b/recipes/mode-compile.rcp
@@ -1,5 +1,5 @@
 (:name mode-compile
        :description "Smart command for compiling files according to major-mode."
        :type http
-       :url "http://perso.tls.cena.fr/boubaker/distrib/mode-compile.el"
+       :url "https://raw.github.com/emacsmirror/mode-compile/master/mode-compile.el"
        :load-path ("."))


### PR DESCRIPTION
mode-compile.el is hosted perso.tls.cena.fr but this host is down now,
use github mirror is better for installing stability.
