### PR TITLE
Fix a bug where el-get-github-clone used the wrong URL.

### DIFF
--- a/methods/el-get-github.el
+++ b/methods/el-get-github.el
@@ -80,10 +80,9 @@ USERNAME and REPONAME are strings."
 
 (defun el-get-github-clone (package url post-install-fun)
   "Clone the given package from Github following the URL."
-  (el-get-insecure-check package url)
-  (el-get-git-clone package
-                    (or url (el-get-github-url package))
-                    post-install-fun))
+  (let ((url (or url (el-get-github-url package))))
+    (el-get-insecure-check package url)
+    (el-get-git-clone package url post-install-fun)))
 
 (defun el-get-github-guess-website (package)
   (let* ((user-and-repo (el-get-github-parse-user-and-repo package))


### PR DESCRIPTION
Missed a case where url in `el-get-github-clone` can be nil.
