### PR TITLE
Updated pkgbuild-mode.rcp

### DIFF
--- a/recipes/pkgbuild-mode.rcp
+++ b/recipes/pkgbuild-mode.rcp
@@ -1,6 +1,6 @@
 (:name pkgbuild-mode
        :description "Major mode for editing PKGBUILD files"
        :type github
-       :pkgname "cdkamat/pkgbuild-mode"
+       :pkgname "juergenhoetzel/pkgbuild-mode"
        :features pkgbuild-mode
        :post-init (add-to-list 'auto-mode-alist '("PKGBUILD$" . pkgbuild-mode)))


### PR DESCRIPTION
cdkamat/pkgbuild-mode is no longer maintained. Replaced it with
original repository
