### PR TITLE
New build step for yasnippet recipe.

### DIFF
--- a/recipes/yasnippet.rcp
+++ b/recipes/yasnippet.rcp
@@ -34,4 +34,4 @@
        ;; byte-compile load vc-svn and that fails
        ;; see https://github.com/dimitri/el-get/issues/200
        :compile nil
-       :submodule nil)
+       :submodule t)


### PR DESCRIPTION
The yasnippet has seperated its snippet and scripts to two other repos, so we need
additional "git submodule" steps to fetch them.

This commit closes #1447 since there're no need anymore. 
