### PR TITLE
Add dash to the list of dependencies of ebib

### DIFF
--- a/recipes/ebib.rcp
+++ b/recipes/ebib.rcp
@@ -3,5 +3,5 @@
        :website "http://ebib.sourceforge.net/index.html"
        :description "Application to manage BibTeX database"
        :pkgname "joostkremers/ebib"
-       :depends (parsebib)
+       :depends (dash parsebib)
        :shallow nil)


### PR DESCRIPTION
Please merge this commit into master.  It is strange that this has not been noticed before, since dash was added as a dependency of ebib over a year ago (joostkremers/ebib@4818d0c).  Thanks.