### PR TITLE
Add dependency on `f` to `projectile` recipe

### DIFF
--- a/recipes/projectile.rcp
+++ b/recipes/projectile.rcp
@@ -2,4 +2,4 @@
        :description "Project navigation and management library for Emacs."
        :type github
        :pkgname "bbatsov/projectile"
-       :depends (dash s pkg-info))
+       :depends (dash s f pkg-info))


### PR DESCRIPTION
A recent version [1] of `projectile` depends on the `f` package.

[1] https://github.com/bbatsov/projectile/blob/7f483c525987785716e22f0b364eb6be683a0bbc/projectile.el#L41

---

close #2001.
