### PR TITLE
Add Elixir language mode recipe.

### DIFF
--- a/recipes/elixir.rcp
+++ b/recipes/elixir.rcp
@@ -1,0 +1,5 @@
+(:name elixir
+       :type github
+       :pkgname "elixir-lang/emacs-elixir"
+       :description "Elixir language's major mode for Emacs"
+       :website "http://github.com/elixir-lang/emacs-elixir")


### PR DESCRIPTION
Add a recipe for Emacs major mode for Elixir, an alternative functional language for the Erlang VM.  I have read the documentation and confirm this does conform to the auto-load standard.  I just successfully installed the recipe using my own branch of el-get on my laptop.
