### PR TITLE
Remove google-weather as obsolete

### DIFF
--- a/recipes/google-weather.rcp
+++ b/recipes/google-weather.rcp
@@ -1,5 +1,0 @@
-(:name google-weather
-       :description "Fetch Google Weather forecasts."
-       :type git
-       :url "git://git.naquadah.org/google-weather-el.git"
-       :features (google-weather org-google-weather))


### PR DESCRIPTION
The Google Weather API has been shutdown in 2012 and therefore package doesn't work anymore.

https://julien.danjou.info/projects/emacs-packages#google-weather

yandex-weather package can be used instead of google-weather.
