### PR TITLE
Update commit hash for Emacs 23-compatible version of package.el

### DIFF
--- a/recipes/package.rcp
+++ b/recipes/package.rcp
@@ -3,7 +3,7 @@
        :description "ELPA implementation (\"package.el\") from Emacs 24"
        :builtin "24"
        :type http
-       :url "http://repo.or.cz/w/emacs.git/blob_plain/1a0a666f941c99882093d7bd08ced15033bc3f0c:/lisp/emacs-lisp/package.el"
+       :url "http://repo.or.cz/w/emacs.git/blob_plain/4525ce3eb56a1f4b7c50eac9217854bbd170f660:/lisp/emacs-lisp/package.el"
        :shallow nil
        :features package
        :post-init


### PR DESCRIPTION
I _believe_ this is the new hash for the same commit, though it's hard to be certain. In any case, the old URL was broken due to the rewriting of the Emacs git repo as part of the bzr->git migration.
