### PR TITLE
Make json recipe builtin starting from Emacs 23

### DIFF
--- a/recipes/json.rcp
+++ b/recipes/json.rcp
@@ -1,5 +1,6 @@
 (:name json
        :description "JavaScript Object Notation parser / generator"
        :type http
+       :builtin "23"
        :url "http://edward.oconnor.cx/elisp/json.el"
        :features json)


### PR DESCRIPTION
I'm making a recipe that depends on the json package but even if it is builtin in my Emacs el-get installed another version. JSON is a builtin package since Emacs 23 I believe. At least it is on Emacs 23.4.1 on my Debian and the website http://edward.oconnor.cx/2006/03/json.el says it is included Emacs since February 2008, Emacs 23 was released in 2009.
