### PR TITLE
Add features keyword to inf-ruby recipe.

### DIFF
--- a/recipes/inf-ruby.rcp
+++ b/recipes/inf-ruby.rcp
@@ -1,4 +1,5 @@
 (:name inf-ruby
        :description "Inferior Ruby Mode - ruby process in a buffer."
        :type github
-       :pkgname "nonsequitur/inf-ruby")
+       :pkgname "nonsequitur/inf-ruby"
+       :features inf-ruby)


### PR DESCRIPTION
Many elisp variables in inf-ruby is not autoloaded, so we must (require
inf-ruby) first, then we can do our own customizations via :after
keyword of el-get-sources.
