### PR TITLE
Add recipe for terraform-mode

### DIFF
--- a/recipes/terraform-mode.rcp
+++ b/recipes/terraform-mode.rcp
@@ -1,0 +1,4 @@
+(:name terraform-mode
+       :type github
+       :pkgname "syohex/emacs-terraform-mode"
+       :description "Major mode for Terraform configuration files")


### PR DESCRIPTION
Added a recipe for a major mode for Terraform. 

Tested that this works with `el-get-install` and `el-get-remove` on Emacs 24.5.1 on OS X Yosemite.


