### PR TITLE
Remove compile keyword in slime.rcp.

### DIFF
--- a/recipes/slime.rcp
+++ b/recipes/slime.rcp
@@ -5,7 +5,6 @@
        :info "doc"
        :pkgname "antifuchs/slime"
        :load-path ("." "contrib")
-       :compile (".")
        :build '(("make" "-C" "doc" "slime.info"))
        :build/berkeley-unix '(("gmake" "-C" "doc" "slime.info"))
        :post-init (slime-setup))


### PR DESCRIPTION
The latest slime (commit b090605) will report "require: Symbol's value
as variable is void: slime-fancy" if byte-compile to elc.
