### PR TITLE
nix-mode.rcp: :prepare no longer needed.

### DIFF
--- a/recipes/nix-mode.rcp
+++ b/recipes/nix-mode.rcp
@@ -1,7 +1,4 @@
 (:name nix-mode
        :type http
        :url "https://raw.github.com/NixOS/nix/master/misc/emacs/nix-mode.el"
-       :description "Major mode for editing Nix expressions"
-       :prepare (progn
-                  (autoload 'nix-mode "nix-mode" nil t)
-                  (add-to-list 'auto-mode-alist '("\\.nix$" . nix-mode))))
+       :description "Major mode for editing Nix expressions")


### PR DESCRIPTION
Nix-mode now has proper autoload cookies for `nix-mode` and
`auto-mode-alist`.
