### PR TITLE
Fix helm build problem

### DIFF
--- a/recipes/helm.rcp
+++ b/recipes/helm.rcp
@@ -2,4 +2,7 @@
        :description "Emacs incremental and narrowing framework"
        :type github
        :pkgname "emacs-helm/helm"
-       :build ("make"))
+       :build ("make")
+       ;; Windows probably doesn't have make available so we fake it.
+       :build/windows-nt (with-temp-file "helm-autoload.el"
+                           nil))


### PR DESCRIPTION
This extends/replaces/ closes #1955.

I just added some code to fake the build process, but only on Windows. On more reasonable OSes where we have make we can use the official build procedure.
