### PR TITLE
Update git url for evil.rcp

### DIFF
--- a/recipes/evil.rcp
+++ b/recipes/evil.rcp
@@ -1,10 +1,10 @@
 (:name evil
-       :website "http://gitorious.org/evil/pages/Home"
+       :website "https://bitbucket.org/lyro/evil"
        :description "Evil is an extensible vi layer for Emacs. It
        emulates the main features of Vim, and provides facilities
        for writing custom extensions."
-       :type git
-       :url "http://gitorious.org/evil/evil.git"
+       :type hg
+       :url "https://bitbucket.org/lyro/evil"
        :features evil
        :depends (undo-tree goto-chg)
        :build (("make" "info" "all"))


### PR DESCRIPTION
GitLab acquires Gitorious so the original gitorious git url is not available now.

Evil has migrated its development to bitbucket and switch from git to hg.

See: https://about.gitlab.com/2015/03/03/gitlab-acquires-gitorious/