### PR TITLE
Support checksums for http-tar and http-zip

### DIFF
--- a/el-get.el
+++ b/el-get.el
@@ -513,16 +513,11 @@ PACKAGE may be either a string or the corresponding symbol."
   (el-get-do-init package)
   (run-hook-with-args 'el-get-post-install-hooks package))
 
-(defun el-get-post-install (package)
-  "Post install PACKAGE. This will get run by a sentinel."
-  (let* ((sync             el-get-default-process-sync)
-         (type             (el-get-package-type package))
-         (hooks            (el-get-method type :install-hook))
-         (commands         (el-get-build-commands package))
+(defun el-get-verify-checksum (package)
+  (let* ((type             (el-get-package-type package))
          (checksum         (plist-get (el-get-package-def package) :checksum))
          (compute-checksum (el-get-method type :compute-checksum)))
 
-    ;; check the checksum of the package here, as early as possible
     (when (and checksum (not compute-checksum))
       (error
        "Checksum verification of package %s is not supported with method %s."
@@ -536,7 +531,17 @@ PACKAGE may be either a string or the corresponding symbol."
               (error "Checksum verification failed. Required: \"%s\", actual: \"%s\"."
                      checksum computed))
           (el-get-verbose-message "el-get: pakage %s checksum is %s."
-                                  package computed))))
+                                  package computed))))))
+
+(defun el-get-post-install (package)
+  "Post install PACKAGE. This will get run by a sentinel."
+  (let* ((sync             el-get-default-process-sync)
+         (type             (el-get-package-type package))
+         (hooks            (el-get-method type :install-hook))
+         (commands         (el-get-build-commands package)))
+
+    ;; check the checksum of the package here, as early as possible
+    (el-get-verify-checksum package)
 
     ;; post-install is the right place to run install-hook
     (run-hook-with-args hooks package)

--- a/methods/el-get-http-tar.el
+++ b/methods/el-get-http-tar.el
@@ -56,7 +56,9 @@
                           do (if (file-directory-p fullpath)
                                  (delete-directory fullpath 'recursive)
                                (delete-file fullpath))))
-                  ;; tar xzf `basename url`
+                  ;; verify checksum before operating on untrusted data
+                  (el-get-verify-checksum package)
+                  ;; tar xvf `basename url`
                   (let ((el-get-sources '(,@el-get-sources)))
                     (el-get-start-process-list
                      package

--- a/methods/el-get-http-tar.el
+++ b/methods/el-get-http-tar.el
@@ -58,7 +58,7 @@
                                (delete-file fullpath))))
                   ;; verify checksum before operating on untrusted data
                   (el-get-verify-checksum package)
-                  ;; tar xvf `basename url`
+                  ;; tar xzf `basename url`
                   (let ((el-get-sources '(,@el-get-sources)))
                     (el-get-start-process-list
                      package
@@ -66,7 +66,7 @@
                                       :buffer-name ,name
                                       :default-directory ,pdir
                                       :program ,(el-get-executable-find "tar")
-                                      :args (,"xvf" ,@options ,tarfile)
+                                      :args (,@options ,tarfile)
                                       :message ,ok
                                       :error ,ko))
                      ,(symbol-function post-install-fun))))))

--- a/methods/el-get-http-tar.el
+++ b/methods/el-get-http-tar.el
@@ -77,6 +77,7 @@
   :update #'el-get-http-tar-install
   :remove #'el-get-rmdir
   :install-hook 'el-get-http-tar-install-hook
-  :update-hook 'el-get-http-tar-install-hook)
+  :update-hook 'el-get-http-tar-install-hook
+  :compute-checksum #'el-get-http-compute-checksum)
 
 (provide 'el-get-http-tar)

--- a/methods/el-get-http-tar.el
+++ b/methods/el-get-http-tar.el
@@ -66,7 +66,7 @@
                                       :buffer-name ,name
                                       :default-directory ,pdir
                                       :program ,(el-get-executable-find "tar")
-                                      :args (,@options ,tarfile)
+                                      :args (,"xvf" ,@options ,tarfile)
                                       :message ,ok
                                       :error ,ko))
                      ,(symbol-function post-install-fun))))))

--- a/methods/el-get-http-zip.el
+++ b/methods/el-get-http-zip.el
@@ -56,6 +56,7 @@
   :update #'el-get-http-zip-install
   :remove #'el-get-rmdir
   :install-hook 'el-get-http-zip-install-hook
-  :update-hook 'el-get-http-zip-install-hook)
+  :update-hook 'el-get-http-zip-install-hook
+  :compute-checksum #'el-get-http-compute-checksum)
 
 (provide 'el-get-http-zip)

--- a/methods/el-get-http-zip.el
+++ b/methods/el-get-http-zip.el
@@ -35,7 +35,9 @@
                           do (if (file-directory-p fullpath)
                                  (delete-directory fullpath 'recursive)
                                (delete-file fullpath))))
-                  ;; zip xzf `basename url`
+                  ;; verify checksum before operating on untrusted data
+                  (el-get-verify-checksum package)
+                  ;; unzip `basename url`
                   (let ((el-get-sources '(,@el-get-sources)))
                     (el-get-start-process-list
                      package


### PR DESCRIPTION
These changes were necessary for me to get http-tar and http-zip working with checksums.  

They are both configured to use the same checksum function as the http method, except they also run the verification process early (before the verification in the `el-get-post-install` function).  

I added the early checksum because it's risky to unzip/untar an archive that hasn't been verified. There might be a cleaner way to do this: it seems like putting the "generic" checksum verification in `el-get-post-install` is too late. It might be better to change the generic process such that there is a stage before "install" called "retrieve" and it models the abstract process of getting all the sources and verifying checksums. Then the zip and tar methods would only implement the unzip/untar process in the "install" stage (which comes after the download/checksum "retrieve" stage). Just an idea... let me know if I'm unclear.

