### PR TITLE
fixing org-trello recipe

### DIFF
--- a/recipes/org-trello.rcp
+++ b/recipes/org-trello.rcp
@@ -2,4 +2,4 @@
        :description "Org minor mode - 2-way sync org & trello"
        :type github
        :pkgname "org-trello/org-trello"
-       :depends (dash s deferred request-deferred))
+       :depends (dash s deferred request))


### PR DESCRIPTION
Hello, I tried to install the org mode trello integration recipe but it seems that there is no recipe `request-deferred` anymore. The recipe seems to now be called simply `request`. I tested it and it seems to work fine with the new depends.