### PR TITLE
Update o-blog recipe to honor v2 source layout.

### DIFF
--- a/recipes/o-blog.rcp
+++ b/recipes/o-blog.rcp
@@ -1,5 +1,6 @@
 (:name o-blog
        :type github
        :description "Stand alone org-mode blog exporter."
+       :load-path ("lisp")
        :pkgname "renard/o-blog"
        :depends htmlize)


### PR DESCRIPTION
el-get-check-recipe output:
~/.emacs.d/el-get/el-get/recipes/o-blog.rcp: 0 error(s) found.

fixes #1806
