### PR TITLE
Cleanup the recipe for rbenv

### DIFF
--- a/recipes/rbenv.rcp
+++ b/recipes/rbenv.rcp
@@ -1,7 +1,5 @@
 (:name rbenv
        :description "Emacs integration for rbenv"
        :type github
-       :features rbenv
        :pkgname "senny/rbenv.el"
-       :compile "rbenv.el"
-       :post-init (rbenv-use-global))
+       :compile "rbenv.el")


### PR DESCRIPTION
Remove unneeded `:features` as autoloads will handle any needed
functionality.  Remove the `:post-init` as there isn't a general default
that works for everyone.
