### PR TITLE
Update rope.rcp

### DIFF
--- a/recipes/rope.rcp
+++ b/recipes/rope.rcp
@@ -3,5 +3,5 @@
        :post-init
        ;; Add to PYTHONPATH directly as it is used in ropemacs and traad
        (el-get-envpath-prepend "PYTHONPATH" default-directory)
-       :type hg
-       :url "http://bitbucket.org/agr/rope")
+       :type git
+       :url "https://github.com/python-rope/rope.git")


### PR DESCRIPTION
The repository "rope" has been deleted.
It now lives at https://github.com/python-rope/rope.
