### PR TITLE
be more precise about elpa package dir names

### DIFF
--- a/methods/el-get-elpa.el
+++ b/methods/el-get-elpa.el
@@ -28,28 +28,14 @@
 (defun el-get-elpa-package-directory (package)
   "Return the directory where ELPA stores PACKAGE, or nil if
 PACKAGE isn't currently installed by ELPA."
-  (let* ((pname (format "%s" package))  ; easy way to cope with symbols etc.
-
-     (ls-command (if (memq system-type '(ms-dos windows-nt)) "dir /B " "ls -1 "))
-
-	 (l
-	  ;; we use try-completion to find the realname of the directory
-	  ;; ELPA used, and this wants an alist, we trick ls -i -1 into
-	  ;; that.
-	  (mapcar 'split-string
-		  (split-string
-		   (shell-command-to-string
-		    (concat
-		     ls-command
-                     (shell-quote-argument
-                      (expand-file-name
-                       (file-name-as-directory package-user-dir))))))))
-
-	 (realnames (all-completions pname l)))
-
-    (when realnames
-      (concat (file-name-as-directory package-user-dir) (car realnames)))))
-
+  ;; package directories are named <package>-<version>.
+  (let* ((pname (el-get-as-string package))
+         (version-offset (+ (length pname) 1)))
+    (loop for pkg-dir in (directory-files package-user-dir nil
+                                          (concat "^" (regexp-quote pname) "-"))
+          if (ignore-errors
+               (version-to-list (substring pkg-dir version-offset)))
+          return (expand-file-name pkg-dir package-user-dir))))
 
 (defun el-get-elpa-package-repo (package)
   "Get the ELPA repository cons cell for PACKAGE.

--- a/test/el-get-issue-1189.el
+++ b/test/el-get-issue-1189.el
@@ -1,0 +1,16 @@
+;;; When installing a package whose name is a prefix of an already
+;;; installed package, `el-get-elpa-package-directory' gets confused.
+
+(setq el-get-sources
+      '((:name load-dir ; I tried to pick the smallest package
+               :type elpa
+               :description "Load all Emacs Lisp files in a given directory"
+               :repo ("gnu" . "http://elpa.gnu.org/packages/"))))
+
+(el-get 'sync 'load-dir)
+
+(assert (not (equal (el-get-elpa-package-directory 'load)
+                    (el-get-elpa-package-directory 'load-dir)))
+        nil
+        "a package name `load' shouldn't use the same directory
+as `load-dir'.")


### PR DESCRIPTION
ELPA Package directories are named `<package>-<version>`.  Previously
`el-get-elpa-package-directory` looked for package-dirs using
`all-completions` meaning anything starting with `<package>` would match.
This is problematic if a package is a prefix of another package, eg the
`s` and `solarized-theme` packages.

Instead of doing that, look for a directory that is precisely
`<package>-<version>` where `<version>` is something acceptable to
`version-to-list`

Fixes #1189.
