### PR TITLE
Add GNU Tramp plugin for Emacs.

### DIFF
--- a/recipes/tramp.rcp
+++ b/recipes/tramp.rcp
@@ -1,0 +1,8 @@
+(:name emacs-w3m
+       :description "GNU TRAMP plugin for Emacs"
+       :website "https://www.gnu.org/software/tramp/"
+       :type git
+       :module "tramp"
+       :url "git://git.savannah.gnu.org/tramp.git"
+       :build `("autoconf" ("./configure" ,(concat "--with-emacs=" el-get-emacs)) "make")
+       :build/windows-nt ("sh /usr/bin/autoconf" "sh ./configure" "make"))


### PR DESCRIPTION
Add recipe for the [GNU TRAMP](https://www.gnu.org/software/tramp/) plugin.  The previously existing [`tramp-adb.rcp`](https://github.com/dimitri/el-get/blob/master/recipes/tramp-adb.rcp) recipe appears to be target for an extension to this plugin that is geared for using the ADB shell to communicate with Android devices.  The second alternative is [magit-tramp](https://github.com/dimitri/el-get/blob/master/recipes/magit-tramp.rcp), which is also an extension to TRAMP geared for the git protocol, but still not the actual plugin.  This plugin is the main version, pulling code directly from GNU SCM server.
