### PR TITLE
Yasnippet: avoid yasmate submodule, and remove hacks

### DIFF
--- a/recipes/yasnippet.rcp
+++ b/recipes/yasnippet.rcp
@@ -3,10 +3,7 @@
        :description "YASnippet is a template system for Emacs."
        :type github
        :pkgname "capitaomorte/yasnippet"
-
-       ;; byte-compile load vc-svn and that fails
-       ;; see https://github.com/dimitri/el-get/issues/200
-       :compile nil
+       :compile "yasnippet.el"
 
        ;; only fetch the `snippets' submodule, others have funny
        ;; file names that can cause problems


### PR DESCRIPTION
- Fixed #1511 by using `git submodule` in `:build` instead of
  `:submodules`.
- Removed the complicated looking customize hacks that aren't needed
  anymore, as far as I can tell.
- According to #200 there is some problem with compilation, although I
  couldn't see exactly what the error was from there. I added
  `yasnippet.el` to `:compile` and eveything appears to be working
  fine when tested.
