### PR TITLE
Create empty dir if no apt-get dir to symlink to

### DIFF
--- a/methods/el-get-apt-get.el
+++ b/methods/el-get-apt-get.el
@@ -67,8 +67,12 @@
         (unless (file-directory-p pdir)
           (shell-command
            (concat "cd " el-get-dir " && ln -s " debdir  " " pname)))
-      (message "%s package `%s' created no elisp files!" method package)
-      (make-directory pdir t))))
+      (unless (file-directory-p pdir)
+       (lwarn '(el-get) :warning
+              "%s package `%s' created no elisp files!" method package)
+       ;; create an empty directory so we have somewhere to run
+       ;; el-get tasks like byte-compile in.
+       (make-directory pdir t)))))
 
 (defun el-get-dpkg-remove-symlink (package)
   "rm -f ~/.emacs.d/el-get/package"


### PR DESCRIPTION
Resolves #1953.

If the apt-get package doesn't contain any elisp files symlinking to the
non-existant /usr/share/emacs/site-lisp/<package> directory will leave
us with a broken link that will raise an error when we attempt to look
for autoloads, clean stale elc files and the like. In this case, simply
create an empty directory instead of a link.

```
* methods/el-get-apt-get.el (el-get-dpkg-symlink): call `make-directory'
  instead of symlink when `debdir' doesn't exist.
```
