### PR TITLE
[org-html5presentation] Use GH repository instead of gist

### DIFF
--- a/recipes/org-html5presentation.rcp
+++ b/recipes/org-html5presentation.rcp
@@ -1,5 +1,4 @@
 (:name org-html5presentation
-       :type http
-       :website "https://gist.github.com/509761"
-       :description "html5 presentation from org files"
-       :url "https://raw.github.com/gist/509761/org-html5presentation.el")
+       :type github
+       :pkgname "kinjo/org-html5presentation.el"
+       :description "HTML5 Presentation Back-End for Org Export Engine")


### PR DESCRIPTION
According to @kinjo [1], main repository has moved to Github more then 1 year ago.

[1] https://gist.github.com/kinjo/509761#comment-1206267