### PR TITLE
Change URL to canonical upstream

### DIFF
--- a/recipes/dtrt-indent.rcp
+++ b/recipes/dtrt-indent.rcp
@@ -1,6 +1,6 @@
 (:name dtrt-indent
-       :description "A minor mode that guesses the indentation offset originally used for creating source code files and transparently adjusts the corresponding settings in Emacs, making it more convenient to edit foreign files."
+       :description "A minor mode that guesses the indentation offset originally used for creating source code files and transparently adjusts the corresponding settings in Emacs."
        :type github
-       :pkgname "rrthomas/dtrt-indent" ; has a fix for a bug that prevents loading; change back to "jscheid/" once https://github.com/jscheid/dtrt-indent/pull/10 is addressed
+       :pkgname "jscheid/dtrt-indent"
        :features (dtrt-indent)
        :post-init (dtrt-indent-mode 1))


### PR DESCRIPTION
The upstream bug preventing loading was fixed.

Also shorten the description.