### PR TITLE
el-get-build: quote post-build-fun

### DIFF
--- a/el-get-build.el
+++ b/el-get-build.el
@@ -128,15 +128,6 @@ recursion.
                                       :error ,(format
                                                "el-get could not build %s [%s]" package c))))
                   commands))
-         ;; This ensures that post-build-fun is always a lambda, not a
-         ;; symbol, which simplifies the following code.
-         (post-build-fun
-          (cond ((null post-build-fun) (lambda (&rest args) nil))
-                ((symbolp post-build-fun)
-                 `(lambda (&rest args)
-                    (apply ,(symbol-function post-build-fun) args)))
-                (t (assert (functionp post-build-fun) 'show-args)
-                   post-build-fun)))
          ;; Do byte-compilation after building, if needed
          (byte-compile-then-post-build-fun
           `(lambda (package)
@@ -149,7 +140,7 @@ recursion.
                (el-get-start-process-list
                 package
                 (list (el-get-byte-compile-process package ,buf ,wdir ,sync bytecomp-files))
-                ,post-build-fun))))
+                #',post-build-fun))))
          ;; unless installing-info, post-build-fun should take care of
          ;; building info too
          (build-info-then-post-build-fun


### PR DESCRIPTION
Instead of converting to lambda.

Tested with `ee` which has an `:info` but no `:build` clause meaning its installation will call `el-get-build` with `post-build-fun` as an fbound symbol **and** as nil.
```el
(require 'trace)
(setq message-log-max t)
(setq el-get-verbose t)

(trace-function 'el-get-build)

(el-get 'sync 'ee)
```

Contents of `*trace-output*`
```
======================================================================
1 -> el-get-build: package=ee commands=nil subdir=nil sync=sync post-build-fun=el-get-post-install-build installing-info=nil
| 2 -> el-get-build: package=ee commands=(("/usr/bin/ginstall-info" "/tmp/el-get-test-home/.emacs.d/el-get/ee/ee.info" "dir")) subdir=nil sync=t post-build-fun=nil installing-info=t
| 2 <- el-get-build: nil
1 <- el-get-build: nil
```