### PR TITLE
Add recipe for git-rebase-mode.el

### DIFF
--- a/recipes/git-rebase-mode.rcp
+++ b/recipes/git-rebase-mode.rcp
@@ -1,0 +1,4 @@
+(:name git-rebase-mode
+       :description "Major mode for editing Git rebase files."
+       :type http
+       :url "https://raw.github.com/magit/git-modes/master/git-rebase-mode.el")


### PR DESCRIPTION
git-rebase-mode.el is a major-mode for editing Git rebase files, the
kind produced by `git rebase --interactive`. It's a part of Magit that
can be used independently, for example by having an emacs server
running and `emacsclient` set as the `EDITOR`.
