### PR TITLE
remove tablist.rcp, because it is moved inside pdf-tools' repo.

### DIFF
--- a/recipes/pdf-tools.rcp
+++ b/recipes/pdf-tools.rcp
@@ -4,7 +4,6 @@
        ;; On Debian, "libpoppler-glib-dev" "libpoppler-dev"
        ;; "libpoppler-private-dev" are needed to build c code in this package.
        :pkgname "politza/pdf-tools"
-       :depends (tablist)
 
        ;; pdf-tools' code written to find "epdfinfo" executable in the lisp
        ;; directory. we preset following variable to avoid that.

--- a/recipes/tablist.rcp
+++ b/recipes/tablist.rcp
@@ -1,5 +1,0 @@
-(:name tablist
-       :description "Extended Emacs tabulated-list-mode."
-       :website "https://github.com/politza/tablist"
-       :type github
-       :pkgname "politza/tablist")


### PR DESCRIPTION
`tablist` is no longer existed. It is only depended by `pdf-tools` and already moved inside pdf-tools' repo. See (https://github.com/politza/pdf-tools/commit/c51aaa7849b5c581144a6e0e126c1453c09c92ed).