### PR TITLE
Projectile depends on pkg-info and fails if not installed.

### DIFF
--- a/recipes/projectile.rcp
+++ b/recipes/projectile.rcp
@@ -2,5 +2,5 @@
        :description "Project navigation and management library for Emacs"
        :type github
        :pkgname "bbatsov/projectile"
-       :depends (dash s)
+       :depends (dash s pkg-info)
        :features projectile)


### PR DESCRIPTION
Projectile fails too install due to a missing dependency: pkg-info. This should solve the problem.
