### PR TITLE
Add nnir-spotlight recipe.

### DIFF
--- a/recipes/nnir-spotlight.rcp
+++ b/recipes/nnir-spotlight.rcp
@@ -1,0 +1,4 @@
+(:name nnir-spotlight
+       :type github
+       :description "Use MacOSX sportlight as nnir backend."
+       :pkgname "renard/nnir-spotlight")


### PR DESCRIPTION
Use MacOSX sportlight as nnir backend to perform email lookups.

`el-get-check-recipe' output:
0 error(s) found.

Signed-off-by: Sébastien Gross <seb•ɑƬ•chezwam•ɖɵʈ•org>
