### PR TITLE
Change two GitHub URLs from HTTP to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ apply your configuration to.
 
 All of these systems require some degree of manual maintenance, especially
 if you have packages from various types of locations:
-[github](http://github.com), [emacswiki](http://emacswiki.org),
+[github](https://github.com), [emacswiki](http://emacswiki.org),
 [GNU ELPA](http://elpa.gnu.org/) or [Marmalade](http://marmalade-repo.org/),
 privately hosted pages, [git](http://git-scm.com/),
 [bzr](http://bazaar.canonical.com/en/), [CVS](http://www.nongnu.org/cvs/),

--- a/el-get-install.el
+++ b/el-get-install.el
@@ -35,7 +35,7 @@
            (git       (or (executable-find "git")
                           (error "Unable to find `git'")))
            (url       (or (bound-and-true-p el-get-git-install-url)
-                          "http://github.com/dimitri/el-get.git"))
+                          "https://github.com/dimitri/el-get.git"))
            (default-directory el-get-root)
            (process-connection-type nil)   ; pipe, no pty (--no-progress)
 


### PR DESCRIPTION
In `README.md`, change the URL `http://github.com` to use HTTPS; in
`el-get-install.el`, do the same for the URL
`http://github.com/dimitri/el-get.git`.
