### PR TITLE
helm-dash no longer depends on sqlite, plus no sqlite recipe exists

### DIFF
--- a/recipes/helm-dash.rcp
+++ b/recipes/helm-dash.rcp
@@ -1,5 +1,5 @@
 (:name "helm-dash"
        :description "Browse Dash docsets inside emacs"
-       :depends (helm sqlite)
+       :depends helm
        :type github
        :pkgname "areina/helm-dash")


### PR DESCRIPTION
I noticed this while moving my configuration to a new machine and getting a stack trace for the update of the helm-dash package.
