### PR TITLE
emacswiki should default to base url for checksum

### DIFF
--- a/methods/el-get-emacswiki.el
+++ b/methods/el-get-emacswiki.el
@@ -41,12 +41,19 @@ filename.el ;;; filename.el --- description"
   (let ((url (or url (format "%s%s.el" el-get-emacswiki-base-url package))))
     (el-get-http-install package url post-install-fun)))
 
+(defun el-get-emacswiki-compute-checksum (package)
+  "Download a single-file PACKAGE over HTTP from emacswiki."
+  (let ((url (or (plist-get (el-get-package-def package) :url)
+                 (format "%s%s.el" el-get-emacswiki-base-url package))))
+    (el-get-http-compute-checksum package url)))
+
 (defun el-get-emacswiki-guess-website (package)
   (format "%s%s.el" el-get-emacswiki-base-url package))
 
 (el-get-register-derived-method :emacswiki :http
   :install #'el-get-emacswiki-install
   :update #'el-get-emacswiki-install
+  :compute-checksum #'el-get-emacswiki-compute-checksum
   :guess-website #'el-get-emacswiki-guess-website)
 
 ;;;

--- a/methods/el-get-http.el
+++ b/methods/el-get-http.el
@@ -81,14 +81,14 @@ into the package :localname option or its `file-name-nondirectory' part."
         (el-get-http-retrieve-callback
          nil package url post-install-fun dest el-get-sources)))))
 
-(defun el-get-http-compute-checksum (package)
+(defun el-get-http-compute-checksum (package &optional url)
   "Look up download time SHA1 of PACKAGE."
   (let ((checksum (gethash package el-get-http-checksums)))
     (unless checksum
       ;; compute the checksum
       (setq checksum
             (with-temp-buffer
-              (insert-file-contents-literally (el-get-http-dest-filename package))
+              (insert-file-contents-literally (el-get-http-dest-filename package url))
               (sha1 (current-buffer))))
       (puthash package checksum el-get-http-checksums))
     checksum))


### PR DESCRIPTION
Since emacswiki recipes might not have an explicit :url in their recipe,
the :compute-checksum method should fallback to the base url, like the
:install and :guess-website methods.

---

fixes #1585
