### PR TITLE
Make ProofGeneral.rcp work with Emacs >= 24.2.

### DIFF
--- a/recipes/ProofGeneral.rcp
+++ b/recipes/ProofGeneral.rcp
@@ -4,7 +4,7 @@
        :type http-tar
        :options ("xzf")
        :url "http://proofgeneral.inf.ed.ac.uk/releases/ProofGeneral-4.2.tgz"
-       :build ("cd ProofGeneral && make clean" "cd ProofGeneral && make compile")
+       :build ("cd ProofGeneral && make clean" "cd ProofGeneral && sed -i 's/setq byte-compile-error-on-warn t//' Makefile && make compile")
        :build/darwin `("cd ProofGeneral && make clean" ,(concat "cd ProofGeneral && make compile EMACS=" el-get-emacs))
        :load  ("ProofGeneral/generic/proof-site.el")
        :info "./ProofGeneral/doc/")


### PR DESCRIPTION
See http://proofgeneral.inf.ed.ac.uk/trac/ticket/458 .
