### PR TITLE
I think the &optional package-status-alist argument isn't needed

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -351,7 +351,7 @@ which defaults to the first element in `el-get-recipe-path'."
 (defvar el-get-activated-list nil
   "List of packages initialized by el-get.")
 
-(defun el-get-init (package &optional package-status-alist)
+(defun el-get-init (package)
   "Make the named PACKAGE available for use, first initializing any
    dependency of the PACKAGE."
   (interactive (progn
@@ -362,7 +362,7 @@ which defaults to the first element in `el-get-recipe-path'."
     (el-get-verbose-message "el-get-init: " init-deps)
     (loop for p in init-deps do (el-get-do-init p) collect p)))
 
-(defun el-get-do-init (package &optional package-status-alist)
+(defun el-get-do-init (package)
   "Make the named PACKAGE available for use.
 
 Add PACKAGE's directory (or `:load-path' if specified) to the
@@ -381,11 +381,10 @@ this warning either uninstall one of the el-get or package.el
 version of %s, or call `el-get' before `package-initialize' to
 prevent package.el from loading it."  package package)))
   (when el-get-auto-update-cached-recipes
-    (el-get-merge-properties-into-status package package-status-alist :noerror t))
+    (el-get-merge-properties-into-status package :noerror t))
   (condition-case err
       (let* ((el-get-sources (el-get-package-status-recipes))
-             (source
-              (el-get-read-package-status-recipe package package-status-alist))
+             (source   (el-get-read-package-status-recipe package))
              (method   (el-get-package-method source))
              (loads    (el-get-as-list (plist-get source :load)))
              (autoloads (plist-get source :autoloads))
@@ -581,14 +580,14 @@ PACKAGE may be either a string or the corresponding symbol."
       (funcall install package url 'el-get-post-install)
       (message "el-get install %s" package))))
 
-(defun el-get-reload (package &optional package-status-alist)
+(defun el-get-reload (package)
   "Reload PACKAGE."
   (interactive
    (progn
      (el-get-clear-status-cache)
      (list (el-get-read-package-with-status "Reload" "installed"))))
   (el-get-verbose-message "el-get-reload: %s" package)
-  (el-get-with-status-sources package-status-alist
+  (el-get-with-status-sources
     (let* ((all-features features)
            (pdir (el-get-package-directory package))
            (package-features (el-get-package-features pdir))
@@ -612,7 +611,7 @@ PACKAGE may be either a string or the corresponding symbol."
                        (error (warn "Error while reloading file %s in package %s: %S\n\n This package may require a restart of emacs to complete the update process."
                                     file package (cdr e)))))
             ;; Redo package initialization
-            (el-get-init package package-status-alist)
+            (el-get-init package)
             ;; Reload all features provided by the package. This ensures
             ;; that autoloaded packages (which normally don't load
             ;; anything until one of their entry points is called) are
@@ -800,7 +799,7 @@ result of an actual problem."
     (run-hook-with-args 'el-get-post-remove-hooks package)))
 
 ;;;###autoload
-(defun el-get-remove (package &optional package-status-alist)
+(defun el-get-remove (package)
   "Remove any PACKAGE that is know to be installed or required."
   (interactive
    (progn
@@ -816,7 +815,7 @@ result of an actual problem."
     (let ((fallback-source
            (or (ignore-errors (el-get-package-def package))
                (list :name package :type 'builtin))))
-      (el-get-with-status-sources package-status-alist
+      (el-get-with-status-sources
         (let* ((source   (or (ignore-errors (el-get-package-def package))
                              fallback-source))
                ;; Put the fallback source into `el-get-sources' so that
@@ -902,11 +901,11 @@ entry which is not a symbol and is not already a known recipe."
   (dired dir))
 
 ;;;###autoload
-(defun el-get-checksum (package &optional package-status-alist)
+(defun el-get-checksum (package)
   "Compute the checksum of the given package, and put it in the kill-ring"
   (interactive
    (list (el-get-read-package-with-status "Checksum" "installed")))
-  (el-get-with-status-sources package-status-alist
+  (el-get-with-status-sources
     (let* ((type             (el-get-package-type package))
            (checksum         (plist-get (el-get-package-def package) :checksum))
            (compute-checksum (el-get-method type :compute-checksum)))


### PR DESCRIPTION
I noticed `el-get-merge-properties-into-status` had this `&optional package-status-alist` which was never actually used, except for the call in `el-get-do-init` which was only passing *its* `&optional package-status-alist`, and so on... There seems to be a whole bunch of functions with this optional argument that is never actually used anywhere. After removing them all, I get no compile errors/warnings about it, so I think this is safe.

```
* el-get-status.el (el-get-package-status-alist,
el-get-package-status-recipes, el-get-read-package-status,
el-get-read-package-status-recipe, el-get-with-status-sources,
el-get-read-cached-recipe, el-get-merge-properties-into-status):
* el-get.el (el-get-init, el-get-do-init, el-get-reload, el-get-remove,
el-get-checksum): Remove &optional package-status-alist argument.
```