### PR TITLE
Fix Jedi Windows recipe.

### DIFF
--- a/recipes/jedi.rcp
+++ b/recipes/jedi.rcp
@@ -3,6 +3,7 @@
        :type github
        :pkgname "tkf/emacs-jedi"
        :build (("make" "requirements"))
+       :build/windows-nt (("make" "requirements" "PYTHON=python.exe" "BINDIR=Scripts"))
        :build/berkeley-unix (("gmake" "requirements"))
        :submodule nil
        :depends (epc auto-complete))


### PR DESCRIPTION
Scripts is the bin file for virtualenv on Windows.
PYTHON needs to be python.exe for windows to find the executable.
