### PR TITLE
Change DDSKK to :type github

### DIFF
--- a/recipes/ddskk.rcp
+++ b/recipes/ddskk.rcp
@@ -1,10 +1,8 @@
 (:name ddskk
        :website "http://openlab.ring.gr.jp/skk/ddskk.html"
        :description "A Japanese input method on Emacs."
-       :type cvs
-       :module "skk/main"
-       :url ":pserver:guest@openlab.jp:/circus/cvsroot"
-       :options "login"
+       :type github
+       :pkgname "skk-dev/ddskk"
        :autoloads nil
        :info "doc/skk.info"
        :features ("skk-setup")


### PR DESCRIPTION
DDSKK repository has been changed to GitHub.
See this post: http://mail.ring.gr.jp/skk/201412/msg00061.html
(It is written in Japanese).
