### PR TITLE
Do not attempt to load CEDET if eieio has been loaded

### DIFF
--- a/recipes/cedet.rcp
+++ b/recipes/cedet.rcp
@@ -23,5 +23,8 @@
   ;; setup.
   :lazy nil
   :post-init
-  (unless (featurep 'cedet-devel-load)
+  (if (or (featurep 'cedet-devel-load)
+          (featurep 'eieio))
+      (message (concat "Emacs' built-in CEDET has already been loaded!  Restart"
+                       " Emacs to load CEDET from el-get instead."))
     (load (expand-file-name "cedet-devel-load.el" pdir))))


### PR DESCRIPTION
CEDET will generate an error if it is loaded after the eieio version that is
shipped with Emacs has been loaded.  During bootstrapping this will continuously
cause my Emacs to stop installing packages and forcing me to restart it.

This change will ensure that Emacs can be fully bootstrapped using el-get even
if the updated version of CEDET is installed.  The new version will simply be
loaded on the next launch.
