### PR TITLE
Add javadoc-lookup recipe

### DIFF
--- a/recipes/javadoc-lookup.rcp
+++ b/recipes/javadoc-lookup.rcp
@@ -1,0 +1,5 @@
+(:name javadoc-lookup
+       :website "https://github.com/skeeto/javadoc-lookup"
+       :description "Quickly look up Javadoc in Emacs."
+       :type github
+       :pkgname "skeeto/javadoc-lookup")


### PR DESCRIPTION
Description from its website:

> This package provides a javadoc-lookup function for quickly looking up Javadoc for any library from within Emacs, optionally integrating with Maven. A browser is launched to view the documentation.
