### PR TITLE
Add missing cl-lib dependency to popup recipe

### DIFF
--- a/recipes/popup.rcp
+++ b/recipes/popup.rcp
@@ -3,4 +3,5 @@
        :description "Visual Popup Interface Library for Emacs"
        :type github
        :submodule nil
+       :depends cl-lib
        :pkgname "auto-complete/popup-el")


### PR DESCRIPTION
see https://github.com/auto-complete/popup-el/blob/master/popup.el#L8

This patch is required for Emacs versions before 24.3.

$ test/check-recipe.el recipes/popup.rcp
0 warning/error(s) total.