### PR TITLE
Fixes for ELPA support

### DIFF
--- a/methods/el-get-elpa.el
+++ b/methods/el-get-elpa.el
@@ -194,10 +194,13 @@ first time.")
 
 (defun el-get-elpa-post-remove (package)
   "Do remove the ELPA bits for package, now"
-  (let ((p-elpa-dir (el-get-elpa-package-directory package)))
-    (if p-elpa-dir
-        (dired-delete-file p-elpa-dir 'always)
-      (message "el-get: could not find ELPA dir for %s." package))))
+  (let* ((pkg (el-get-as-symbol package))
+         (pkg-descs (cdr (assq pkg package-alist))))
+    (dolist (pkg-desc pkg-descs)
+      (with-no-warnings
+        (if (version< emacs-version "24.4")
+            (package-delete pkg (package-desc-version pkg-desc))
+          (package-delete pkg-desc))))))
 
 (add-hook 'el-get-elpa-remove-hook 'el-get-elpa-post-remove)
 


### PR DESCRIPTION
The biggest issue is that `el-get-elpa-post-remove` only deletes the package directory.  But it won't remove the package from the `package-alist` which causes package.el to still consider the package installed and thus subsequent attempts to reinstall the package will fail.  The patch changes the function to use `package-delete` instead.

Minor issues I had: `el-get-elpa-package-directory` should check if the elpa directory exists.  On a fresh install `~/.emacs.d/elpa/` might not yet exist and this prevented package installation completely since the directory is queried before install is called.  The patch also changes the function to consider packages in the global directories `package-directory-list`.

While debugging the major issue I also ran into trouble with `el-get-elpa-symlink-package` causing an error in `file-relative-name`.  I changed it to provide a better error message.
