### PR TITLE
Get rid of version numbers in the filename.

### DIFF
--- a/recipes/undo-tree.rcp
+++ b/recipes/undo-tree.rcp
@@ -2,4 +2,5 @@
        :description "Treat undo history as a tree"
        :type http
        :website "http://www.dr-qubit.org/emacs.php"
-       :url "http://www.dr-qubit.org/undo-tree/undo-tree-0.6.3.el")
+       :url "http://www.dr-qubit.org/undo-tree/undo-tree-0.6.3.el"
+       :localname "undo-tree.el")


### PR DESCRIPTION
Remove version numbers in the filename of the downloaded elisp, i.e. download the remote "undo-tree-0.6.3.el" as a local "undo-tree.el".
