### PR TITLE
git-timemachine no longer requires Emacs 24.4

### DIFF
--- a/recipes/git-timemachine.rcp
+++ b/recipes/git-timemachine.rcp
@@ -1,5 +1,5 @@
 (:name git-timemachine
        :description "Step through historic versions of git controlled file using everyone's favourite editor"
        :type github
-       :minimum-emacs-version "24.4" ;; Depends on `subr-x'.
+       :minimum-emacs-version "24"
        :pkgname "pidu/git-timemachine")


### PR DESCRIPTION
Requirement of 24.4 was dropped with pidu/git-timemachine#3
