### PR TITLE
Fix github syntax for handlebars-mode recipe

### DIFF
--- a/recipes/handlebars-mode.rcp
+++ b/recipes/handlebars-mode.rcp
@@ -1,5 +1,5 @@
 (:name handlebars-mode
        :website "https://github.com/danielevans/handlebars-mode"
        :description "Emacs Major Mode for Handlebars"
-       :type git
-       :url "git@github.com:danielevans/handlebars-mode.git")
+       :type github
+       :pkgname "danielevans/handlebars-mode")


### PR DESCRIPTION
The old URL `git@github.com:danielevans/handlebars-mode.git` is the GitHub SSH clone URL so only repo collaborators can use that URL to clone. If anything it should use the HTTPS URL. However since the recipe support the `github` type we should just use that instead.
