### PR TITLE
Updated URL for pelican-mode

### DIFF
--- a/recipes/pelican-mode.rcp
+++ b/recipes/pelican-mode.rcp
@@ -1,5 +1,5 @@
 (:name pelican-mode
-       :website "https://github.com/joewreschnig/pelican-mode"
+       :website "https://github.com/emacsmirror/pelican-mode"
        :description "Emacs utilities for the pelican blogging package"
        :type github
-       :pkgname "joewreschnig/pelican-mode")
+       :pkgname "emacsmirror/pelican-mode")


### PR DESCRIPTION
Looks like the original repo for pelican-mode disappeared. Moving to the emacsmirror replication.
