### PR TITLE
Fixed installation of tomorrow-theme.

### DIFF
--- a/recipes/tomorrow-theme.rcp
+++ b/recipes/tomorrow-theme.rcp
@@ -7,5 +7,4 @@
        :minimum-emacs-version 24
        :autoloads nil
        :post-init (add-to-list 'custom-theme-load-path
-                               (concat (file-name-as-directory default-directory)
-                                       "GNU Emacs")))
+                               (expand-file-name "GNU Emacs" default-directory)))


### PR DESCRIPTION
I tried installing tomorrow-theme but it didn't work very well for me. For example, both the post-init and the autoloads generation added incorrect paths to custom-theme-load-path. I've disabled the generation of autoloads (note, using `:autoloads nil` didn't work for me until I merged #1373 into my el-get) and fixed the path in post-init. With these changes I can now use `customize-theme` to select the various Tomorrow themes.
