### PR TITLE
replace obsolete :username with :pkgname

### DIFF
--- a/recipes/actionscript-mode.rcp
+++ b/recipes/actionscript-mode.rcp
@@ -1,5 +1,5 @@
 (:name actionscript-mode
        :type github
-       :username "austinhaas"
+       :pkgname "austinhaas/actionscript-mode"
        :post-init (progn
                     (add-to-list 'auto-mode-alist '("\\.as$" . actionscript-mode))))


### PR DESCRIPTION
As discussed in #1559, `:username` no longer works.

PS #1579 should have closed #1559.
