### PR TITLE
vala-mode: switch to emacsorphanage

### DIFF
--- a/recipes/vala-mode.rcp
+++ b/recipes/vala-mode.rcp
@@ -1,7 +1,4 @@
 (:name vala-mode
-       :description "Emacs mode for Vala language"
-       :type http
-       :url "https://wiki.gnome.org/Projects/Vala/Emacs?action=AttachFile&do=get&target=vala-mode.el"
-       :localname "vala-mode.el"
-       :prepare (progn
-                  (add-to-list 'auto-mode-alist '("\\.vala$" . vala-mode))))
+       :description "Major mode for Vala language"
+       :type github
+       :pkgname "emacsorphanage/vala-mode")


### PR DESCRIPTION
Seems to have been abandoned upstream; MELPA uses emacsorphanage.