### PR TITLE
Add :load clause for "filladapt"

### DIFF
--- a/recipes/filladapt.rcp
+++ b/recipes/filladapt.rcp
@@ -1,4 +1,5 @@
 (:name filladapt
        :description "Filladapt enhances the behavior of Emacs' fill functions by guessing the proper fill prefix in many contexts. Emacs has a built-in adaptive fill mode but Filladapt is much better."
        :type http
-       :url "http://www.wonderworks.com/download/filladapt.el")
+       :url "http://www.wonderworks.com/download/filladapt.el"
+       :load "filladapt.el")


### PR DESCRIPTION
Without this, one is stuck loading filladapt manually.  In the comments,
filladapt.el states:

```
    ;; Since this package replaces existing Emacs functions, it cannot
    ;; be autoloaded.  Save this in a file named filladapt.el in a
    ;; Lisp directory that Emacs knows about, byte-compile it and put
    ;;    (require 'filladapt)
    ;; in your .emacs file.
```

Closes #1876
