### PR TITLE
Add go-errcheck recipe

### DIFF
--- a/recipes/go-errcheck-el.rcp
+++ b/recipes/go-errcheck-el.rcp
@@ -1,0 +1,5 @@
+(:name go-errcheck-el
+       :description "Provides an easy way to invoke errcheck from within Emacs"
+       :type github
+       :depends go-errcheck
+       :pkgname "dominikh/go-errcheck.el")

--- a/recipes/go-errcheck.rcp
+++ b/recipes/go-errcheck.rcp
@@ -1,0 +1,5 @@
+(:name go-errcheck
+       :description "Program for checking for unchecked errors in go code"
+       :type go
+       :pkgname "github.com/kisielk/errcheck"
+       :post-init (el-get-envpath-prepend "PATH" (concat default-directory "bin")))


### PR DESCRIPTION
- go-errcheck-el.rcp emacs interface to the go errcheck program
- go-errcheck.rcp builds the 'errcheck' program
