### PR TITLE
Fix `ac-nrepl.rcp` to point to clojure-emacs

### DIFF
--- a/recipes/ac-nrepl.rcp
+++ b/recipes/ac-nrepl.rcp
@@ -1,6 +1,6 @@
 (:name ac-nrepl
        :description "Nrepl completion source for Emacs auto-complete package"
        :type github
-       :pkgname "purcell/ac-nrepl"
+       :pkgname "clojure-emacs/ac-nrepl"
        :depends (auto-complete cider)
        :features ac-nrepl)


### PR DESCRIPTION
`clojure-emacs/ac-nrepl` is now the canonical repository
