### PR TITLE
Disable edts autoload

### DIFF
--- a/recipes/edts.rcp
+++ b/recipes/edts.rcp
@@ -2,4 +2,5 @@
        :description "Erlang Development Tool Suite."
        :type github
        :pkgname "tjarvstrand/edts"
-       :build ("make"))
+       :build ("make")
+       :autoloads nil)


### PR DESCRIPTION
The generated autoload file requires `f-join`, but it cannot be found.

We can use `(require 'edts-start)` instead of autoload.
