### PR TITLE
Make ProofGeneral.rcp work with Emacs >= 24.2. on OS X

### DIFF
--- a/recipes/ProofGeneral.rcp
+++ b/recipes/ProofGeneral.rcp
@@ -5,6 +5,6 @@
        :options ("xzf")
        :url "http://proofgeneral.inf.ed.ac.uk/releases/ProofGeneral-4.2.tgz"
        :build ("cd ProofGeneral && make clean" "cd ProofGeneral && sed -i 's/setq byte-compile-error-on-warn t//' Makefile && make compile")
-       :build/darwin `("cd ProofGeneral && make clean" ,(concat "cd ProofGeneral && make compile EMACS=" el-get-emacs))
+       :build/darwin `("cd ProofGeneral && make clean" ,(concat "cd ProofGeneral && sed -i 's/setq byte-compile-error-on-warn t//' Makefile && make compile EMACS=" el-get-emacs))
        :load  ("ProofGeneral/generic/proof-site.el")
        :info "./ProofGeneral/doc/")


### PR DESCRIPTION
See [this commit](https://github.com/dimitri/el-get/commit/9b09e5d4876a2536f05cb2459ea272549ba59f92#diff-8825f5390c141818253b79c59f5c496c).
the commit makes ProofGeneral.rcp work with Emacs >= 24.2. but, it doesn't support OS X.
