### PR TITLE
Fix for git shallow clones

### DIFF
--- a/test/el-get-issue-1920.el
+++ b/test/el-get-issue-1920.el
@@ -1,35 +1,35 @@
-;; Test for testing `el-get-git-shallow-clone-supported?' function
+;; Test for testing `el-get-git-shallow-clone-supported-p' function
 ;; the function detects whether shallow clone is supported for url
 
 (require 'cl-lib)
 
-;; Tests for lower level function [el-get-git-url-from-known-smart-domains]
-(cl-assert (el-get-git-shallow-clone-supported? "https://www.bitbucket.org/alfaromurillo/org-passwords.el.git"))
-(cl-assert (el-get-git-url-from-known-smart-domains "https://www.github.com/dimitri/el-get"))
-(cl-assert (el-get-git-url-from-known-smart-domains "https://bitbucket.org/alfaromurillo/org-passwords.el.git"))
-(cl-assert (el-get-git-url-from-known-smart-domains "https://github.com/dimitri/el-get"))
+;; Tests for lower level function [el-get-git-url-from-known-smart-domains-p]
+(cl-assert (el-get-git-shallow-clone-supported-p "https://www.bitbucket.org/alfaromurillo/org-passwords.el.git"))
+(cl-assert (el-get-git-url-from-known-smart-domains-p "https://www.github.com/dimitri/el-get"))
+(cl-assert (el-get-git-url-from-known-smart-domains-p "https://bitbucket.org/alfaromurillo/org-passwords.el.git"))
+(cl-assert (el-get-git-url-from-known-smart-domains-p "https://github.com/dimitri/el-get"))
 
-;; Tests for lower level function [el-get-git-is-host-smart-http]
-(cl-assert (el-get-git-is-host-smart-http "https://github.com/dimitri/el-get.git"))
-(cl-assert (el-get-git-is-host-smart-http "http://repo.or.cz/r/anything-config.git"))
-(cl-assert (not (el-get-git-is-host-smart-http "http://www.dr-qubit.org/git/undo-tree.git")))
+;; Tests for lower level function [el-get-git-is-host-smart-http-p]
+(cl-assert (el-get-git-is-host-smart-http-p "https://github.com/dimitri/el-get.git"))
+(cl-assert (el-get-git-is-host-smart-http-p "http://repo.or.cz/r/anything-config.git"))
+(cl-assert (not (el-get-git-is-host-smart-http-p "http://www.dr-qubit.org/git/undo-tree.git")))
 
 ;; Function should not fail for urls without '.git' prefix
-(cl-assert (el-get-git-is-host-smart-http "https://github.com/dimitri/el-get"))
-(cl-assert (el-get-git-is-host-smart-http "http://repo.or.cz/r/anything-config"))
-(cl-assert (not (el-get-git-is-host-smart-http "http://www.dr-qubit.org/git/undo-tree")))
+(cl-assert (el-get-git-is-host-smart-http-p "https://github.com/dimitri/el-get"))
+(cl-assert (el-get-git-is-host-smart-http-p "http://repo.or.cz/r/anything-config"))
+(cl-assert (not (el-get-git-is-host-smart-http-p "http://www.dr-qubit.org/git/undo-tree")))
 
-;; Tests for function [el-get-git-shallow-clone-supported?]
+;; Tests for function [el-get-git-shallow-clone-supported-p]
 ;; `git', `ssh' and `file' support shallow clones
-(cl-assert (el-get-git-shallow-clone-supported? "git://gitorious.org/evil/evil.git"))
-(cl-assert (el-get-git-shallow-clone-supported? "file:///opt/git/project.git"))
-(cl-assert (el-get-git-shallow-clone-supported? "ssh://some_user@some_server/some_project.git"))
+(cl-assert (el-get-git-shallow-clone-supported-p "git://gitorious.org/evil/evil.git"))
+(cl-assert (el-get-git-shallow-clone-supported-p "file:///opt/git/project.git"))
+(cl-assert (el-get-git-shallow-clone-supported-p "ssh://some_user@some_server/some_project.git"))
 
 ;; The following repos support shallow clones
-(cl-assert (el-get-git-shallow-clone-supported? "http://repo.or.cz/r/anything-config.git"))
-(cl-assert (el-get-git-shallow-clone-supported? "https://github.com/dimitri/el-get"))
-(cl-assert (el-get-git-shallow-clone-supported? "https://bitbucket.org/alfaromurillo/org-passwords.el.git"))
+(cl-assert (el-get-git-shallow-clone-supported-p "http://repo.or.cz/r/anything-config.git"))
+(cl-assert (el-get-git-shallow-clone-supported-p "https://github.com/dimitri/el-get"))
+(cl-assert (el-get-git-shallow-clone-supported-p "https://bitbucket.org/alfaromurillo/org-passwords.el.git"))
 
 ;; The following do not support shallow clones
-(cl-assert (not (el-get-git-shallow-clone-supported? "http://www.dr-qubit.org/git/undo-tree.git/")))
-(cl-assert (not (el-get-git-shallow-clone-supported? "http://michael.orlitzky.com/git/nagios-mode.git")))
+(cl-assert (not (el-get-git-shallow-clone-supported-p "http://www.dr-qubit.org/git/undo-tree.git/")))
+(cl-assert (not (el-get-git-shallow-clone-supported-p "http://michael.orlitzky.com/git/nagios-mode.git")))


### PR DESCRIPTION
This fixes the bug described in #1920. It uses a couple of approaches to check if shallow clone is supported

1) It maintains a list of known domains that support shallow clone and checks if url belongs to supported domain 
2) If the urls domain is not listed in list of known smart domains, it tries parsing response headers to detect of shallow clone is supported

Tests for new functions have also been added.

---

fixes #1920
fixes #558
