### PR TITLE
Canonicalize the info path file name for Windows.

### DIFF
--- a/el-get-build.el
+++ b/el-get-build.el
@@ -201,9 +201,10 @@ recursion.
 	     (el-get-build
 	      package
               (list (list el-get-install-info
-                          (if (string= (substring infofile -5) ".info")
-			      infofile
-			    (concat infofile ".info"))
+                          (convert-standard-filename
+                           (if (string= (substring infofile -5) ".info")
+                               infofile
+                             (concat infofile ".info")))
                           "dir"))
               infodir-rel t nil t)))
 	  (t


### PR DESCRIPTION
The msys install-info incorrectly parsed the path to info file.  The problem occured because each path was a mix of forward slashes and colons, e.g. `C:/Users/joe` instead of back slashes and colons, like `C:\Users\joe`.  Msys install info would cut off the `c:` and subsequently fail to find the info file.  An example backtrace from my system is below.  

The fix is to canonicalize the paths by using the elisp function [`convert-standard-filename` ](http://www.gnu.org/software/emacs/manual/html_node/elisp/Standard-File-Names.html) which does exactly that.

```
install-info: No such file or directory for /Users/joe/.emacs.d/el-get/el-get/./el-get.info
Running commands synchronously: ((:command-name "c:/msysgit/bin/install-info.exe" :buffer-name "*el-get-build: el-get*" :default-directory "c:/Users/joe/.emacs.d/el-get/el-get/." :shell t :sync t :program "c:/msysgit/bin/install-info.exe" :args ("c:/Users/joe/.emacs.d/el-get/el-get/./el-get.info" "dir") :message "el-get-build el-get: c:/msysgit/bin/install-info.exe c:/Users/joe/.emacs.d/el-get/el-get/./el-get.info dir ok." :error "el-get could not build el-get [c:/msysgit/bin/install-info.exe c:/Users/joe/.emacs.d/el-get/el-get/./el-get.info dir]"))
el-get is waiting for "c:/msysgit/bin/install-info.exe" to complete
"install-info: No such file or directory for /Users/joe/.emacs.d/el-get/el-get/./el-get.info
"
el-get failed to initialize package el-get
el-get failed to install: (error el-get: c:/msysgit/bin/install-info.exe el-get could not build el-get [c:/msysgit/bin/install-info.exe c:/Users/joe/.emacs.d/el-get/el-get/./el-get.info dir])
el-get failed to initialize package el-get
el-get failed to install: (error el-get: c:/msysgit/bin/install-info.exe el-get could not build el-get [c:/msysgit/bin/install-info.exe c:/Users/joe/.emacs.d/el-get/el-get/./el-get.info dir])
el-get-installation-failed: el-get: c:/msysgit/bin/install-info.exe el-get could not build el-get [c:/msysgit/bin/install-info.exe c:/Users/joe/.emacs.d/el-get/el-get/./el-get.info dir]
```
