### PR TITLE
Fix Google Calendar build step

### DIFF
--- a/recipes/google-calendar.rcp
+++ b/recipes/google-calendar.rcp
@@ -4,8 +4,10 @@
        :pkgname "bateast/google-calendar"
        :depends (google-contacts json)
        :prepare (progn
-                  (autoload 'google-calendar/get-calendar "google-calendar" nil t)
-                  (autoload 'google-calendar/fetch-calendars "google-calendar" nil t))
-       :build (progn
-                (require 'ob-tangle)
-                (org-babel-tangle-file "google-calendar.org")))
+                  (autoload 'google-calendar/get-calendar "google-calendar.el" nil t)
+                  (autoload 'google-calendar/fetch-calendars "google-calendar.el" nil t))
+       :post-init (let ((source-file (expand-file-name "google-calendar.org" (el-get-package-directory "google-calendar")))
+                        (target-file (expand-file-name "google-calendar.el" (el-get-package-directory "google-calendar"))))
+                    (when (not (file-exists-p target-file))
+                      (require 'ob-tangle)
+                      (org-babel-tangle-file source-file target-file "emacs-lisp"))))


### PR DESCRIPTION
:build assumes that a shell command should be executed resulting in a failed build of Google Calendar.
