### PR TITLE
Add missing pymacs dependency to ropemacs recipe

### DIFF
--- a/recipes/ropemacs.rcp
+++ b/recipes/ropemacs.rcp
@@ -4,6 +4,6 @@
        (progn
          (unless (boundp 'pymacs-load-path) (setq pymacs-load-path nil))
          (add-to-list 'pymacs-load-path default-directory))
-       :depends (rope ropemode)
+       :depends (rope ropemode pymacs)
        :type git
        :url "https://github.com/python-rope/ropemacs")


### PR DESCRIPTION
It seems ropemacs won't work without installing pymacs too.
