### PR TITLE
Add recipe for thing-cmds with explicit dependency

### DIFF
--- a/recipes/thing-cmds.rcp
+++ b/recipes/thing-cmds.rcp
@@ -1,0 +1,4 @@
+(:name thing-cmds
+       :description "Commands that use things, as defined by `thingatpt.el'."
+       :type emacswiki
+       :depends (hide-comnt))


### PR DESCRIPTION
Overrides generated EmacsWiki recipe for sake of requiring hide-comnt.

Fixes #1662.
