### PR TITLE
URL of ropemacs and ropemode

### DIFF
--- a/recipes/ropemacs.rcp
+++ b/recipes/ropemacs.rcp
@@ -5,5 +5,5 @@
          (unless (boundp 'pymacs-load-path) (setq pymacs-load-path nil))
          (add-to-list 'pymacs-load-path default-directory))
        :depends (rope ropemode)
-       :type hg
-       :url "http://bitbucket.org/agr/ropemacs")
+       :type git
+       :url "https://github.com/python-rope/ropemacs")

--- a/recipes/ropemode.rcp
+++ b/recipes/ropemode.rcp
@@ -4,5 +4,5 @@
        (progn
          (unless (boundp 'pymacs-load-path) (setq pymacs-load-path nil))
          (add-to-list 'pymacs-load-path default-directory))
-       :type hg
-       :url "http://bitbucket.org/agr/ropemode")
+       :type git
+       :url "https://github.com/python-rope/ropemode")


### PR DESCRIPTION
The repository url of repemacs and ropemode have changed. They both have been
moved to git.
