### PR TITLE
update jade-mode recipe to use github instead of elpa

### DIFF
--- a/recipes/jade-mode.rcp
+++ b/recipes/jade-mode.rcp
@@ -1,4 +1,4 @@
 (:name jade-mode
        :description "Emacs major mode for jade template highlighting."
-       :features jade-mode
-       :type elpa)
+       :type git
+       :url "https://github.com/brianc/jade-mode.git")


### PR DESCRIPTION
Pick jade-mode from upstream, ELPA package is outdated.