### PR TITLE
Update structured-haskell-mode.rcp

### DIFF
--- a/recipes/structured-haskell-mode.rcp
+++ b/recipes/structured-haskell-mode.rcp
@@ -4,5 +4,4 @@
        :pkgname "chrisdone/structured-haskell-mode"
        :depends (haskell-mode)
        :build `(("cabal" "install"))
-       :features shm
        :load-path "elisp")


### PR DESCRIPTION
- structured-haskell-mode provides the feature "shm" (presumably because
  "structured-haskell-mode" is too long a name)
- Running `cabal configure` right before `cabal install` is fruitless
  and can actually fail even when `cabal install` would succeed.  See
  http://ircbrowse.net/day/haskell/2014/06/02?id=18252351&timestamp=1401731943#t1401731943 .
