### PR TITLE
Add recipe for abc-mode (hosted at GitHub)

### DIFF
--- a/recipes/abc-mode.rcp
+++ b/recipes/abc-mode.rcp
@@ -1,0 +1,5 @@
+(:name abc-mode
+       :description "Major mode for editing abc music files"
+       :website "https://github.com/mkjunker/abc-mode"
+       :type github
+       :pkgname "mkjunker/abc-mode")


### PR DESCRIPTION
This is an improved recipe over the one I proposed in my previous pull request (#1738).  It uses the GitHub repository for abc-mode. Thanks to [David Holm](https://github.com/dholm) for noticing this.
