### PR TITLE
Fix sx recipe

### DIFF
--- a/recipes/sx.rcp
+++ b/recipes/sx.rcp
@@ -2,5 +2,5 @@
        :description "Stack Exchange for Emacs."
        :website "https://github.com/vermiculus/sx.el"
        :type github
-       :depends (markdown-mode)
+       :depends (markdown-mode let-alist)
        :pkgname "vermiculus/sx.el")


### PR DESCRIPTION
sx.el [requires let-alist](https://github.com/vermiculus/sx.el/blob/master/sx.el#L9) and requiring sx-tab is mandatory, because el-get placing all autoloads not in package's directory, but in one in `~/.emacs.d/el-get`.