### PR TITLE
Add org2jekyll

### DIFF
--- a/recipes/org2jekyll.rcp
+++ b/recipes/org2jekyll.rcp
@@ -1,0 +1,5 @@
+(:name org2jekyll
+       :description "Minor mode to publish org-mode post to jekyll without specific yaml"
+       :type github
+       :pkgname "ardumont/org2jekyll"
+       :depends (dash dash-functional s deferred))


### PR DESCRIPTION
Hello,

Using `M-x el-get-elpa-build-local-recipes` makes the package appear in
`M-x el-get-list-packages`.

Then `I RET x` installs it.

Here is the *Compile log* buffer extract:

```txt

Compiling no file at Mon Feb 16 19:57:14 2015
Leaving directory `/home/tony/.emacs.d/elpa/org2jekyll-0.1.2'

Compiling file /home/tony/.emacs.d/elpa/org2jekyll-0.1.2/org2jekyll-autoloads.el at Mon Feb 16 19:57:15 2015
Entering directory `/home/tony/.emacs.d/elpa/org2jekyll-0.1.2/'

Compiling file /home/tony/.emacs.d/elpa/org2jekyll-0.1.2/org2jekyll-pkg.el at Mon Feb 16 19:57:15 2015

Compiling file /home/tony/.emacs.d/elpa/org2jekyll-0.1.2/org2jekyll.el at Mon Feb 16 19:57:15 2015

Compiling no file at Mon Feb 16 19:57:15 2015
Leaving directory `/home/tony/.emacs.d/elpa/org2jekyll-0.1.2'

Compiling file /home/tony/.emacs.d/el-get/.loaddefs.el at Mon Feb 16 19:57:15 2015
Entering directory `/home/tony/.emacs.d/el-get/'

Compiling no file at Mon Feb 16 19:57:27 2015
```

Do you need something else?

Cheers,