### PR TITLE
Don't build mu-cite

### DIFF
--- a/recipes/mu-cite.rcp
+++ b/recipes/mu-cite.rcp
@@ -4,5 +4,4 @@
        :type http-tar
        :options ("xzf")
        :url "http://www.jpl.org/elips/mu/snapshots/mu-cite-201202272330.tar.gz"
-       :build `(("make" ,(format "EMACS=%s" el-get-emacs)))
        :depends (apel flim))


### PR DESCRIPTION
I have issues using their build command on one of my systems and el-get will
byte-compile it anyway.
