### PR TITLE
Adding recipe for rtags, c/c++ tags package

### DIFF
--- a/recipes/rtags.rcp
+++ b/recipes/rtags.rcp
@@ -1,0 +1,10 @@
+(:name rtags
+       :description "Client/server application that indexes C/C++ code and keeps a persistent in-memory database of references, declarations, definitions, symbolnames"
+       :type github
+       :website "https://github.com/Andersbakken/rtags"
+       :pkgname "Andersbakken/rtags"
+       :build `(("cmake" ".")
+                ("make" ,@el-get-parallel-make-args))
+       :compile "src"
+       :load-path "src"
+       :post-init (setq rtags-path default-directory))


### PR DESCRIPTION
- Requires clang to be installed on the computer
- Requires the user to be running a specific daemon
  which is built with the :build() commands provided
  in the recipe

Output of el-get-check-recipe:
/home/lefteris/.emacs.d/el-get/el-get/recipes/rtags.rcp: 0 error(s) found.
