### PR TITLE
prodigy needs f.el

### DIFF
--- a/recipes/prodigy.rcp
+++ b/recipes/prodigy.rcp
@@ -3,4 +3,4 @@
        :website "https://github.com/rejeep/prodigy.el"
        :type github
        :pkgname "rejeep/prodigy.el"
-       :depends (f))
+       :depends (f s dash))


### PR DESCRIPTION
Got an error when loading prodigy

> File error: Cannot open load file, no such file or directory,  f

But this problem is solved after I require f manually.
I guess f.el is not part of default installed package of emacs? 
(My emacs is compiled from source)
If true, then prodigy.rcp needs a new depends.

P.S. Prodigy is a control panel for programs which execute in the background.
Thank you!
