### PR TITLE
Fix a auctex recipe build bug.

### DIFF
--- a/recipes/auctex.rcp
+++ b/recipes/auctex.rcp
@@ -7,7 +7,6 @@
        :build `(("./autogen.sh")
                 ("./configure"
                  "--without-texmf-dir"
-                 "--with-lispdir=`pwd`"
                  ,(concat "--with-emacs=" el-get-emacs))
                 "make")
        :load-path ("." "preview")


### PR DESCRIPTION
The original auctex recipe build steps will result in a boot error, which tells
that "tex-site.el not found".
