### PR TITLE
(FIX) Cannot autoload `el-get-bundle` just after a clean setup

### DIFF
--- a/el-get-install.el
+++ b/el-get-install.el
@@ -71,6 +71,7 @@
           (error "Couldn't `git checkout -t %s`" branch)))
 
       (add-to-list 'load-path pdir)
+      (add-to-list 'load-path el-get-root)
       (load package)
       (let ((el-get-default-process-sync t) ; force sync operations for installer
             (el-get-verbose t))             ; let's see it all

--- a/test/travis-ci.sh
+++ b/test/travis-ci.sh
@@ -19,7 +19,7 @@ if [ "$EMACS" = 'emacs-snapshot' ]; then
     prereqs() {
         sudo add-apt-repository -y ppa:cassou/emacs || exit $?;
         sudo apt-get update -qq || exit $?;
-        sudo apt-get install -qq emacs-snapshot-nox || exit $?;
+        sudo apt-get install -qq --force-yes emacs-snapshot-nox || exit $?;
     }
     # Only need to run these for 1 version, so make them nops here
     check-recipes() { :; }


### PR DESCRIPTION
After dd35ba1bf3a9c970130f8a7361c7baf14f540ea7, a whole package setup with El-Get (including the installation of El-Get itself) gets stuck on an error `Cannot open load file: el-get/el-get-bundle`.

### Reproduction

Save this file as `some/where/init.el` and running Emacs by `emacs -q -l some/where/init.el` will reproduce the problem.

```lisp
;; Emacs directory
(when load-file-name
  (setq user-emacs-directory (file-name-directory load-file-name)))

;; Install El-Get
(add-to-list 'load-path (locate-user-emacs-file "el-get/el-get"))
(unless (require 'el-get nil 'noerror)
  (with-current-buffer
      (url-retrieve-synchronously
       "https://raw.githubusercontent.com/dimitri/el-get/master/el-get-install.el")
    (goto-char (point-max))
    (eval-print-last-sexp)))

;; Install some package
(el-get-bundle auto-complete)
```

### Reason

- In #2099, the way El-Get being loaded have been [changed from `load` to `require`](https://github.com/dimitri/el-get/commit/e6a877115892ee04004275e033e68e6f712b23cb)
- For a clean setup, `el-get.el` had been loaded again by `:load` property evaluated inside [`el-get-post-install`](https://github.com/dimitri/el-get/blob/d01af1ca51ce79300698aa4d26cca3e105138d2f/el-get-install.el#L77) before the change
    - When `el-get.el` is loaded for the second time, it had overridden the `autoload`s of `el-get-bundle` to [those with absolute paths](https://github.com/dimitri/el-get/blob/d01af1ca51ce79300698aa4d26cca3e105138d2f/el-get.el#L195-L199)
- After the change in #2099, `autoload`s of `el-get-bundle` come from `~/.emacs.d/el-get/.loaddefs.el`, where the paths are relative to `el-get-dir`
    - Note that `:features` property evaluated inside [`el-get-post-install`](https://github.com/dimitri/el-get/blob/d01af1ca51ce79300698aa4d26cca3e105138d2f/el-get-install.el#L77) does not load `el-get.el` again for a clean setup since [it has already been loaded](https://github.com/dimitri/el-get/blob/d01af1ca51ce79300698aa4d26cca3e105138d2f/el-get-install.el#L74)

### Patch

I Added `el-get-root` (`~/.emacs.d/el-get`) to the load path for a clean setup so that the `autoload`s from `~/.emacs.d/el-get/.loaddefs.el` will work.  Note that [the root directory is also added to the load path in `el-get` function](https://github.com/dimitri/el-get/blob/d01af1ca51ce79300698aa4d26cca3e105138d2f/el-get.el#L996).  I think it is quite reasonable to emulate this behavior for the installation of El-Get itself.