### PR TITLE
Fix for recipes ProofGeneral and scala-mode

### DIFF
--- a/recipes/ProofGeneral.rcp
+++ b/recipes/ProofGeneral.rcp
@@ -5,6 +5,8 @@
        :options ("xzf")
        :url "http://proofgeneral.inf.ed.ac.uk/releases/ProofGeneral-4.2.tgz"
        :build ("cd ProofGeneral && make clean" "cd ProofGeneral && sed -i 's/setq byte-compile-error-on-warn t//' Makefile && make compile")
-       :build/darwin `("cd ProofGeneral && make clean" ,(concat "cd ProofGeneral && sed -i 's/setq byte-compile-error-on-warn t//' Makefile && make compile EMACS=" el-get-emacs))
+       :build/darwin `(("make" "-C" "ProofGeneral" "clean")
+                       ("sed" "-i" "s/setq byte-compile-error-on-warn t//" "ProofGeneral/Makefile")
+                       ("make" "-C" "ProofGeneral" "compile" ,(concat "EMACS=" el-get-emacs)))
        :load  ("ProofGeneral/generic/proof-site.el")
        :info "./ProofGeneral/doc/")

--- a/recipes/scala-mode.rcp
+++ b/recipes/scala-mode.rcp
@@ -1,7 +1,7 @@
 (:name scala-mode
        :description "Major mode for editing Scala code."
        :type git
-       :url "https://github.com/scala/scala-dist.git"
-       :build `(("make -C tool-support/src/emacs" ,(concat "ELISP_COMMAND=" el-get-emacs)))
-       :load-path ("tool-support/src/emacs")
+       :url "https://github.com/scala/scala-tool-support.git"
+       :build `(("make" "-C" "tool-support/emacs" "all" ,(concat "ELISP_COMMAND=" el-get-emacs)))
+       :load-path ("tool-support/emacs")
        :features scala-mode-auto)


### PR DESCRIPTION
ProofGeneral did not build as is on reasonably current Aquamacs.
scala-mode has been moved to a different repo upstream.