### PR TITLE
folding.rcp: upstream moved to github

### DIFF
--- a/recipes/folding.rcp
+++ b/recipes/folding.rcp
@@ -1,7 +1,6 @@
 (:name folding
        :description "A folding-editor-like minor mode."
-       :type http
-       :url "http://git.savannah.gnu.org/cgit/emacs-tiny-tools.git/plain/lisp/other/folding.el?h=devel"
-       :localname "folding.el"
-       :features (folding folding-isearch)
-       :post-init (folding-mode-add-find-file-hook))
+       :type github
+       :pkgname "jaalto/project-emacs--folding-mode"
+       :compile "\\.el$" ; ignore epackage/ subdir
+       :prepare (folding-mode-add-find-file-hook))


### PR DESCRIPTION
also remove needless :features, set hooks in :prepare to support lazy
mode.

fixes #1711
