### PR TITLE
Do not depend on `url-parse` for extracting hosts from urls

### DIFF
--- a/el-get-core.el
+++ b/el-get-core.el
@@ -254,6 +254,18 @@ directory or a symlink in el-get-dir."
     (or (file-directory-p pdir)
         (file-symlink-p   pdir))))
 
+(defun el-get-url-host (url)
+  "Extract host from given URL.
+
+Earlier we used the built-in library `url-parse' to extract host. This broke
+installation of CEDET since it requires that the built-in versions of certain
+packages (one of them is `eieio') are not loaded before loading it. However
+`url-parse' depends on `auth-source' which in turn depends on `eieio' leading to
+loading of `eieio' before initializing CEDET causing CEDET's initialization to
+fail."
+  (string-match "://\\([^/:]+\\)" url)
+  (match-string-no-properties 1 url))
+
 
 ;;
 ;; el-get-reload API functions

--- a/methods/el-get-git.el
+++ b/methods/el-get-git.el
@@ -14,7 +14,6 @@
 
 (require 'el-get-core)
 (require 'el-get-recipes)
-(require 'url-parse)
 
 (defcustom el-get-git-clone-hook nil
   "Hook run after git clone."
@@ -52,7 +51,7 @@ domain in `el-get-git-known-smart-domains'
 This is needed because some domains like bitbucket support shallow clone even
 though they do not indicate this in their response headers see
 `el-get-git-is-host-smart-http-p'"
-  (let* ((host (url-host (url-generic-parse-url url)))
+  (let* ((host (el-get-url-host url))
          ;; Prepend www to domain, if it consists only of two components
          (prefix (when (= (length (split-string host "\\.")) 2)
                    "www.")))

--- a/test/el-get-issue-1939.el
+++ b/test/el-get-issue-1939.el
@@ -1,0 +1,23 @@
+;; Tests for `el-get-url-host', fix for issue #1939
+;; The function should extract host from url
+;; URLs used for test were extracted from existing recipes
+
+(require 'cl-lib)
+(require 'url-parse)
+
+(cl-assert (string= (el-get-url-host "http://os.inf.tu-dresden.de/~mp26/download/tbemail.el")
+                    (url-host (url-generic-parse-url "http://os.inf.tu-dresden.de/~mp26/download/tbemail.el"))))
+(cl-assert (string= (el-get-url-host "http://mumble.net/~campbell/emacs/paredit.el")
+                    (url-host (url-generic-parse-url "http://mumble.net/~campbell/emacs/paredit.el"))))
+(cl-assert (string= (el-get-url-host "http://repo.or.cz/r/anything-config.git")
+                    (url-host (url-generic-parse-url "http://repo.or.cz/r/anything-config.git"))))
+(cl-assert (string= (el-get-url-host "https://bitbucket.org/xemacs/edict")
+                    (url-host (url-generic-parse-url "https://bitbucket.org/xemacs/edict"))))
+(cl-assert (string= (el-get-url-host "git://gitorious.org/evil/evil.git")
+                    (url-host (url-generic-parse-url "git://gitorious.org/evil/evil.git"))))
+(cl-assert (string= (el-get-url-host "ftp://210.155.141.202/pub/morishima.net/naoto/ElScreen/elscreen-1.4.6.tar.gz")
+                    (url-host (url-generic-parse-url "ftp://210.155.141.202/pub/morishima.net/naoto/ElScreen/elscreen-1.4.6.tar.gz"))))
+(cl-assert (string= (el-get-url-host "svn://svn.forge.ocamlcore.org/svn/tuareg/trunk")
+                    (url-host (url-generic-parse-url "svn://svn.forge.ocamlcore.org/svn/tuareg/trunk"))))
+(cl-assert (string= (el-get-url-host "bzr://rudel.bzr.sourceforge.net/bzrroot/rudel/trunk")
+                    (url-host (url-generic-parse-url "bzr://rudel.bzr.sourceforge.net/bzrroot/rudel/trunk"))))


### PR DESCRIPTION
This fixes for #1939. Tests have been added to test/el-get-issue-1939.el. I wasn't really sure in which file I should put `el-get-url-host`, I put it in `el-get-core` since it maybe useful in other places as well.

@dholm You might want to test this
