### PR TITLE
Make window-margin use (now-updated) canonical upstream repo

### DIFF
--- a/recipes/window-margin.rcp
+++ b/recipes/window-margin.rcp
@@ -1,4 +1,4 @@
 (:name window-margin
        :description "Automatic margins for visual-line-mode wrapping"
        :type github
-       :pkgname "rrthomas/window-margin.el") ; go to nslater/ once https://github.com/nslater/window-margin.el/pull/1 addressed
+       :pkgname "aculich/window-margin.el")


### PR DESCRIPTION
Some necessary changes have been pulled by upstream, so revert to that repo.
