### PR TITLE
Fix haskell-mode recipe

### DIFF
--- a/recipes/haskell-mode.rcp
+++ b/recipes/haskell-mode.rcp
@@ -2,7 +2,8 @@
        :description "A Haskell editing mode"
        :type github
        :pkgname "haskell/haskell-mode"
-       :load "haskell-site-file.el"
+       :build ("make")
+       :load "haskell-mode-autoloads.el"
        :post-init (progn
                     (add-hook 'haskell-mode-hook 'turn-on-haskell-doc-mode)
                     (add-hook 'haskell-mode-hook 'turn-on-haskell-indentation)))


### PR DESCRIPTION
In 13.7, 'haskell-site-file.el' is renamed to 'haskell-mode-autoloads.el',
which needs to be built before loading.

Signed-off-by: Mike McClurg mike.mcclurg@gmail.com
