### PR TITLE
Add recipe for eimp

### DIFF
--- a/recipes/eimp.rcp
+++ b/recipes/eimp.rcp
@@ -1,0 +1,6 @@
+(:name eimp
+       :description "Emacs Image Manipulation Package"
+       :website "https://mph-emacs-pkgs.alioth.debian.org/EimpEl.html"
+       :type http
+       :url "https://alioth.debian.org/scm/viewvc.php/*checkout*/mph-emacs-pkgs/elisp/eimp.el?root=mph-emacs-pkgs"
+       :localname "eimp.el")


### PR DESCRIPTION
If this recipe, I find useful to add the following in my personal el-get initialization code:

``` elisp
(:name eimp
       :before (add-hook 'image-mode-hook 'eimp-mode)
```

I thought about putting the above in the :prepare section of the recipe, but this might be too intrusive.
