### PR TITLE
el-get-describe: Show install path and provide `el-get-cd`.

### DIFF
--- a/el-get-list-packages.el
+++ b/el-get-list-packages.el
@@ -51,6 +51,11 @@
                        (el-get-update package)))
   'help-echo (purecopy "mouse-2, RET: update package"))
 
+(define-button-type 'el-get-help-cd
+  :supertype 'help-xref
+  'help-function #'dired
+  'help-echo (purecopy "mouse-2, RET: open directory"))
+
 (define-button-type 'el-get-help-describe-package
   :supertype 'help-xref
   'help-function #'el-get-describe
@@ -80,6 +85,7 @@ matching REGEX with TYPE and ARGS as parameter."
          (def (el-get-package-def pname))
          (name (plist-get def :name))
          (website (plist-get def :website))
+         (directory (el-get-package-directory package))
          (descr (plist-get def :description))
          (type (el-get-package-method def))
          (builtin (plist-get def :builtin))
@@ -134,9 +140,15 @@ matching REGEX with TYPE and ARGS as parameter."
         (princ (format "  Warning: Your Emacs is too old (%s)!" emacs-version)))
       (princ "\n"))
     (if (eq type 'builtin)
-        (princ (format "The package is built-in since Emacs %s.\n\n" builtin))
-      (princ (format "The default installation method is %s%s.\n\n" type
+        (princ (format "The package is built-in since Emacs %s.\n" builtin))
+      (princ (format "The default installation method is %s%s.\n" type
                      (if url (format " from %s" url) ""))))
+    (when (string= status "installed")
+      (princ "Installed in ")
+      (el-get-describe-princ-button (format "`%s'" directory) "`\\([^']+\\)"
+                                    'el-get-help-cd directory)
+      (princ ".\n"))
+    (princ "\n")
     (princ "Full definition")
     (let ((file (el-get-recipe-filename package)))
       (if (not file)


### PR DESCRIPTION
If the package is installed `el-get-describe` will now show the
install path and provide an interface similar to `el-get-cd`.

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
