### PR TITLE
Fix `el-get-bundle` callsite identifier generation

### DIFF
--- a/el-get-bundle.el
+++ b/el-get-bundle.el
@@ -119,7 +119,7 @@
                (or (file-exists-p el-get-bundle-init-directory)
                    (make-directory el-get-bundle-init-directory t) t)))
     (let* ((path (file-name-sans-extension (expand-file-name load-file-name)))
-           (callsite (mapconcat #'identity (split-string path "/") "_"))
+           (callsite (replace-regexp-in-string "[^a-zA-Z0-9._-]" "_" path))
            (package (plist-get src :name))
            (id (el-get-bundle-init-id path))
            (init-file (concat el-get-bundle-init-directory

--- a/el-get-bundle.el
+++ b/el-get-bundle.el
@@ -118,7 +118,8 @@
              (ignore-errors
                (or (file-exists-p el-get-bundle-init-directory)
                    (make-directory el-get-bundle-init-directory t) t)))
-    (let* ((path (file-name-sans-extension (expand-file-name load-file-name)))
+    (let* ((path (expand-file-name (convert-standard-filename load-file-name)))
+           (path (file-name-sans-extension path))
            (callsite (replace-regexp-in-string "[^a-zA-Z0-9._-]" "_" path))
            (package (plist-get src :name))
            (id (el-get-bundle-init-id path))


### PR DESCRIPTION
The callsite identifier must include only valid characters for path names.  Characters other than `/` were replaced to `_` but this was not enough for example for GNU Emacs on Windows, where `:` appears after the drive letter of a callsite path.
