### PR TITLE
add highlight to 'depends'

### DIFF
--- a/recipes/lispy.rcp
+++ b/recipes/lispy.rcp
@@ -2,4 +2,4 @@
        :description "vi-like paredit."
        :type github
        :pkgname "abo-abo/lispy"
-       :depends (helm ace-jump-mode s noflet multiple-cursors iedit))
+       :depends (helm ace-jump-mode s noflet multiple-cursors iedit highlight))


### PR DESCRIPTION
Add missing `highlight` feature which is requested by lispy package as `depends`. 