### PR TITLE
Fix go-autocomplete.rcp

### DIFF
--- a/recipes/go-autocomplete.rcp
+++ b/recipes/go-autocomplete.rcp
@@ -1,4 +1,5 @@
 (:name go-autocomplete
+       :description "An autocompletion daemon for the Go programming language."
        :type go
        :pkgname "github.com/nsf/gocode"
        :features (go-autocomplete)


### PR DESCRIPTION
Going back to :type go that was established with #1488 
