### PR TITLE
just warn about install failures

### DIFF
--- a/el-get-core.el
+++ b/el-get-core.el
@@ -41,6 +41,17 @@ the original object."
 (defun el-get-verbose-message (format &rest arguments)
   (when el-get-verbose (apply 'message format arguments)))
 
+(defmacro el-get-with-errors-as-warnings (prefix &rest body)
+  (declare (indent 1) (debug t))
+  (let ((error-var (make-symbol "err")))
+    `(condition-case ,error-var
+         (progn ,@body)
+       ((debug error)
+        (display-warning 'el-get
+                         (concat ,prefix (error-message-string ,error-var))
+                         :error)
+        nil))))
+
 (defsubst el-get-plist-keys (plist)
   "Return a list of all keys in PLIST.
 

--- a/el-get.el
+++ b/el-get.el
@@ -964,8 +964,14 @@ considered \"required\"."
     (el-get-verbose-message "el-get-init-and-install: install %S" install-deps)
     (el-get-verbose-message "el-get-init-and-install: init %S" init-deps)
 
-    (loop for p in install-deps do (el-get-do-install p) collect p into done)
-    (loop for p in init-deps    do (el-get-do-init p)    collect p into done)
+    (loop for p in install-deps
+          when (el-get-with-errors-as-warnings (format "while installing %s: " p)
+                 (el-get-do-install p))
+          collect p into done)
+    (loop for p in init-deps
+          when (el-get-with-errors-as-warnings (format "while initializing %s: " p)
+                 (el-get-do-init p))
+          collect p into done)
     done))
 
 ;;;###autoload


### PR DESCRIPTION
I was at first a bit unsure the possiblity of cascading errors would be a problem, but after seeing this in action in `use-package` I think it's much better to chance a few extra error messages in the `*Warnings*` buffer than failing to get through the init.el.

fixes #1625, though in my tests network failures seem to result in very long timeouts, so I doubt I'd have the patience to wait for a warning message.