### PR TITLE
update projectile-rails recipe to depend on rake

### DIFF
--- a/recipes/projectile-rails.rcp
+++ b/recipes/projectile-rails.rcp
@@ -2,4 +2,4 @@
        :type github
        :pkgname "asok/projectile-rails"
        :description "Minor mode for Rails projects based on projectile-mode"
-       :depends (projectile inflections inf-ruby f))
+       :depends (projectile inflections inf-ruby f rake))


### PR DESCRIPTION
There's a new dependency on `projectile-rails`.
The output:
```bash
$ test/check-recipe.el recipes/projectile-rails.rcp
0 warning/error(s) total.
```