### PR TITLE
Fix qml-mode receipe

### DIFF
--- a/recipes/qml-mode.rcp
+++ b/recipes/qml-mode.rcp
@@ -1,5 +1,4 @@
 (:name qml-mode
-       :website "https://github.com/cataska/qml-mode"
        :description "Qt Declarative UI (QML) mode for Emacs"
        :type github
        :pkgname "cataska/qml-mode"


### PR DESCRIPTION
This fixes the installation. Otherwise el-get tries to clone with the https URL, which asks for a password.
