### PR TITLE
Point `workgroups` recipe to new repository

### DIFF
--- a/recipes/workgroups.rcp
+++ b/recipes/workgroups.rcp
@@ -1,5 +1,5 @@
 (:name workgroups
        :description "Workgroups for windows (for Emacs)"
        :type github
-       :pkgname "tlh/workgroups.el"
+       :pkgname "workgroups/workgroups.el"
        :features "workgroups")


### PR DESCRIPTION
`tlh/workgroups` has been dead for a while now.
