### PR TITLE
Add erlang-mode recipe

### DIFF
--- a/recipes/erlang-mode.rcp
+++ b/recipes/erlang-mode.rcp
@@ -1,0 +1,6 @@
+(:name erlang-mode
+       :description "Major mode for editing and running Erlang"
+       :type http
+       :url "http://www.erlang.org/download/contrib/erlang.el"
+       :post-init (progn
+                    (add-to-list 'auto-mode-alist '("\\.erl$" . erlang-mode))))

--- a/recipes/erlware-mode.rcp
+++ b/recipes/erlware-mode.rcp
@@ -1,7 +1,4 @@
 (:name erlware-mode
        :description "Major modes for editing and running Erlang"
-       :type http-tar
-       :options ("xzf")
-       :url "http://erlware-mode.googlecode.com/files/erlware-mode-0.1.19.tar.gz"
-       :load "erlang-start.el"
-       )
+       :type builtin
+       :depends erlang-mode)


### PR DESCRIPTION
This recipe replace erlware-mode recipe since erlang-mode is its
integration into the official distribution of Erlang.

However, I am unsure if doing an automatic transition is a good idea. The old recipe still works.
