### PR TITLE
Update ein pkgname

### DIFF
--- a/recipes/ein.rcp
+++ b/recipes/ein.rcp
@@ -1,7 +1,7 @@
 (:name ein
        :description "IPython notebook client in Emacs"
        :type github
-       :pkgname "tkf/emacs-ipython-notebook"
+       :pkgname "millejoh/emacs-ipython-notebook"
        :depends (websocket request auto-complete)
        :load-path ("lisp")
        :submodule nil


### PR DESCRIPTION
The original ein package is now unmaintained. This updates the recipe to the
to point to the actively maintained fork that has become the official repository
on MELPA [1].

[1] https://github.com/milkypostman/melpa/pull/2245