### PR TITLE
Removed call to install development dependencies.

### DIFF
--- a/recipes/pdf-tools.rcp
+++ b/recipes/pdf-tools.rcp
@@ -10,7 +10,6 @@
        :prepare (setq pdf-info-epdfinfo-program
                       (concat (el-get-package-directory "pdf-tools")
                               "server/epdfinfo"))
-       :build `(("make" "install-server-deps")
-                ("make"))
+       :build ("make")
        :load-path ("lisp")
        :compile ("lisp/"))


### PR DESCRIPTION
The previous version issued a `make install-server-deps`, which depends
on the availability of apt-get, and thus breaks the recipe on systems
without this tool.

After this change, the recipe works on non-Debian systems, provided that
the required development packages are installed.