### PR TITLE
helm.rcp: fix build on OS X.

### DIFF
--- a/recipes/helm.rcp
+++ b/recipes/helm.rcp
@@ -3,6 +3,7 @@
        :type github
        :pkgname "emacs-helm/helm"
        :build ("make")
+       :build/darwin `(("make" ,(format "EMACS_COMMAND=%s" el-get-emacs)))
        ;; Windows probably doesn't have make available so we fake it.
        :build/windows-nt (with-temp-file "helm-autoload.el"
                            nil))


### PR DESCRIPTION
By override the EMACS_COMMAND in the Makefile of helm.
