### PR TITLE
Update git-modes: `:features' no longer necessary.

### DIFF
--- a/recipes/git-modes.rcp
+++ b/recipes/git-modes.rcp
@@ -1,6 +1,4 @@
 (:name git-modes
        :description "GNU Emacs modes for various Git-related files"
        :type github
-       :pkgname "magit/git-modes"
-       :features ("gitconfig-mode" "gitignore-mode" "git-commit-mode"
-                  "git-rebase-mode"))
+       :pkgname "magit/git-modes")


### PR DESCRIPTION
Git-modes comes with proper autoloads.

See also #1345 and f51c711f27c664a.

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
