### PR TITLE
recipes/markdown-preview-mode.rcp: new recipe markdown-preview-mode

### DIFF
--- a/recipes/markdown-preview-mode.rcp
+++ b/recipes/markdown-preview-mode.rcp
@@ -1,0 +1,6 @@
+(:name markdown-preview-mode
+       :description "Markdown preview mode with websocket.el"
+       :type github
+       :depends (websocket markdown-mode)
+       :website "https://github.com/ancane/markdown-preview-mode.git"
+       :pkgname "ancane/markdown-preview-mode")


### PR DESCRIPTION
It's a minor mode to preview markdown output in browser upon buffer save.
