### PR TITLE
Added ocp-indent recipe.

### DIFF
--- a/recipes/ocp-indent.rcp
+++ b/recipes/ocp-indent.rcp
@@ -1,0 +1,5 @@
+(:name ocp-indent
+       :description "Automatic indentation with ocp-indent"
+       :type http
+       :url "https://raw.githubusercontent.com/OCamlPro/ocp-indent/master/tools/ocp-indent.el"
+       :features ocp-indent)


### PR DESCRIPTION
ocp-indent tends to do a better job indenting ocaml code (e.g. exception in pattern matching).

Note: It requires you to install ocp-ident but that is not el-get's job.