### PR TITLE
Updated github repo for ido-vertical-mode

### DIFF
--- a/recipes/ido-vertical-mode.rcp
+++ b/recipes/ido-vertical-mode.rcp
@@ -1,5 +1,5 @@
 (:name ido-vertical-mode
        :type github
-       :pkgname "sdegutis/ido-vertical-mode.el"
+       :pkgname "rson/ido-vertical-mode.el"
        :description "makes ido-mode display vertically"
        :features ido-vertical-mode)


### PR DESCRIPTION
The current ido-vertical-mode recipe is no longer valid, the github account it refers no longer exists. 
This commit updates the recipe with new location on github.
