### PR TITLE
Un-break el-get when installing rust-mode

### DIFF
--- a/recipes/rust-mode.rcp
+++ b/recipes/rust-mode.rcp
@@ -1,6 +1,5 @@
 (:name rust-mode
        :type http
        :url "https://raw.github.com/mozilla/rust/master/src/etc/emacs/rust-mode.el"
-       :depends cm-mode
        :description "Emacs mode for Rust"
        :features rust-mode)


### PR DESCRIPTION
rust-mode no longer requires cm-mode, and furthermore, cm-mode has
been removed from the Rust repository.  That means that without this
patch updating one's rust-mode will break one's .emacs initialization.

Fix this by simply removing the dependency metadata.
