### PR TITLE
[cisco-router-mode] generate autoload instead of requiring package

### DIFF
--- a/recipes/cisco-router-mode.rcp
+++ b/recipes/cisco-router-mode.rcp
@@ -1,4 +1,8 @@
 (:name cisco-router-mode
        :description "Major mode for editing Cisco router configuration files"
        :type emacswiki
-       :features cisco-router-mode)
+       :prepare
+       (progn
+         (autoload 'cisco-router-mode "cisco-router-mode"
+           "Major mode for editing Cisco router configuration files"
+           t)))


### PR DESCRIPTION
el-get-check-recipe output:

~/.emacs.d/el-get/el-get/recipes/cisco-router-mode.rcp: 0 error(s) found.
