### PR TITLE
FIx build problem for auctex on OSX

### DIFF
--- a/recipes/auctex.rcp
+++ b/recipes/auctex.rcp
@@ -9,9 +9,16 @@
                  "--without-texmf-dir"
                  "--with-packagelispdir=$(pwd)"
                  "--with-packagedatadir=$(pwd)"
-                 ,@(when (eq system-type 'darwin) "--with-lispdir=`pwd`")
                  ,(concat "--with-emacs=" el-get-emacs))
                 ("make"))
+       :build/darwin `(("./autogen.sh")
+                       ("./configure"
+                        "--without-texmf-dir"
+                        "--with-packagelispdir=$(pwd)"
+                        "--with-packagedatadir=$(pwd)"
+                        "--with-lispdir=$(pwd)"
+                        ,(concat "--with-emacs=" el-get-emacs))
+                       ("make"))
        :load-path (".")
        :load  ("tex-site.el" "preview-latex.el")
        :info "doc")


### PR DESCRIPTION
The auctex recipe produced a wrong build command, making it unable to build. I factored out the Darwin command as `:build/darwin`, this way the build works for me again.