### PR TITLE
Read all recipes fixes

### DIFF
--- a/el-get-recipes.el
+++ b/el-get-recipes.el
@@ -122,6 +122,14 @@ Used to avoid errors when exploring the path for recipes"
         (el-get-read-recipe-file filename)
       (error "El-get can not find a recipe for package \"%s\"" package))))
 
+(defun el-get-all-recipe-file-names ()
+  "Return the list of all file based recipe names.
+
+The result may have duplicates."
+  (loop for dir in (el-get-recipe-dirs)
+        nconc (mapcar #'file-name-base
+                      (directory-files dir nil "^[^.].*\.\\(rcp\\|el\\)$"))))
+
 (defun el-get-read-all-recipe-files ()
   "Return the list of all file based recipes, formated like `el-get-sources'.
 

--- a/el-get.el
+++ b/el-get.el
@@ -221,7 +221,8 @@
 
 This is useful to use for providing completion candidates for
 package names."
-  (mapcar 'el-get-source-name (el-get-read-all-recipes)))
+  (delete-dups (append (mapcar #'el-get-source-name el-get-sources)
+                       (el-get-all-recipe-file-names))))
 
 (defun el-get-error-unless-package-p (package)
   "Raise an error if PACKAGE does not name a package that has a valid recipe."


### PR DESCRIPTION
Make package list use merged recipe definitions

el-get-list-packages wasn't showing descriptions when a partial recipe
in el-get-sources didn't have a :description field.

fixes #1797

---

Optimize el-get-read-all-recipe-names

This function is used to create completion candidates, so its slowness
is quite noticable. The main cause of slowness was the reading of all
the recipe files which can be avoided because the file name gives the
recipe name.
