### PR TITLE
Adds a sed line that allows to build slime.info with makeinfo v. 5.X

### DIFF
--- a/recipes/slime.rcp
+++ b/recipes/slime.rcp
@@ -5,6 +5,8 @@
        :info "doc"
        :pkgname "antifuchs/slime"
        :load-path ("." "contrib")
-       :build '(("make" "-C" "doc" "slime.info"))
+       :build '(("sed" "-i" "s/@itemx INIT-FUNCTION/@item INIT-FUNCTION/"
+                 "doc/slime.texi")
+                ("make" "-C" "doc" "slime.info"))
        :build/berkeley-unix '(("gmake" "-C" "doc" "slime.info"))
        :post-init (slime-setup))


### PR DESCRIPTION
With newer versions of makeinfo, current recipe does not work due to an error that was previously a warning.

Adding an itemx to the texi file, prevents this from happening.

Sources:
- [Original thread with the fix](https://forums.gentoo.org/viewtopic-t-959158.html?sid=b8422e97ae46ebb98e3d3a2f7c52bc28)
- [Discussion on texinfo](http://savannah.gnu.org/bugs/?38997)
