### PR TITLE
Delete :depends of matlab-mode

### DIFF
--- a/recipes/matlab-mode.rcp
+++ b/recipes/matlab-mode.rcp
@@ -5,5 +5,5 @@
        :url ":pserver:anonymous@matlab-emacs.cvs.sourceforge.net:/cvsroot/matlab-emacs"
        :build ("make")
        :load-path (".")
-       :features matlab-load
-       :after (require 'cedet))
+       :features matlab-load)
+


### PR DESCRIPTION
Hello Dimitri:
Accroding to emacswiki, cedet is part of the standard Emacs distribution since version 23.2., so I think that matlab-mode doesn't need to depend on cedet(-bzr) anymore. By the way, users should add (require 'cedet) if cedet or semantic is needed. For users with emacs under version 23.2, cedet isn't a standard butlt-in. :after (require 'cedet) will make mistake.
I have test this new recipe with Emacs 24.3, it works fine.
