### PR TITLE
add dependencies to virtualenvwrapper recipe

### DIFF
--- a/recipes/virtualenvwrapper.rcp
+++ b/recipes/virtualenvwrapper.rcp
@@ -2,4 +2,5 @@
        :type github
        :website "https://github.com/porterjamesj/virtualenvwrapper.el"
        :description "virtualenv tool for emacs"
-       :pkgname "porterjamesj/virtualenvwrapper.el")
+       :pkgname "porterjamesj/virtualenvwrapper.el"
+       :depends (dash s))


### PR DESCRIPTION
virtualenvwrapper.el complained that it requires `dash` and `s` as dependencies. This PR adds them.