### PR TITLE
delete temp files in `el-get-start-process-list'

### DIFF
--- a/el-get-core.el
+++ b/el-get-core.el
@@ -395,6 +395,7 @@ makes it easier to conditionally splice a command into the list.
                       (message "el-get: %s" message)
                     (set-window-buffer (selected-window) cbuf)
                     (error "el-get: %s %s" cname errorm))
+                  (when infile (delete-file infile))
                   (when cbuf (kill-buffer cbuf))
                   (if next
                       ;; Prevent stack overflow on very long command


### PR DESCRIPTION
It's been pretty annoying to have `ls /tmp` give me a whole screen of `el-get1954174e` after running tests.
