### PR TITLE
lua-mode: add ample-regexps dep, change type to github

### DIFF
--- a/recipes/lua-mode.rcp
+++ b/recipes/lua-mode.rcp
@@ -1,5 +1,5 @@
 (:name lua-mode
        :description "A major-mode for editing Lua scripts"
-       :website "https://github.com/immerrr/lua-mode"
-       :type git
-       :url "https://github.com/immerrr/lua-mode")
+       :depends (ample-regexps)
+       :type github
+       :pkgname "immerrr/lua-mode")


### PR DESCRIPTION
I'm going to add `ample-regexps` library as a dependency to `lua-mode`, so I
think I have to update the recipe beforehand.
