### PR TITLE
Fix dependency of elscreen

### DIFF
--- a/recipes/elscreen.rcp
+++ b/recipes/elscreen.rcp
@@ -1,6 +1,5 @@
 (:name elscreen
        :description "Screen Manager for Emacsen"
        :website "https://github.com/emacs-jp/elscreen"
-       :depends apel
        :type github
        :pkgname "emacs-jp/elscreen")


### PR DESCRIPTION
Nowadays elsceen does not require apel.
https://github.com/emacs-jp/elscreen/blob/master/elscreen.el#L30-L34

By the way, elscreen required apel at 2639154.