### PR TITLE
recipe: powershell.el

### DIFF
--- a/recipes/powershell.rcp
+++ b/recipes/powershell.rcp
@@ -1,0 +1,6 @@
+(:name powershell
+       :website "https://github.com/jschaf/powershell.el"
+       :description "Major mode for powershell files."
+       :type "github"
+       :branch "master"
+       :pkgname "jschaf/powershell.el")


### PR DESCRIPTION
I combined powershell.el and powershell-mode.el that were floating around emacs-wiki. I cleaned up the documentation and reorganized some of the code.

I received permission from the creator to re-use the name powershell to create a canonical package.

https://github.com/jschaf/powershell.el

A little bit of history is available in my Melpa pull request: https://github.com/milkypostman/melpa/pull/1308