### PR TITLE
Build info for flycheck.

### DIFF
--- a/recipes/flycheck.rcp
+++ b/recipes/flycheck.rcp
@@ -2,4 +2,6 @@
        :type github
        :pkgname "lunaryorn/flycheck"
        :description "On-the-fly syntax checking extension"
+       :build ("cd doc && makeinfo flycheck.texi")
+       :info "./doc"
        :depends (s dash cl-lib f pkg-info))


### PR DESCRIPTION
The default `make info` from flycheck's Makefile need `cask` installed, which is not universal in general. 
