### PR TITLE
magit-tramp/org-magit:  Change upstream to magit.

### DIFF
--- a/recipes/magit-tramp.rcp
+++ b/recipes/magit-tramp.rcp
@@ -1,5 +1,5 @@
 (:name magit-tramp
        :description "Git method for Emacs Tramp"
        :type github
-       :pkgname "sigma/magit-tramp"
+       :pkgname "magit/magit-tramp"
        :depends (magit))

--- a/recipes/org-magit.rcp
+++ b/recipes/org-magit.rcp
@@ -2,4 +2,4 @@
        :depends magit
        :type github
        :description "Link to magit from org documents."
-       :pkgname "sigma/org-magit")
+       :pkgname "magit/org-magit")


### PR DESCRIPTION
Both packages seem to be maintained by the magit team now.
