### PR TITLE
Fixed org-gcal recipe dependency on emacs-request.

### DIFF
--- a/recipes/org-gcal.rcp
+++ b/recipes/org-gcal.rcp
@@ -3,5 +3,5 @@
        :website "https://github.com/myuhe/org-gcal"
        :type github
        :minimum-emacs-version "24"
-       :depends (request-deferred alert cl-lib)
+       :depends (request alert cl-lib)
        :pkgname "myuhe/org-gcal.el")


### PR DESCRIPTION
It looks like the org-gcal (https://github.com/myuhe/org-gcal.el) dependency on emacs-request is out of date or incorrect and doesn't work.

It looks like the right dependency is "request" rather than "request-deferred"; the latter doesn't exist as far as I can tell. I've checked the "request" recipe and verified that it points to "tkf/emacs-request" which is the dependency listed on the org-gcal github page, so I think that's right.

I've tested locally on my machine and the package fetches correctly and works, so I think it's the correct dependency.

Apologies if I've missed anything or done something dumb here. I'm a newbie here, both to el-get and to github, so if I can do anything else to help then please let me know.

Finally, thank you so much for el-get. It's an excellent piece of tech and I'm finding it absolutely invaluable.