### PR TITLE
Change to the emacswiki source

### DIFF
--- a/recipes/ansi-color.rcp
+++ b/recipes/ansi-color.rcp
@@ -1,5 +1,4 @@
 (:name ansi-color
        :description "translate ANSI escape sequences into faces"
-       :type github
-       :pkgname "emacsattic/ansi-color"
-       :load "ansi-color.el")
+       :type emacswiki
+       :website "http://www.emacswiki.org/emacs/download/ansi-color.el")


### PR DESCRIPTION
The github repo is no longer available, changing the recipe to point to the emacswiki source allows it to be installed.

This fixes issue #1016
