### PR TITLE
Add recipe for scroll-in-place

### DIFF
--- a/recipes/scroll-in-place.rcp
+++ b/recipes/scroll-in-place.rcp
@@ -1,0 +1,7 @@
+(:name scroll-in-place
+       :description "Improved vertical scrolling commands"
+       :website "http://www.cs.utah.edu/~eeide/emacs/"
+       :type http
+       :url "http://www.cs.utah.edu/~eeide/emacs/scroll-in-place.el.gz"
+       :prepare (defalias 'screen-width 'display-pixel-width)
+       :features scroll-in-place)


### PR DESCRIPTION
This is a recipe for a quite old file (last updated in 1994), but I think that it is still very useful and I am not aware of another package that implements the same feature.  The :prepare section is necessary, because the scree-width function is not defined in Emacs 24.
