### PR TITLE
elixir-mix it's not maintained anymore, use alchemist instead

### DIFF
--- a/recipes/elixir-mix.rcp
+++ b/recipes/elixir-mix.rcp
@@ -1,6 +1,0 @@
-(:name elixir-mix
-       :description "Integration of Elixir's building and deployment tool: mix into Emacs."
-       :type github
-       :features elixir-mix
-       :pkgname "tonini/elixir-mix.el"
-       :compile "elixir-mix.el")


### PR DESCRIPTION
Hi,

The `elixir-mix` package is now integrated in the [`alchemist`](https://github.com/tonini/alchemist.el) package and will not be maintained in the future.

Cheers
