### PR TITLE
Removed rope as a dependency from elpy.rcp.

### DIFF
--- a/recipes/elpy.rcp
+++ b/recipes/elpy.rcp
@@ -5,5 +5,4 @@
        :pkgname "jorgenschaefer/elpy"
        :post-init (el-get-envpath-prepend "PYTHONPATH" default-directory)
        :depends (company-mode yasnippet highlight-indentation
-                              find-file-in-project idomenu iedit
-                              nose jedi pyvenv))
+                              find-file-in-project idomenu pyvenv))


### PR DESCRIPTION
recipes/elpy.rcp:

```
    Removed the rope dependency from elpy. The rope dependency in
    el-get includes the full rope python library. While this is very
    convenient for installing el-get packages that require the rope
    library, it poses a major problem for Python 3 users of
    elpy. Elpy is itself fully capable of working with either python
    3 or python 2, but if it is being used with python 3 it requires
    an alternative version of rope in order to function,
    rope_py3k (https://github.com/jorgenschaefer/elpy/wiki).

    Having rope as a dependency of elpy overrides whatever version
    of rope is installed on the local machine, and prevents users of
    elpy through el-get from using elpy with Python 3 without using
    a custom recipe.

    It is better to have the users install the library themselves
    locally, rather than pulling the version 2 specific one as a
    dependency. This shouldn't be an issue as elpy users already
    have to manually install many other libraries on the system to
    support the elpy frontend (such as jedi).
```
