### PR TITLE
Update repo for ido-ubiquitous.

### DIFF
--- a/recipes/ido-ubiquitous.rcp
+++ b/recipes/ido-ubiquitous.rcp
@@ -1,3 +1,4 @@
 (:name ido-ubiquitous
        :description "Use ido (nearly) everywhere"
-       :type elpa)
+       :type github
+       :pkgname "DarwinAwardWinner/ido-ubiquitous")


### PR DESCRIPTION
ELPA doesn't host ido-ubiquitous anymore.  The most updated repo is
DarwinAwardWinnder's repo.
