### PR TITLE
fix test 683, removed package has no status

### DIFF
--- a/test/el-get-issue-683.el
+++ b/test/el-get-issue-683.el
@@ -6,10 +6,9 @@
       el-get-default-process-sync t)
 
 (defun assert-package-fully-removed (pkg)
-  (assert (string= "removed"
-                   (el-get-read-package-status pkg))
+  (assert (null (el-get-read-package-status pkg))
           nil
-          "Package %s should have status \"removed\", but actually has status \"%s\"."
+          "Package %s should have status `nil', but actually has status \"%s\"."
           pkg (el-get-read-package-status pkg))
   (assert (not (or (file-exists-p (el-get-package-directory pkg))
                    (file-symlink-p (el-get-package-directory pkg))))


### PR DESCRIPTION
Since 0e1d2d2444b1998b50c5e899406c60e16fe7bc34 a removed package is
simply deleted from the status list, but the test was still expecting
"removed".
