### PR TITLE
Remove whitespace variables from .dir-locals.el

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -3,19 +3,6 @@
 
 ((nil
   (sentence-end-double-space . t)
-  (require-final-newline . t)
   (indent-tabs-mode))
  (emacs-lisp-mode
-  (byte-compile-warnings . (not cl-functions))
-  (whitespace-style face trailing lines-tail)
-  (whitespace-line-column . 80)
-  (eval ignore-errors
-        "Write-contents-functions is a buffer-local alternative to before-save-hook"
-        (add-hook 'write-contents-functions
-                  (lambda ()
-                    (delete-trailing-whitespace)
-                    nil))
-        (require 'whitespace)
-        "Sometimes the mode needs to be toggled off and on."
-        (whitespace-mode 0)
-        (whitespace-mode 1))))
+  (byte-compile-warnings . (not cl-functions))))

--- a/test/run-travis-ci.sh
+++ b/test/run-travis-ci.sh
@@ -12,6 +12,14 @@ if [ "$EMACS" = emacs ] ; then # only run this for 1 emacs version
      $EMACS -Q -L . -batch -l el-get-recipes -f el-get-check-recipe-batch \
          -Wno-features -Wno-github -Wno-autoloads \
          recipes/
+
+     if [ -z "$TRAVIS_COMMIT_RANGE" ] ; then
+         # Contrary to http://docs.travis-ci.com/user/ci-environment,
+         # $TRAVIS_COMMIT_RANGE is not defined for pull requests.
+         # See https://github.com/travis-ci/travis-ci/issues/1719
+         TRAVIS_COMMIT_RANGE=$TRAVIS_BRANCH..FETCH_HEAD
+     fi
+     git --no-pager -c core.whitespace=tab-in-indent diff --check "$TRAVIS_COMMIT_RANGE"
 fi
 
 # TODO: actually run some tests


### PR DESCRIPTION
The overriding whitespace-style had the annoying effect of hiding tabs
in whitespace-mode. Furthermore, when testing with emacs -Q, it was
triggering the unsafe local variable warning.

To compensate for removing whitespace handling from emacs, add a
whitespace check into the travis test.

---

I hope it's okay to get rid of these? It's really been annoying me for a while now.
