### PR TITLE
Fix build rules in mmm-mode recipe

### DIFF
--- a/recipes/mmm-mode.rcp
+++ b/recipes/mmm-mode.rcp
@@ -2,15 +2,8 @@
        :description "Allow Multiple Major Modes in a buffer"
        :type github
        :pkgname "purcell/mmm-mode"
-       :build `(("./autogen.sh")
+       :build `(("make" "maintainer-clean")
+                ("./autogen.sh")
                 ("./configure")
-                ;; Make a copy of the version.texi file which was checkout out
-                ;; from Git.  Although this file is under version control, it is
-                ;; changed during package building by make.
-                ("cp" "version.texi" "version.texi-orig")
-                ("make" ,(format "EMACS=%s" el-get-emacs))
-                ;; Restore the original, Git-checked-out version of the
-                ;; file version.texi.  This will prevent conflicts when the
-                ;; this file is updated upstream.
-                ("mv" "version.texi-orig" "version.texi"))
+                ("make" ,(format "EMACS=%s" el-get-emacs)))
        :info "mmm.info")


### PR DESCRIPTION
This is a followup on the pull request that I filed recently (https://github.com/dimitri/el-get/pull/2042).  The hack proposed in that commit was needed for avoiding a locally modified version.texi file interfering with the build process.  This has been reported (https://github.com/purcell/mmm-mode/issues/41) and fixed upstream (https://github.com/purcell/mmm-mode/commit/53524db13dfedcc104866c3cd3c62adda1232679).  This commit takes the upstream changes into account and replaces the cp/mv commands by "make maintainer-clean" before the autotools/make commands.
