### PR TITLE
fix ido-vertical-mode owner name

### DIFF
--- a/recipes/ido-vertical-mode.rcp
+++ b/recipes/ido-vertical-mode.rcp
@@ -1,5 +1,5 @@
 (:name ido-vertical-mode
        :type github
-       :pkgname "sdegutis/ido-vertical-mode.el"
+       :pkgname "rson/ido-vertical-mode.el"
        :description "makes ido-mode display vertically"
        :features ido-vertical-mode)


### PR DESCRIPTION
It's seems like the user `sdegutis' is vanish or rename to rson, there's no any`sdegutis' on GitHub has the ido-vertical-mode.el repo, but rson has. 

Note: In melpa, this recipes's owner is rson, not sdegutis
