### PR TITLE
Add org-present recipe

### DIFF
--- a/recipes/org-present.rcp
+++ b/recipes/org-present.rcp
@@ -1,5 +1,4 @@
 (:name org-present
-       :website "https://github.com/rlister/org-present"
        :description "Ultra-minimalist presentation minor-mode for Emacs org-mode"
        :type github
        :pkgname "rlister/org-present")


### PR DESCRIPTION
Add recipe for org-present, a Ultra-minimalist presentation minor-mode for Emacs org-mode  (https://github.com/rlister/org-present)
