### PR TITLE
Fix el-get-elpa-package-directory returning a non-existing directory.

### DIFF
--- a/methods/el-get-elpa.el
+++ b/methods/el-get-elpa.el
@@ -45,10 +45,11 @@ PACKAGE isn't currently installed by ELPA."
                       (expand-file-name
                        (file-name-as-directory package-user-dir))))))))
 
-	 (realname (try-completion pname l)))
+	 (realnames (all-completions pname l)))
 
-    (if realname (concat (file-name-as-directory package-user-dir) realname)
-      realname)))
+    (when realnames
+      (concat (file-name-as-directory package-user-dir) (car realnames)))))
+
 
 (defun el-get-elpa-package-repo (package)
   "Get the ELPA repository cons cell for PACKAGE.


### PR DESCRIPTION
el-get-elpa-package-directory will not always return a real directory,
since two directories might have the same prefix (for example, erc
installs as `erc-5.3` but has a package name of `erc`. So
`try-completion` will return `erc-` if you have something
like `erc-image` installed.)

`all-completions` will return a list of actual directories which
satisfy the completion, and the `car` of this list will be the package
we want. `when realnames` will return `nil` when there are no possible
completions.
