### PR TITLE
Add directive for building the info file in mmm-mode recipe

### DIFF
--- a/recipes/mmm-mode.rcp
+++ b/recipes/mmm-mode.rcp
@@ -1,4 +1,16 @@
 (:name mmm-mode
        :description "Allow Multiple Major Modes in a buffer"
        :type github
-       :pkgname "purcell/mmm-mode")
+       :pkgname "purcell/mmm-mode"
+       :build `(("./autogen.sh")
+                ("./configure")
+                ;; Make a copy of the version.texi file which was checkout out
+                ;; from Git.  Although this file is under version control, it is
+                ;; changed during package building by make.
+                ("cp" "version.texi" "version.texi-orig")
+                ("make" ,(format "EMACS=%s" el-get-emacs))
+                ;; Restore the original, Git-checked-out version of the
+                ;; file version.texi.  This will prevent conflicts when the
+                ;; this file is updated upstream.
+                ("mv" "version.texi-orig" "version.texi"))
+       :info "mmm.info")


### PR DESCRIPTION
Notice that a workaround was implemented for avoiding the version.texi being locally changed by the build process.  It would be better to have this fixed by the upstream authors of mmm-mode.  By thye way, I have ready reported this problem upstream, see https://github.com/purcell/mmm-mode/issues/41
