### PR TITLE
Rename el-get-(generate -> use)-autoloads

### DIFF
--- a/el-get-autoloads.el
+++ b/el-get-autoloads.el
@@ -42,7 +42,7 @@
 
 (defun el-get-eval-autoloads ()
   "Evaluate the autoloads from the autoload file."
-  (when (and el-get-generate-autoloads
+  (when (and el-get-use-autoloads
              (file-exists-p el-get-autoload-file))
     (el-get-verbose-message "el-get: evaluating autoload file")
     (el-get-load-fast el-get-autoload-file)))

--- a/el-get-custom.el
+++ b/el-get-custom.el
@@ -109,8 +109,10 @@ directly."
   :group 'el-get
   :type 'boolean)
 
-(defcustom el-get-generate-autoloads t
-  "Whether or not to generate autoloads for packages. Can be used
+(define-obsolete-variable-alias 'el-get-generate-autoloads 'el-get-use-autoloads
+  "June, 2014")
+(defcustom el-get-use-autoloads t
+  "Whether or not to use the generated autoloads for packages. Can be used
 to disable autoloads globally."
   :group 'el-get
   :type 'boolean)

--- a/test/caching-speedtest.el
+++ b/test/caching-speedtest.el
@@ -23,7 +23,7 @@
       el-get-verbose t
       el-get-default-process-sync t
       el-get-notify-type 'message
-      el-get-generate-autoloads nil
+      el-get-use-autoloads nil
       el-get-byte-compile nil
       repetitions 50
       el-get-sources


### PR DESCRIPTION
This reflects what the variable actually does.

See https://github.com/dimitri/el-get/pull/1385#issuecomment-25770253
