### PR TITLE
Modify `auto-mode-alist` in `prepare` step

### DIFF
--- a/recipes/actionscript-mode.rcp
+++ b/recipes/actionscript-mode.rcp
@@ -1,5 +1,5 @@
 (:name actionscript-mode
        :type github
        :username "austinhaas"
-       :post-init (progn
-                    (add-to-list 'auto-mode-alist '("\\.as$" . actionscript-mode))))
+       :prepare (progn
+                  (add-to-list 'auto-mode-alist '("\\.as$" . actionscript-mode))))

--- a/recipes/cmake-mode.rcp
+++ b/recipes/cmake-mode.rcp
@@ -3,7 +3,7 @@
        :description "Provides syntax highlighting and indentation for CMakeLists.txt and *.cmake source files."
        :type http
        :url "http://www.cmake.org/CMakeDocs/cmake-mode.el"
-       :before (progn
-                 (autoload 'cmake-mode "cmake-mode" "Major mode for editing CMake listfiles.")
-                 (add-to-list 'auto-mode-alist '("CMakeLists\\.txt\\'" . cmake-mode))
-                 (add-to-list 'auto-mode-alist '("\\.cmake\\'" . cmake-mode))))
+       :prepare (progn
+                  (autoload 'cmake-mode "cmake-mode" "Major mode for editing CMake listfiles.")
+                  (add-to-list 'auto-mode-alist '("CMakeLists\\.txt\\'" . cmake-mode))
+                  (add-to-list 'auto-mode-alist '("\\.cmake\\'" . cmake-mode))))

--- a/recipes/coffee-mode.rcp
+++ b/recipes/coffee-mode.rcp
@@ -4,8 +4,9 @@
        :type github
        :pkgname "defunkt/coffee-mode"
        :features coffee-mode
