### PR TITLE
Use 'path-separator' for splitting/joining environment variables

### DIFF
--- a/el-get-recipes.el
+++ b/el-get-recipes.el
@@ -282,11 +282,11 @@ Use this to modify environment variable such as $PATH or $PYTHONPATH."
 
 (defun el-get-envpath-prepend-1 (paths head)
   "Return \"HEAD:PATHS\" omitting duplicates in it."
-  (let ((pplist (split-string (or paths "") ":" 'omit-nulls)))
+  (let ((pplist (split-string (or paths "") path-separator 'omit-nulls)))
     (mapconcat 'identity
                (remove-duplicates (cons head pplist)
                                   :test #'string= :from-end t)
-               ":")))
+               path-separator)))
 
 (defvar el-get-check--last-file-or-buffer nil
   "The last file-or-buffer checked.")


### PR DESCRIPTION
This is more portable than current approach, which leads to errors in
windows, since it uses ':' in drive names and ';' to separate entries in
environment variables
