### PR TITLE
Add growl-for-emacs recipe

### DIFF
--- a/recipes/growl-for-emacs.rcp
+++ b/recipes/growl-for-emacs.rcp
@@ -1,0 +1,5 @@
+(:name growl-for-emacs
+       :description "A simple Emacs wrapper for growlnotify that supports coalescing"
+       :type github
+       :pkgname "SkydiveMike/growl-for-emacs"
+       )


### PR DESCRIPTION
Updated version of growl.el that supports coalescing of notifications
with `-d` option of `growlnotify`.
