### PR TITLE
Add recipe for `arcadia-dot-el' package

### DIFF
--- a/recipes/arcadia.rcp
+++ b/recipes/arcadia.rcp
@@ -1,0 +1,7 @@
+(:name arcadia
+ :description "Emacs integration with the Arcadia Unity project"
+ :type github
+ :features arcadia
+ :depends (dash)
+ :username "arcadia-unity"
+ :pkgname "arcadia-dot-el")


### PR DESCRIPTION
This package is for integration between Emacs and [Arcadia](https://github.com/arcadia-unity/arcadia-dot-el). Only just starting out, but it would be good to be able to install it with el-get!

> c:/cygwin64/home/Elliot/.emacs.d/el-get/el-get/recipes/arcadia.rcp: 0 error(s) found.
