### PR TITLE
consolidate 3 zenburn recipes into 1

### DIFF
--- a/recipes/color-theme-zenburn.rcp
+++ b/recipes/color-theme-zenburn.rcp
@@ -1,7 +1,7 @@
 (:name color-theme-zenburn
-       :description "Just some alien fruit salad to keep you in the zone"
+       :description "The Zenburn colour theme ported to Emacs"
        :website "https://github.com/bbatsov/zenburn-emacs"
+       :minimum-emacs-version "24"
        :type github
        :pkgname "bbatsov/zenburn-emacs"
-       :prepare (add-to-list 'custom-theme-load-path
-                             default-directory))
+       :prepare (add-to-list 'custom-theme-load-path default-directory))

--- a/recipes/zenburn-emacs.rcp
+++ b/recipes/zenburn-emacs.rcp
@@ -1,8 +1,0 @@
-(:name zenburn-emacs
-       :description "Zenburn for Emacs is a direct port of the popular Zenburn theme for vim, developed by Jani Nurminen."
-       :website "https://github.com/bbatsov/zenburn-emacs"
-       :minimum-emacs-version "24"
-       :type github
-       :pkgname "bbatsov/zenburn-emacs"
-       :prepare (add-to-list 'custom-theme-load-path
-                             default-directory))

--- a/recipes/zenburn-theme.rcp
+++ b/recipes/zenburn-theme.rcp
@@ -1,6 +1,0 @@
-(:name zenburn-theme
-       :description "Zenburn theme for Emacs"
-       :type http
-       :url "https://raw.github.com/djcb/elisp/master/themes/zenburn-theme.el"
-       :prepare (add-to-list 'custom-theme-load-path
-                             default-directory))


### PR DESCRIPTION
zenburn-emacs.rcp referred to the same code as
color-theme-zenburn.rcp. zenburn-theme.rcp referred to a version of
zenburn that hasn't been updated for 2 years.

---

Although maybe we should keep zenburn-theme.rcp? Thoughts?
