### PR TITLE
Prevent error when installing Jedi

### DIFF
--- a/recipes/jedi.rcp
+++ b/recipes/jedi.rcp
@@ -2,8 +2,12 @@
        :description "An awesome Python auto-completion for Emacs"
        :type github
        :pkgname "tkf/emacs-jedi"
-       :build (("make" "requirements"))
-       :build/windows-nt (("make" "requirements" "PYTHON=python.exe" "BINDIR=Scripts"))
-       :build/berkeley-unix (("gmake" "requirements"))
+       ;; Jedi will install into a virtualenv anyway so disable pip's check
+       ;; to avoid an error during build.
+       :build (("env" "PIP_REQUIRE_VIRTUALENV=false" "make" "requirements"))
+       :build/windows-nt (("make" "requirements" "PYTHON=python.exe"
+                           "BINDIR=Scripts"))
+       :build/berkeley-unix (("env" "PIP_REQUIRE_VIRTUALENV=false"
+                              "gmake" "requirements"))
        :submodule nil
        :depends (epc auto-complete))


### PR DESCRIPTION
Temporarily lift pip's restriction from requiring a virtual environment if the
user has that feature enabled.  Jedi still installs into a virtualenv so this
just prevents the recipe from failing to install.