+       :prepare (progn
+                  (add-to-list 'auto-mode-alist '("\\.coffee$" . coffee-mode))
+                  (add-to-list 'auto-mode-alist '("Cakefile" . coffee-mode)))
        :post-init (progn
-                    (add-to-list 'auto-mode-alist '("\\.coffee$" . coffee-mode))
-                    (add-to-list 'auto-mode-alist '("Cakefile" . coffee-mode))
                     ;; it defaults to js2-mode, which is not present in Emacs by default
                     (setq coffee-js-mode 'javascript-mode)))

--- a/recipes/django-mode.rcp
+++ b/recipes/django-mode.rcp
@@ -3,11 +3,11 @@
        :type github
        :pkgname "myfreeweb/django-mode"
        :depends yasnippet
-       :prepare (autoload 'django-mode "django-mode" "Major mode for Django web framework." t)
+       :prepare (progn
+                  (autoload 'django-mode "django-mode" "Major mode for Django web framework." t)
+                  (add-to-list 'auto-mode-alist '("\.djhtml$" . django-html-mode)))
        :post-init
        (progn
          ;; Load yasnippet because yas/load-directory has no autoload
          (require 'yasnippet)
-	 (yas/load-directory (expand-file-name "snippets"))
-	 ;; django-html-mode is autoloaded, should just work
-	 (add-to-list 'auto-mode-alist '("\.djhtml$" . django-html-mode))))
+	 (yas/load-directory (expand-file-name "snippets"))))

--- a/recipes/dockerfile-mode.rcp
+++ b/recipes/dockerfile-mode.rcp
@@ -2,6 +2,6 @@
        :description "An emacs mode for handling Dockerfiles."
        :type github
        :pkgname "spotify/dockerfile-mode"
-       :post-init (progn
-                    (add-to-list 'auto-mode-alist
-                                 '("Dockerfile\\'" . dockerfile-mode))))
+       :prepare (progn
+                  (add-to-list 'auto-mode-alist
+                               '("Dockerfile\\'" . dockerfile-mode))))

--- a/recipes/enh-ruby-mode.rcp
+++ b/recipes/enh-ruby-mode.rcp
@@ -3,7 +3,7 @@
        :type github
        :pkgname "zenspider/enhanced-ruby-mode"
        :features enh-ruby-mode
-       :post-init (progn
+       :prepare (progn
 		  (autoload 'enh-ruby-mode "enh-ruby-mode" "Major mode for ruby files" t)
 		  (add-to-list 'interpreter-mode-alist '("ruby" . enh-ruby-mode))
 		  (add-to-list 'auto-mode-alist '("\\.rake$" . enh-ruby-mode))
@@ -11,4 +11,3 @@
 		  (add-to-list 'auto-mode-alist '("\\.gemspec$" . enh-ruby-mode))
 		  (add-to-list 'auto-mode-alist '("Gemfile$" . enh-ruby-mode))
 		  (add-to-list 'auto-mode-alist '("\\.rb$" . enh-ruby-mode))))
-)

--- a/recipes/erlang-mode.rcp
+++ b/recipes/erlang-mode.rcp
@@ -2,5 +2,5 @@
        :description "Major mode for editing and running Erlang"
        :type http
        :url "http://www.erlang.org/download/contrib/erlang.el"
-       :post-init (progn
-                    (add-to-list 'auto-mode-alist '("\\.erl$" . erlang-mode))))
+       :prepare (progn
+                  (add-to-list 'auto-mode-alist '("\\.erl$" . erlang-mode))))

--- a/recipes/feature-mode.rcp
+++ b/recipes/feature-mode.rcp
@@ -3,5 +3,5 @@
        :type github
        :pkgname "michaelklishin/cucumber.el"
        :features feature-mode
-       :post-init (add-to-list 'auto-mode-alist
-                               '("\\.feature\\'" . feature-mode)))
+       :prepare (add-to-list 'auto-mode-alist
+                             '("\\.feature\\'" . feature-mode)))

--- a/recipes/flex-mode.rcp
+++ b/recipes/flex-mode.rcp
@@ -3,4 +3,4 @@
        :type http
        :url "http://ftp.sunet.se/pub/gnu/emacs-lisp/incoming/flex-mode.el"
        :features flex-mode
-       :post-init (add-to-list 'auto-mode-alist '("\\.l$" . flex-mode)))
+       :prepare (add-to-list 'auto-mode-alist '("\\.l$" . flex-mode)))

--- a/recipes/fsharp-mode.rcp
+++ b/recipes/fsharp-mode.rcp
@@ -4,5 +4,5 @@
        :url "https://fsharp-mode.svn.sourceforge.net/svnroot/fsharp-mode"
        :load-path (".")
        :features (fsharp inf-fsharp)
-       :post-init (add-to-list 'auto-mode-alist
-                               '("\\.fs[iylx]?$" . fsharp-mode)))
+       :prepare (add-to-list 'auto-mode-alist
+                             '("\\.fs[iylx]?$" . fsharp-mode)))

--- a/recipes/gregorio-mode.rcp
+++ b/recipes/gregorio-mode.rcp
@@ -4,5 +4,5 @@
        :type github
        :pkgname "cajetanus/gregorio-mode.el"
        :features gregorio-mode
-       :post-init (progn
-                    (add-to-list 'auto-mode-alist '("\\.gabc$" . gregorio-mode))))
+       :prepare (progn
+                  (add-to-list 'auto-mode-alist '("\\.gabc$" . gregorio-mode))))

--- a/recipes/hs-mode.rcp
+++ b/recipes/hs-mode.rcp
@@ -5,11 +5,11 @@
        :depends (peg auto-complete auto-complete-etags paredit)
        :load-path ("./src/")
        :features (hs)
-       :post-init (progn
-                    ;; From examples/init.el
-                    (add-to-list 'auto-mode-alist
-                                 (cons "\\.hs\\'" 'hs-mode))
-                    (add-to-list 'auto-mode-alist
-                                 (cons "\\.cabal\\'" 'hs-cabal-mode))
-                    (add-to-list 'auto-mode-alist
-                                 '("\\.hcr\\'" . hs-core-mode))))
+       :prepare (progn
+                  ;; From examples/init.el
+                  (add-to-list 'auto-mode-alist
+                               (cons "\\.hs\\'" 'hs-mode))
+                  (add-to-list 'auto-mode-alist
+                               (cons "\\.cabal\\'" 'hs-cabal-mode))
+                  (add-to-list 'auto-mode-alist
+                               '("\\.hcr\\'" . hs-core-mode))))

--- a/recipes/markdown-mode.rcp
+++ b/recipes/markdown-mode.rcp
@@ -3,5 +3,5 @@
        :website "http://jblevins.org/projects/markdown-mode/"
        :type git
        :url "git://jblevins.org/git/markdown-mode.git"
-       :before (add-to-list 'auto-mode-alist
-                            '("\\.\\(md\\|mdown\\|markdown\\)\\'" . markdown-mode)))
+       :prepare (add-to-list 'auto-mode-alist
+                             '("\\.\\(md\\|mdown\\|markdown\\)\\'" . markdown-mode)))

--- a/recipes/mustache-mode.rcp
+++ b/recipes/mustache-mode.rcp
@@ -3,8 +3,8 @@
        :features mustache-mode
        :type github
        :pkgname "mustache/emacs"
-       :post-init (progn
-                    (add-to-list 'auto-mode-alist
-                                 '("\\.hs$" . mustache-mode))
-                    (add-to-list 'auto-mode-alist
-                                 '("\\.handlebars$" . mustache-mode))))
+       :prepare (progn
+                  (add-to-list 'auto-mode-alist
+                               '("\\.hs$" . mustache-mode))
+                  (add-to-list 'auto-mode-alist
+                               '("\\.handlebars$" . mustache-mode))))

--- a/recipes/newlisp-mode.rcp
+++ b/recipes/newlisp-mode.rcp
@@ -4,6 +4,6 @@
        :type github
        :pkgname "kosh04/newlisp-mode"
        :features newlisp-mode
-       :post-init (progn
-                    (add-to-list 'auto-mode-alist '("\\.lsp$" . newlisp-mode))
-                    (add-to-list 'interpreter-mode-alist '("newlisp" . newlisp-mode))))
+       :prepare (progn
+                  (add-to-list 'auto-mode-alist '("\\.lsp$" . newlisp-mode))
+                  (add-to-list 'interpreter-mode-alist '("newlisp" . newlisp-mode))))

--- a/recipes/ntcmd.rcp
+++ b/recipes/ntcmd.rcp
@@ -2,6 +2,6 @@
        :type emacswiki
        :description "major mode for editing cmd scripts"
        :load-path "."
-       :post-init (progn
-                    (add-to-list 'auto-mode-alist '("\\.[bB][Aa][Tt]\\'" . ntcmd-mode))
-                    (add-to-list 'auto-mode-alist '("\\.[Cc][Mm][Dd]\\'" . ntcmd-mode))))
+       :prepare (progn
+                  (add-to-list 'auto-mode-alist '("\\.[bB][Aa][Tt]\\'" . ntcmd-mode))
+                  (add-to-list 'auto-mode-alist '("\\.[Cc][Mm][Dd]\\'" . ntcmd-mode))))

--- a/recipes/pkgbuild-mode.rcp
+++ b/recipes/pkgbuild-mode.rcp
@@ -3,4 +3,4 @@
        :type github
        :pkgname "juergenhoetzel/pkgbuild-mode"
        :features pkgbuild-mode
-       :post-init (add-to-list 'auto-mode-alist '("PKGBUILD$" . pkgbuild-mode)))
+       :prepare (add-to-list 'auto-mode-alist '("PKGBUILD$" . pkgbuild-mode)))

--- a/recipes/po-mode.rcp
+++ b/recipes/po-mode.rcp
@@ -3,8 +3,8 @@
        :type http
        :url "http://cvs.savannah.gnu.org/viewvc/*checkout*/gettext/gettext/gettext-tools/misc/po-mode.el"
        :features po-mode
-       :post-init (progn
-                    (add-to-list 'auto-mode-alist
-                                 '("\\.po$" . po-mode))
-                    (add-to-list 'auto-mode-alist
-                                 '("\\.pot$" . po-mode))))
+       :prepare (progn
+                  (add-to-list 'auto-mode-alist
+                               '("\\.po$" . po-mode))
+                  (add-to-list 'auto-mode-alist
+                               '("\\.pot$" . po-mode))))

--- a/recipes/sass-mode.rcp
+++ b/recipes/sass-mode.rcp
@@ -3,5 +3,5 @@
        :type github
        :pkgname "nex3/sass-mode"
        :depends haml-mode
-       :post-init (add-to-list 'auto-mode-alist
-                               '("\\.scss$" . sass-mode)))
+       :prepare (add-to-list 'auto-mode-alist
+                             '("\\.scss$" . sass-mode)))

--- a/recipes/syslog-mode.rcp
+++ b/recipes/syslog-mode.rcp
@@ -3,5 +3,5 @@
        :type github
        :pkgname "vapniks/syslog-mode"
        :depends (hide-lines)
-       :post-init (progn
-                    (add-to-list 'auto-mode-alist '("/var/log.*\\'" . syslog-mode))))
+       :prepare (progn
+                  (add-to-list 'auto-mode-alist '("/var/log.*\\'" . syslog-mode))))

--- a/recipes/ttcn-mode.rcp
+++ b/recipes/ttcn-mode.rcp
@@ -3,6 +3,6 @@
        :description "A TTCN major mode"
        :type github
        :pkgname "dholm/ttcn-el"
-       :post-init (progn
-                    (add-to-list 'auto-mode-alist '("\\.mp$" . ttcn-mode))
-                    (add-to-list 'auto-mode-alist '("\\.ttcn" . ttcn-3-mode))))
+       :prepare (progn
+                  (add-to-list 'auto-mode-alist '("\\.mp$" . ttcn-mode))
+                  (add-to-list 'auto-mode-alist '("\\.ttcn" . ttcn-3-mode))))

--- a/recipes/vala-mode.rcp
+++ b/recipes/vala-mode.rcp
@@ -1,5 +1,5 @@
 (:name vala-mode
        :description "Emacs mode for Vala language"
        :type elpa
-       :post-init (progn
-                    (add-to-list 'auto-mode-alist '("\\.vala$" . vala-mode))))
+       :prepare (progn
+                  (add-to-list 'auto-mode-alist '("\\.vala$" . vala-mode))))

--- a/recipes/wikipedia-mode.rcp
+++ b/recipes/wikipedia-mode.rcp
@@ -2,5 +2,5 @@
        :description "Mode for editing Wikipedia articles off-line"
        :type emacswiki
        :features wikipedia-mode
-       :post-init (add-to-list 'auto-mode-alist
-                               '("\\.wiki\\.txt\\'" . wikipedia-mode)))
+       :prepare (add-to-list 'auto-mode-alist
+                             '("\\.wiki\\.txt\\'" . wikipedia-mode)))


### PR DESCRIPTION
When lazy mode is enabled, altering `auto-mode-alist` in `post-init`
won't work until the mode is enabled a first time. We move all
modifications of `auto-mode-alist` in `prepare`.

I didn't check if the modification of `auto-mode-alist` was still needed (some modes may have been updated for that to be autoloaded). I don't know if there is an easy way to ask el-get to download everything so that I can check something like that.