### PR TITLE
wc-mode version number update

### DIFF
--- a/recipes/wc-mode.rcp
+++ b/recipes/wc-mode.rcp
@@ -2,8 +2,8 @@
        :website "http://www.dr-qubit.org/emacs.php"
        :description "A minor mode to provide a 'wc' function for Emacs buffers."
        :type http
-       :url "http://www.dr-qubit.org/emacs-misc/wc-mode-0.2.el"
-       :build '(("mv" "wc-mode-0.2.el" "wc-mode.el"))
+       :url "http://www.dr-qubit.org/emacs-misc/wc-mode-0.3.el"
+       :build '(("mv" "wc-mode-0.3.el" "wc-mode.el"))
        :compile "wc-mode.el"
        :prepare (progn
                   (autoload 'wc-mode "wc-mode" nil t)))


### PR DESCRIPTION
The wc-mode contains the version number in the file name. This updates
the version to match the one currently available online.

Most recent is v0.3, v0.2 is not available.