### PR TITLE
removed solarized-theme -- duplicate of color-theme-solarized

### DIFF
--- a/recipes/solarized-theme.rcp
+++ b/recipes/solarized-theme.rcp
@@ -1,5 +1,0 @@
-(:name solarized-theme
-       :type github
-       :pkgname "sellout/emacs-color-theme-solarized"
-       :description "Solarized themes for Emacs"
-       :prepare (add-to-list 'custom-theme-load-path default-directory))


### PR DESCRIPTION
`color-theme-solarized` is more complete than `solarized-theme`, so I've chosen to remove the latter.
