### PR TITLE
recipes: Update cmake-mode recipe.

### DIFF
--- a/recipes/cmake-mode.rcp
+++ b/recipes/cmake-mode.rcp
@@ -1,9 +1,5 @@
 (:name cmake-mode
-       :website "http://www.itk.org/Wiki/CMake_Editors_Support"
+       :website "http://www.itk.org/Wiki/CMake/Editors/Emacs"
        :description "Provides syntax highlighting and indentation for CMakeLists.txt and *.cmake source files."
        :type http
-       :url "http://www.cmake.org/CMakeDocs/cmake-mode.el"
-       :before (progn
-                 (autoload 'cmake-mode "cmake-mode" "Major mode for editing CMake listfiles.")
-                 (add-to-list 'auto-mode-alist '("CMakeLists\\.txt\\'" . cmake-mode))
-                 (add-to-list 'auto-mode-alist '("\\.cmake\\'" . cmake-mode))))
+       :url "http://cmake.org/gitweb?p=cmake.git;a=blob_plain;hb=master;f=Auxiliary/cmake-mode.el")


### PR DESCRIPTION
`cmake-mode.el` is now hosted in the cmake git and it comes with
autoloads and everything.

./test-recipe.sh output: **\* SUCCESS ../recipes/cmake-mode.rcp ***

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
