### PR TITLE
test http-tar method el-get-update

### DIFF
--- a/test/el-get-issue-809.el
+++ b/test/el-get-issue-809.el
@@ -1,0 +1,7 @@
+(setq el-get-sources
+      '((:name session :url "http://downloads.sourceforge.net/project/emacs-session/session/2.1c/session-2.1c.tar.gz")))
+(el-get 'sync "session")
+
+(setq el-get-sources
+      '((:name session :url "http://downloads.sourceforge.net/project/emacs-session/session/session-2.3a.tar.gz")))
+(el-get-update "session")


### PR DESCRIPTION
This test attempts to recreate the situation described in #809. The test
passes, which means either the issue has been fixed, or this test case
isn't actually testing the right thing.

closes #809
