### PR TITLE
Restore the --with-lispdir configure option on Darwin.

### DIFF
--- a/recipes/auctex.rcp
+++ b/recipes/auctex.rcp
@@ -7,6 +7,9 @@
        :build `(("./autogen.sh")
                 ("./configure"
                  "--without-texmf-dir"
+                 ,(cond
+                   ((eq system-type 'darwin)  "--with-lispdir=`pwd`")
+                   (t ""))
                  ,(concat "--with-emacs=" el-get-emacs))
                 "make")
        :load-path ("." "preview")


### PR DESCRIPTION
Please see #1375 and notes on ef79bfd23e90fef3e880c3ad6de39d4c5d44dc01.
