### PR TITLE
Add recipe for the deftheme version of darkmine

### DIFF
--- a/recipes/darkmine-theme.rcp
+++ b/recipes/darkmine-theme.rcp
@@ -1,0 +1,7 @@
+(:name darkmine-theme
+       :description "Yet another emacs dark color theme"
+       :type github
+       :pkgname "pierre-lecocq/darkmine-theme"
+       :minimum-emacs-version 24
+       :prepare (add-to-list 'custom-theme-load-path
+                             default-directory))


### PR DESCRIPTION
Hi,

I rewrote the color theme for Emacs24, therefore, here the recipe of the new version.
For the moment, I won't remove the "color-theme" version. Once it is obsolete, I will remove the corresponding recipe (except if you prefer to get only one version).

Thanks
