### PR TITLE
Added new git URI for emacs-jabber

### DIFF
--- a/recipes/emacs-jabber.rcp
+++ b/recipes/emacs-jabber.rcp
@@ -1,7 +1,7 @@
 (:name emacs-jabber
        :description "A minimal jabber client"
        :type git
-       :url "git://emacs-jabber.git.sourceforge.net/gitroot/emacs-jabber/emacs-jabber"
+       :url "git://git.code.sf.net/p/emacs-jabber/git"
        :info "."
        :load-path (".")
        :features jabber-autoloads


### PR DESCRIPTION
Emacs Jabber development moved to sourceforge's new git hosting some time ago.
