### PR TITLE
[org2jekyll] Remove dash-functional dependency

### DIFF
--- a/recipes/org2jekyll.rcp
+++ b/recipes/org2jekyll.rcp
@@ -2,4 +2,4 @@
        :description "Minor mode to publish org-mode post to jekyll without specific yaml"
        :type github
        :pkgname "ardumont/org2jekyll"
-       :depends (dash dash-functional s deferred))
+       :depends (dash s deferred))


### PR DESCRIPTION
dash-functional already installed along with dash by el-get.

Tested with the script you referenced to me @yyr in #2095 and no problem arise.

(Edit: added the log below)
