### PR TITLE
guide-key recipe

### DIFF
--- a/recipes/guide-key-tip.rcp
+++ b/recipes/guide-key-tip.rcp
@@ -1,5 +1,4 @@
 (:name guide-key-tip
-       :website "https://github.com/aki2o/guide-key-tip"
        :description "Interface of guide-key.el using pos-tip.el"
        :type github
        :pkgname "aki2o/guide-key-tip"

--- a/recipes/guide-key.rcp
+++ b/recipes/guide-key.rcp
@@ -1,0 +1,5 @@
+(:name guide-key
+       :description "Guide the following key bindings automatically and dynamically."
+       :type github
+       :pkgname "kbkbkbkb1/guide-key"
+       :depends (popwin))


### PR DESCRIPTION
guide-key-tip depends on guide-key but we did not have a recipe for it.
I also removed the website from guide-key-tip as it is a github recipe.
