### PR TITLE
Don't update popup-el submodule

### DIFF
--- a/recipes/popup.rcp
+++ b/recipes/popup.rcp
@@ -2,4 +2,5 @@
        :website "https://github.com/auto-complete/popup-el"
        :description "Visual Popup Interface Library for Emacs"
        :type github
+       :submodule nil
        :pkgname "auto-complete/popup-el")


### PR DESCRIPTION
Because its submodule is used only for tests

  auto-complete/popup-el#49

Please see this patch
