### PR TITLE
Return correct library from `:pkgname` for github based recipe

### DIFF
--- a/el-get-custom.el
+++ b/el-get-custom.el
@@ -339,8 +339,9 @@ definition provided by `el-get' recipes locally.
 
     When lazy, :library sets the file against which to register
     the :after and :post-init forms for `eval-after-load'.  It
-    defaults to the first :feature, :pkgname or :package, in that
-    order.  See also `el-get-eval-after-load'.
+    defaults to the first :feature, :pkgname (removing the
+    \"username\" part for github and emacsmirror) or :package,
+    in that order.  See also `el-get-eval-after-load'.
 
 :options
 

--- a/el-get-recipes.el
+++ b/el-get-recipes.el
@@ -241,6 +241,26 @@ which defaults to installed, required and removed.  Example:
         def :minimum-emacs-version
       0)))
 
+(defun el-get-package-effective-library (package-or-source)
+  "Return the effective :library of PACKAGE-OR-SOURCE.
+
+See `el-get-sources' for details."
+  (let* ((source   (if (or (symbolp package-or-source) (stringp package-or-source))
+                       (el-get-package-def package-or-source)
+                     package-or-source))
+         (package  (if (or (symbolp package-or-source) (stringp package-or-source))
+                       (el-get-as-symbol package-or-source)
+                     (plist-get source :name)))
+         (pkgname  (plist-get source :pkgname))
+         (feats    (el-get-as-list (plist-get source :features))))
+    (or (plist-get source :library)
+        (car feats)
+        (if (memq (el-get-package-method source)
+                  '(github emacsmirror github-tar github-zip))
+            (cdr (el-get-github-parse-user-and-repo package))
+          pkgname)
+        package)))
+
 (defun el-get-version-to-list (version)
   "Convert VERSION to a standard version list.
 

--- a/el-get.el
+++ b/el-get.el
@@ -279,13 +279,7 @@ which defaults to the first element in `el-get-recipe-path'."
 (defun el-get-eval-after-load (package form)
   "Like `eval-after-load', but first arg is an el-get package name."
   (let* ((package  (el-get-as-symbol package))
-         (source   (el-get-package-def package))
-         (pkgname  (plist-get source :pkgname))
-         (feats    (el-get-as-list (plist-get source :features)))
-         (library  (or (plist-get source :library)
-                       (car feats)
-                       pkgname
-                       package)))
+         (library  (el-get-package-effective-library package)))
     (el-get-verbose-message "Using library `%s' for `eval-after-load' for package `%s'"
                             library package)
     (eval-after-load (el-get-as-string library) form)))


### PR DESCRIPTION
If `:library` and `:feature` are not specified, `eval-after-load` will use `:pkgname` as its first argument.  For a github based recipe, the `:pkgname` has two parts: "username/reponame".  We need to remove the "username" part before passing `:pkgname` to `eval-after-load`.