### PR TITLE
Don't cache http checksums.

### DIFF
--- a/methods/el-get-http.el
+++ b/methods/el-get-http.el
@@ -21,9 +21,6 @@
   :group 'el-get
   :type 'hook)
 
-(defvar el-get-http-checksums (make-hash-table)
-  "Hash table for storing downloaded SHA1 checksums.")
-
 (defun el-get-filename-from-url (url)
   "return a suitable filename from given url
 
@@ -38,8 +35,6 @@ Test url: http://repo.or.cz/w/ShellArchive.git?a=blob_plain;hb=HEAD;f=ack.el"
                              url (car (cdr err)) (cdr (cdr err))))))
   (let* ((pdir   (el-get-package-directory package))
          (dest   (or dest (format "%s%s.el" (file-name-as-directory pdir) package)))
-         (part   (concat dest ".part"))
-         (el-get-sources (if sources sources el-get-sources))
          (buffer-file-coding-system 'no-conversion)
          (require-final-newline nil))
     ;; prune HTTP headers before save
@@ -47,12 +42,8 @@ Test url: http://repo.or.cz/w/ShellArchive.git?a=blob_plain;hb=HEAD;f=ack.el"
     (or (re-search-forward "\r?\n\r?\n" nil t)
         (error (format "Failed to find end of headers in HTTP response from %s for package %s; see buffer %s"
                        url package (buffer-name))))
-    (write-region (point) (point-max) part)
-    (puthash package (sha1 (current-buffer)) el-get-http-checksums)
-    (when (file-exists-p dest)
-      (delete-file dest))
-    (rename-file part dest)
-    (message "Wrote %s" dest)
+    (delete-region (point-min) (point))
+    (write-file dest)
     (kill-buffer))
   (funcall post-install-fun package))
 
@@ -83,16 +74,10 @@ into the package :localname option or its `file-name-nondirectory' part."
          nil package url post-install-fun dest el-get-sources)))))
 
 (defun el-get-http-compute-checksum (package &optional url)
-  "Look up download time SHA1 of PACKAGE."
-  (let ((checksum (gethash package el-get-http-checksums)))
-    (unless checksum
-      ;; compute the checksum
-      (setq checksum
-            (with-temp-buffer
-              (insert-file-contents-literally (el-get-http-dest-filename package url))
-              (sha1 (current-buffer))))
-      (puthash package checksum el-get-http-checksums))
-    checksum))
+  "Compute SHA1 of PACKAGE."
+  (with-temp-buffer
+    (insert-file-contents-literally (el-get-http-dest-filename package url))
+    (sha1 (current-buffer))))
 
 (defun el-get-http-guess-website (package)
   (plist-get (el-get-package-def package) :url))

--- a/test/el-get-issue-1752.el
+++ b/test/el-get-issue-1752.el
@@ -1,0 +1,8 @@
+(setq
+ el-get-sources
+ '((:name el-get-install
+          :type http
+          :url "https://github.com/dimitri/el-get/raw/master/el-get-install.el"
+          :checksum "b3a5ada02e27597894210fa1ae2c857579a457ae")))
+
+(el-get 'sync 'el-get-install)


### PR DESCRIPTION
- If the file was changed on the HTTP server before you restarted emacs, the
  checksum wouldn't be recomputed because it would be taken from the
  cache.
- The cached value was wrongly including the HTTP headers in the
  computation. Added a test for this.
- Computing a SHA1 is not so expensive that it needs the complication of
  caching.

fixes #1752
