### PR TITLE
Bring the `clj-refactor` recipe up-to-date

### DIFF
--- a/recipes/clj-refactor.rcp
+++ b/recipes/clj-refactor.rcp
@@ -1,5 +1,5 @@
 (:name clj-refactor
        :description "A collection of simple clojure refactoring functions"
        :type github
-       :depends (dash s clojure-mode yasnippet paredit multiple-cursors)
+       :depends (dash s clojure-mode yasnippet paredit multiple-cursors cider edn)
        :pkgname "magnars/clj-refactor.el")

--- a/recipes/edn.rcp
+++ b/recipes/edn.rcp
@@ -1,0 +1,5 @@
+(:name edn
+       :description "Edn.el is an emacs lisp library for reading and writing the data format edn."
+       :type github
+       :depends (dash cl-lib s peg)
+       :pkgname "expez/edn.el")


### PR DESCRIPTION
`clj-refactor` depends on 2 new explicit dependencies: `cider` and `edn`. El-Get does not have a recipe for edn.el, so I've added that as well.