### PR TITLE
Fix melpa host name

### DIFF
--- a/methods/el-get-elpa.el
+++ b/methods/el-get-elpa.el
@@ -249,8 +249,8 @@ first time.")
           (string-match-p "marmalade-repo\\.org" repo-url))
       (concat "http://marmalade-repo.org/packages/" package))
      ((or (string= "melpa" repo-name)
-          (string-match-p "melpa.milkbox.net" repo-url))
-      (concat "http://melpa.milkbox.net/#" package)))))
+          (string-match-p "melpa.org" repo-url))
+      (concat "http://melpa.org/#" package)))))
 
 (el-get-register-method :elpa
   :install #'el-get-elpa-install

--- a/recipes/package.rcp
+++ b/recipes/package.rcp
@@ -27,7 +27,7 @@
           (lambda (pa)
             (add-to-list 'package-archives pa 'append))
           '(("ELPA" . "http://tromey.com/elpa/")
-            ("melpa" . "http://melpa.milkbox.net/packages/")
+            ("melpa" . "http://melpa.org/packages/")
             ("gnu" . "http://elpa.gnu.org/packages/")
             ("marmalade" . "http://marmalade-repo.org/packages/")
             ("SC"   . "http://joseito.republika.pl/sunrise-commander/")))))


### PR DESCRIPTION
Now lives at melpa.org. As seen in http://www.reddit.com/r/emacs/comments/2k2kmv/melpamilkboxnet_is_now_melpaorg/
