### PR TITLE
New function, el-get-add-load-path-to-ffsp

### DIFF
--- a/el-get-custom.el
+++ b/el-get-custom.el
@@ -58,6 +58,14 @@ Each hook is a unary function accepting a package"
   :group 'el-get
   :type 'hook)
 
+(defvar find-function-source-path)
+(defun el-get-add-load-path-to-ffsp (package)
+  "Adds a package's :load-path to `find-function-source-path'.
+Can be added to `el-get-post-init-hooks'."
+  (setq find-function-source-path
+        (append (el-get-load-path package)
+                (bound-and-true-p find-function-source-path))))
+
 (defcustom el-get-post-install-hooks nil
   "Hooks to run after installing a package.
 Each hook is a unary function accepting a package"


### PR DESCRIPTION
`(add-hook 'el-get-post-init-hooks 'el-get-add-load-path-to-ffsp)` will ensure
find-function-source-path has all of el-get's load paths.

---

replaces/ closes #1476, closes #1167.
