### PR TITLE
fix dependencies for pkg-info

### DIFF
--- a/recipes/pkg-info.rcp
+++ b/recipes/pkg-info.rcp
@@ -2,4 +2,4 @@
        :description "Provide information about Emacs packages."
        :type github
        :pkgname "lunaryorn/pkg-info.el"
-       :depends (s epl))
+       :depends (dash epl))


### PR DESCRIPTION
Just updating the recipe's dependencies to reflect what's in the `pkg-info.el` package header.  I assume this is correct, but it somewhat mystifies me why this is necessary, as described here:

  https://github.com/dimitri/el-get/issues/1471
