### PR TITLE
Add cider recipe

### DIFF
--- a/recipes/cider.rcp
+++ b/recipes/cider.rcp
@@ -1,0 +1,5 @@
+(:name cider
+       :description "Clojure Integrated Development Environment and REPL"
+       :type github
+       :pkgname "clojure-emacs/cider"
+       :depends (dash clojure-mode pkg-info))


### PR DESCRIPTION
**[CIDER](https://github.com/clojure-emacs/cider)** was renamed from `nREPL.el`.
The malfunction does not occur for the moment. However, I think that I should migrate a package name.

I become able to install it using the new name by an added `cider.rcp` recipe. But `nrepl.rcp` still remains.

I thought that it can be settled peacefully if I do it in this way, but do not seem to get along well...

``` patch
diff --git a/recipes/nrepl.rcp b/recipes/nrepl.rcp
index 08e2eb9..b6b507d 100644
--- a/recipes/nrepl.rcp
+++ b/recipes/nrepl.rcp
@@ -1,5 +1,4 @@
 (:name nrepl
        :description "An Emacs client for nREPL, the Clojure networked REPL server."
-       :type github
-       :pkgname "clojure-emacs/nrepl.el"
-       :depends (dash clojure-mode pkg-info))
+       :type no-op
+       :depends cider)
```
