### PR TITLE
Add a recipe for gyp-mode.

### DIFF
--- a/recipes/gyp-mode.rcp
+++ b/recipes/gyp-mode.rcp
@@ -1,0 +1,9 @@
+(:name gyp-mode
+       :description "Major mode for editing gyp files"
+       :type http
+       :url "https://gyp.googlecode.com/svn/trunk/tools/emacs/gyp.el"
+       :prepare (progn
+                  (autoload 'gyp-mode "gyp"
+                    "Major mode for editing gyp files")
+                  (add-to-list 'auto-mode-alist '("\\.gyp$" . gyp-mode))
+                  (add-to-list 'auto-mode-alist '("\\.gypi$" . gyp-mode))))


### PR DESCRIPTION
This is the official mode for gyp files. Since Google Code does not
provide source archive anymore, we just "hotlink" to the appropriate
file.
