### PR TITLE
Delete stale compiled file if compilation fails

### DIFF
--- a/el-get-byte-compile.el
+++ b/el-get-byte-compile.el
@@ -40,6 +40,10 @@ newer, then compilation is skipped."
         emacs-lisp-mode-hook byte-compile-warnings)
     (when (or (not (file-exists-p elc))
               (not (file-newer-than-file-p elc el)))
+      (when (file-exists-p elc)
+        ;; Delete the old elc to make sure that if the compilation fails to
+        ;; generate a new one, there will be no discrepancy between them.
+        (delete-file elc))
       (condition-case err
           (byte-compile-file el)
         ((debug error) ;; catch-all, allow for debugging


### PR DESCRIPTION
Previously, when compilation failed inside `el-get-byte-compile-file` it might
leave an old version of `elc` in place, which bit me when one of the packages
in my config exported a bad autoload record and screwed up `.loaddefs.elc`.
