### PR TITLE
build magit from the master branch

### DIFF
--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -3,6 +3,7 @@
        :description "It's Magit! An Emacs mode for Git."
        :type github
        :pkgname "magit/magit"
+       :branch "master"
        :depends (cl-lib git-modes)
        :info "."
        ;; use the Makefile to produce the info manual, el-get can


### PR DESCRIPTION
Yesterday I have just released 1.4.0 and am now preparing to release 2.1.0.
The new HEAD branch is next, but I would like the El-get packages to be
build from the master branches for a little longer. I will switch to the next
branches approximately to weeks before 2.1.0 is actually released.