### PR TITLE
Update slime recipe.

### DIFF
--- a/recipes/slime.rcp
+++ b/recipes/slime.rcp
@@ -4,6 +4,7 @@
        :autoloads "slime-autoloads"
        :info "doc"
        :pkgname "slime/slime"
+       :depends cl-lib
        :load-path ("." "contrib")
        :build '(("sed" "-i" "s/@itemx INIT-FUNCTION/@item INIT-FUNCTION/"
                  "doc/slime.texi")


### PR DESCRIPTION
Slime is now officially on github and requires cl-lib.

http://article.gmane.org/gmane.lisp.slime.devel/11212

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
