### PR TITLE
Handle change in :depends

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -1017,6 +1017,9 @@ considered \"required\"."
                                 collect p)
                         (mapcar 'el-get-as-symbol installed)))
          (init-deps   (el-get-dependencies to-init))
+         (req-inits   (loop for p in init-deps
+                                unless (member (el-get-as-string p) installed)
+                                collect p))
          (to-install  (if packages
                           (loop for p in packages
                                 unless (member p init-deps)
@@ -1024,6 +1027,10 @@ considered \"required\"."
                         (mapcar 'el-get-as-symbol required)))
          (install-deps (el-get-dependencies to-install))
          done)
+    (when req-inits       ; we can't init a pkg unless it's installed!
+      (setq install-deps (append req-inits install-deps))
+      (setq init-deps (set-difference init-deps req-inits)))
+
     (el-get-verbose-message "el-get-init-and-install: install %S" install-deps)
     (el-get-verbose-message "el-get-init-and-install: init %S" init-deps)
 

--- a/test/el-get-issue-1472.el
+++ b/test/el-get-issue-1472.el
@@ -1,0 +1,19 @@
+;;; https://github.com/dimitri/el-get/issues/1472
+;;; (el-get) fails when installed packages acquire dependencies that
+;;; have not been installed.
+
+(el-get-register-method-alias :test :builtin)
+
+;;; install a
+(setq el-get-sources
+      '((:name a :type test)))
+
+(el-get 'sync "a")
+
+;;; make a depend on b
+(setq el-get-sources
+      '((:name a :type test :depends (b))
+        (:name b :type test)))
+
+;;; init a, now requires b!
+(el-get 'sync)


### PR DESCRIPTION
If a package to be init'd has new dependencies, simply install them rather than throwing an error about missing packages. A warning about changing non-whitelisted properties is still issued.

fixes #1472
