### PR TITLE
el-get-set-info-path: make safe if package removed

### DIFF
--- a/test/el-get-issue-1562.el
+++ b/test/el-get-issue-1562.el
@@ -1,0 +1,22 @@
+;;; https://github.com/dimitri/el-get/issues/1562 Removing a package
+;;; that comes with an info manual, causes an error when calling info
+
+(el-get-register-method-alias :test :builtin)
+
+;;; install a
+(setq el-get-sources
+      `((:name a :type test
+               :build (("sh" "-c"
+                        ,(format "echo %s > a.info"
+                                 (shell-quote-argument
+                                  (concat
+                                   "\x1f\n"
+                                   "Tag Table:\n"
+                                   "\x1f\n"
+                                   "End Tag Table\n")))))
+               :info ".")))
+
+(el-get 'sync "a")
+(el-get-remove "a")
+
+(info)


### PR DESCRIPTION
Use an eval-after-load form that won't throw an error, regardless of
removed packages.

Fixes #1562. I didn't use the hack suggested there, since that would depend on the precise form `eval-after-load` adds to `after-load-alist` which could easily change between emacs versions.

---

Note that the info path still isn't removed on package uninstall; I looked at how `infodir-rel` is computed:

``` el
      (let* ((infodir-abs-conf (concat pdir infodir))
             (infodir-abs (file-name-as-directory
                           (if (file-directory-p infodir-abs-conf)
                               infodir-abs-conf
                             (file-name-directory infodir-abs-conf))))
             (infodir-rel (if (file-directory-p infodir-abs-conf)
                              infodir
                            (file-name-directory infodir)))
             (info-dir    (concat infodir-abs "dir"))
             (infofile (if (and (file-exists-p infodir-abs-conf)
                                (not (file-directory-p infodir-abs-conf)))
                           infodir-abs-conf
                         (concat infodir-abs pname))))
```

too complicated, depends on state of the filesystem: a good chance we'd come up with a different answer during uninstall.
