### PR TITLE
Update obsolete org-trello recipe

### DIFF
--- a/recipes/org-trello.rcp
+++ b/recipes/org-trello.rcp
@@ -2,4 +2,4 @@
        :description "Org minor mode - 2-way sync org & trello"
        :type github
        :pkgname "org-trello/org-trello"
-       :depends (dash request elnode esxml s db))
+       :depends (dash s deferred request-deferred))


### PR DESCRIPTION
Hello,

I discovered that org-trello's el-get recipe was obsolete (indeed, lots of changes those last month).

Thanks.

Referencing the issue that revealed this: https://github.com/org-trello/org-trello/issues/207

Cheers,
