### PR TITLE
Update bbdb.rcp to be compatible with current version of bbdb

### DIFF
--- a/recipes/bbdb.rcp
+++ b/recipes/bbdb.rcp
@@ -5,9 +5,7 @@
        :url "git://git.savannah.nongnu.org/bbdb.git"
        :load-path ("./lisp")
        ;; if using vm, add `--with-vm-dir=DIR' after ./configure
-       :build `("autoconf" ,(concat "./configure --with-emacs=" el-get-emacs)
-                "make clean" "rm -f lisp/bbdb-autoloads.el"
-                "make info bbdb")
+       :build `("./autogen.sh" "./configure" "make")
        :features bbdb-loaddefs
        :autoloads nil
        :info "doc"


### PR DESCRIPTION
Recently I was unable to build bbdb through el-get. 

configure.ac:33: error: possibly undefined macro: AM_INIT_AUTOMAKE
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure.ac:35: error: possibly undefined macro: AC_PACKAGE_DATE
configure.ac:41: error: possibly undefined macro: AM_PATH_LISPDIR

I found by googling that build scripts in bbdb is different now: https://savannah.nongnu.org/bugs/?38780#comment5

With this patch I was able to build bbdb.
