### PR TITLE
Fix org2blog recipe to remove .el from metaweblog dependency extension f...

### DIFF
--- a/recipes/metaweblog.rcp
+++ b/recipes/metaweblog.rcp
@@ -1,4 +1,4 @@
-(:name metaweblog.el
+(:name metaweblog
        :description "Metaweblog"
        :type github
-       :pkgname "punchagan/metaweblog.el")
+       :pkgname "punchagan/metaweblog")

--- a/recipes/org2blog.rcp
+++ b/recipes/org2blog.rcp
@@ -2,5 +2,5 @@
        :description "Blog from Org mode to wordpress"
        :type github
        :pkgname "punchagan/org2blog"
-       :depends (xml-rpc-el metaweblog.el)
+       :depends (xml-rpc-el metaweblog)
        :features org2blog)


### PR DESCRIPTION
...rom dependency, causing 'el-get can not find a recipe for package metaweblog.el' error.
