### PR TITLE
Use the correct Emacs when building haskell-mode

### DIFF
--- a/recipes/haskell-mode.rcp
+++ b/recipes/haskell-mode.rcp
@@ -3,7 +3,7 @@
        :type github
        :pkgname "haskell/haskell-mode"
        :info "."
-       :build (("make" "all"))
+       :build `(("make" ,(format "EMACS=%s" el-get-emacs) "all"))
        :post-init (progn
                     (require 'haskell-mode-autoloads)
                     (add-hook 'haskell-mode-hook 'turn-on-haskell-doc-mode)


### PR DESCRIPTION
On MacOS X /usr/bin/emacs gets picked up which is too old to successfully build
haskell-mode.
