### PR TITLE
avoid many package-refresh-contents via let-bind

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -829,21 +829,8 @@ itself.")
   (when (or no-prompt
             (yes-or-no-p
              "Do you really want to update all installed packages? "))
-    ;; The let and flet forms here ensure that
-    ;; `package-refresh-contents' is only called once, regardless of
-    ;; how many ELPA-type packages need to be installed. Without this,
-    ;; a refresh would happen for every ELPA package, which is totally
-    ;; unnecessary when updating them all at once.
-    (let ((refreshed nil)
-          (orig-package-refresh-contents
-           (ignore-errors (symbol-function 'package-refresh-contents))))
-      (flet ((package-refresh-contents
-              (&rest args)
-              (unless refreshed
-                (apply orig-package-refresh-contents args)
-                (setq refreshed t))))
-        ;; This is the only line that really matters
-        (mapc 'el-get-update (el-get-list-package-names-with-status "installed"))))))
+    (let ((el-get-elpa-do-refresh 'once))
+      (mapc 'el-get-update (el-get-list-package-names-with-status "installed")))))
 
 ;;;###autoload
 (defun el-get-update-packages-of-type (type)

--- a/methods/el-get-elpa.el
+++ b/methods/el-get-elpa.el
@@ -133,11 +133,21 @@ the recipe, then return nil."
       (version-list-< installed-version
                       (funcall pkg-version available-package)))))
 
+(defvar el-get-elpa-do-refresh t
+  "Whether to call `package-refresh-contents' during `el-get-elpa-update'.
+
+Let-bind this variable to `once' around many `el-get-elpa-update'
+calls to ensure `package-refresh-contents' is only called the
+first time.")
+
 (defun el-get-elpa-update (package url post-update-fun)
   "Ask elpa to update given PACKAGE."
   (unless package--initialized
     (package-initialize t))
-  (package-refresh-contents)
+  (when el-get-elpa-do-refresh
+   (package-refresh-contents)
+   (when (eq el-get-elpa-do-refresh 'once)
+     (setq el-get-elpa-do-refresh nil)))
   (when (el-get-elpa-update-available-p package)
     (el-get-elpa-remove package url nil)
     (package-install (el-get-as-symbol package)))


### PR DESCRIPTION
Previous flet hack is not needed since package-refresh-contents calls
are performed by code that is under our control, namely
el-get-elpa-update.

see also discussion in #1636.
