### PR TITLE
New recipe: yow.lines

### DIFF
--- a/recipes/yow.lines.rcp
+++ b/recipes/yow.lines.rcp
@@ -1,0 +1,6 @@
+(:name yow.lines
+       :description "Download the old version of \"yow.lines\" for `yow'."
+       :type http
+       :url "https://raw.github.com/emacsmirror/emacs/74110cbac76d632309edd38b2cee4f8c1e6eccd7/etc/yow.lines"
+       :post-init
+       (setq yow-file (expand-file-name "yow.lines" default-directory)))


### PR DESCRIPTION
Download the old version of "yow.lines" for `yow'.  It was removed in
Emacs 22 because of copyright reasons.

See
- http://lists.gnu.org/archive/html/emacs-devel/2006-06/msg00290.html
- http://en.wikipedia.org/wiki/Zippy_the_Pinhead

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
