### PR TITLE
remove deprecated dependency

### DIFF
--- a/recipes/elpy.rcp
+++ b/recipes/elpy.rcp
@@ -4,6 +4,6 @@
        :type github
        :pkgname "jorgenschaefer/elpy"
        :post-init (el-get-envpath-prepend "PYTHONPATH" default-directory)
-       :depends (auto-complete yasnippet virtualenv
+       :depends (auto-complete yasnippet
                                highlight-indentation find-file-in-project
                                idomenu iedit nose jedi rope pyvenv))


### PR DESCRIPTION
elpy no longer depends on virtualenv, and virtualenv is no longer available
