### PR TITLE
Add recipe for magit-filenotify.

### DIFF
--- a/recipes/magit-filenotify.rcp
+++ b/recipes/magit-filenotify.rcp
@@ -1,0 +1,6 @@
+(:name magit-filenotify
+       :description "Refresh status buffer when git tree changes.  Warning: Requires an unreleased
+test version of Emacs with file-notify support!"
+;       :minimum-emacs-version "24.4" TODO when Emacs 24.4 is released.
+       :type github
+       :pkgname "magit/magit-filenotify")


### PR DESCRIPTION
This requires Emacs 24.4, which is not yet released.  Therefore I
omitted the `:minimum-emacs-version' property for now but it should be
activated when Emacs 24.4 is released.

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
