### PR TITLE
Remove inf-ruby-bond recipe.

### DIFF
--- a/recipes/inf-ruby-bond.rcp
+++ b/recipes/inf-ruby-bond.rcp
@@ -1,6 +1,0 @@
-(:name inf-ruby-bond
-       :description "Use Bond autocompletion from inf-ruby buffers"
-       :type github
-       :pkgname "pd/inf-ruby-bond"
-       :depends inf-ruby
-       :features inf-ruby-bond)


### PR DESCRIPTION
This package has been deprecated. Check
https://github.com/pd/inf-ruby-bond.
