### PR TITLE
fixed typo in magit.rcp

### DIFF
--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -9,6 +9,6 @@
        ;; handle compilation and autoloads on its own.
        :compile "magit.*\.el\\'"
        :build `(("make" "docs"))
-       :build/berkeley-unix (("gmake docs"))
+       :build/berkeley-unix (("gmake" "docs"))
        ;; assume windows lacks make and makeinfo
        :build/windows-nt (progn nil))


### PR DESCRIPTION
the build command was broken on berkeley-unix
