### PR TITLE
add org-mode dependency to org2blog

### DIFF
--- a/recipes/org2blog.rcp
+++ b/recipes/org2blog.rcp
@@ -2,5 +2,5 @@
        :description "Blog from Org mode to wordpress"
        :type github
        :pkgname "punchagan/org2blog"
-       :depends (xml-rpc-el metaweblog)
+       :depends (xml-rpc-el metaweblog org-mode)
        :features org2blog)


### PR DESCRIPTION
This change fixes an error about a missing library, ox-html. This library is located within el-get/org-mode/lisp/ox-html.elc when I have org-mode installed (with el-get). Without org-mode, org2blog doesn't fully load.
