### PR TITLE
change the github-default-url-type to https

### DIFF
--- a/methods/el-get-github.el
+++ b/methods/el-get-github.el
@@ -22,7 +22,7 @@
         'ssh "git@github.com:%USER%/%REPO%.git")
   "Plist mapping Github types to their URL format strings.")
 
-(defcustom el-get-github-default-url-type 'http
+(defcustom el-get-github-default-url-type 'https
   "The kind of URL to use for Github repositories.
 
 Choices are `http', `https', `git'. This is effectively the


### PR DESCRIPTION
When I use http url-type to install github packages, the 405 code is returned. I think it's time to change the github-default-url-type from http to https, or there will be many git clone errors.
