### PR TITLE
recipes/auctex.rcp: Set correct dirs.

### DIFF
--- a/recipes/auctex.rcp
+++ b/recipes/auctex.rcp
@@ -7,6 +7,8 @@
        :build `(("./autogen.sh")
                 ("./configure"
                  "--without-texmf-dir"
+                 "--with-packagelispdir=$(pwd)"
+                 "--with-packagedatadir=$(pwd)"
                  ,(cond
                    ((eq system-type 'darwin)  "--with-lispdir=`pwd`")
                    (t ""))


### PR DESCRIPTION
If `packagelispdir` and `packagedatadir` are not set then AUCTeX expects
tex-site.el to be in a directory above the actual auctex dir and sets
the variables `TeX-data-directory` and `TeX-lisp-directory` to incorrect
values.  This will prevent such things as correct loading of the styles/
directory.

---

For darwin backlash (`) is used.  I'm not sure if this still works properly (no osx/darwin to test it) because when I tried it for the `package*dir` parameters it seems the configure script got a literal `pwd` instead of the result of `pwd`. Maybe `(concat "--with-...=" default-directory)` should be used instead to make it independent of shell interpolation all together.
