### PR TITLE
always set hooks in :prepare, not :post-init

### DIFF
--- a/recipes/ensime.rcp
+++ b/recipes/ensime.rcp
@@ -3,6 +3,6 @@
        :type github
        :pkgname "ensime/ensime-emacs"
        :depends (s dash popup auto-complete scala-mode2)
-       :post-init (progn
-                    (autoload 'ensime-scala-mode-hook "ensime")
-                    (add-hook 'scala-mode-hook 'ensime-scala-mode-hook)))
+       :prepare (progn
+                  (autoload 'ensime-scala-mode-hook "ensime")
+                  (add-hook 'scala-mode-hook 'ensime-scala-mode-hook)))

--- a/recipes/flycheck-d-unittest.rcp
+++ b/recipes/flycheck-d-unittest.rcp
@@ -3,5 +3,5 @@
        :type github
        :pkgname "flycheck/flycheck-d-unittest"
        :depends (flycheck dash)
-       :post-init (eval-after-load 'flycheck
-                    '(add-hook 'flycheck-mode-hook #'setup-flycheck-d-unittest)))
+       :prepare (eval-after-load 'flycheck
+                  '(add-hook 'flycheck-mode-hook #'setup-flycheck-d-unittest)))

--- a/recipes/flycheck-haskell.rcp
+++ b/recipes/flycheck-haskell.rcp
@@ -3,5 +3,5 @@
        :type github
        :pkgname "flycheck/flycheck-haskell"
        :depends (flycheck haskell-mode dash f)
-       :post-init (eval-after-load 'flycheck
-                    '(add-hook 'flycheck-mode-hook #'flycheck-haskell-setup)))
+       :prepare (eval-after-load 'flycheck
+                  '(add-hook 'flycheck-mode-hook #'flycheck-haskell-setup)))

--- a/recipes/flycheck-hdevtools.rcp
+++ b/recipes/flycheck-hdevtools.rcp
@@ -3,5 +3,5 @@
        :pkgname "flycheck/flycheck-hdevtools"
        :description "A Flycheck checker for Haskell using hdevtools"
        :depends (flycheck)
-       :post-init (eval-after-load 'flycheck
-                    '(require 'flycheck-hdevtools)))
+       :prepare (eval-after-load 'flycheck
+                  '(require 'flycheck-hdevtools)))

--- a/recipes/flycheck-mercury.rcp
+++ b/recipes/flycheck-mercury.rcp
@@ -3,5 +3,5 @@
        :type github
        :pkgname "flycheck/flycheck-mercury"
        :depends (flycheck s dash)
-       :post-init (eval-after-load 'flycheck
-                    '(require 'flycheck-mercury)))
+       :prepare (eval-after-load 'flycheck
+                  '(require 'flycheck-mercury)))

--- a/recipes/go-company.rcp
+++ b/recipes/go-company.rcp
@@ -4,6 +4,7 @@
        :pkgname "github.com/nsf/gocode"
        :depends (company-mode)
        :load-path ("src/github.com/nsf/gocode/emacs-company")
+       :prepare (progn
+                  (add-hook 'go-mode-hook (require 'company-go)))
        :post-init (progn
-                    (add-hook 'go-mode-hook (require 'company-go))
                     (add-to-list 'exec-path (concat default-directory "bin"))))

--- a/recipes/go-oracle.rcp
+++ b/recipes/go-oracle.rcp
@@ -3,7 +3,8 @@
        :type go
        :pkgname "code.google.com/p/go.tools/cmd/oracle"
        :load-path "src/code.google.com/p/go.tools/cmd/oracle"
+       :prepare (progn
+                  (autoload 'go-oracle-mode "oracle" nil t)
+                  (add-hook 'go-mode-hook 'go-oracle-mode))
        :post-init (progn
-                    (setq go-oracle-command (concat default-directory "bin/oracle"))
-                    (autoload 'go-oracle-mode "oracle" nil t)
-                    (add-hook 'go-mode-hook 'go-oracle-mode)))
+                    (setq go-oracle-command (concat default-directory "bin/oracle"))))


### PR DESCRIPTION
otherwise it won't help for users with `el-get-is-lazy` set to `t`.

---

I noticed a bunch of recently added or modified were calling `add-hook` and/or `eval-after-load` in `:post-init`, but since those things should take effect before the package is started it's better to put that in `:prepare`.

@dholm: I think most of the modifications/additions were yours, can you confirm these changes are sane?
