### PR TITLE
Update git-modes recipe.

### DIFF
--- a/recipes/git-modes.rcp
+++ b/recipes/git-modes.rcp
@@ -1,5 +1,4 @@
 (:name git-modes
        :description "GNU Emacs modes for various Git-related files"
        :type github
-       :pkgname "lunaryorn/git-modes"
-       :features ("gitconfig-mode" "gitignore-mode" "git-commit-mode"))
+       :pkgname "magit/git-modes")


### PR DESCRIPTION
Repository is now managed by the magit project and no `:features'
needed (comes with proper autoloads).

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
