### PR TITLE
Fix sed command in yatex recipe

### DIFF
--- a/recipes/yatex.rcp
+++ b/recipes/yatex.rcp
@@ -5,6 +5,6 @@
        :url "http://www.yatex.org/hgrepos/yatex"
        ;;; this fix the trouble on .loaddefs.el
        ;;; yatexmth.el contains inappropriate autoload magic comment
-       :build (("sed -i 's/ from yatex.el//' yatexmth.el"))
-       :build/berkeley-unix (("sed -i '' 's/ from yatex.el//' yatexmth.el"))
-       :build/darwin (("LANG=C LC_ALL=C") ("sed -i '' 's/ from yatex.el//' yatexmth.el")))
+       :build (("sed" "-i" "s/ from yatex.el//" "yatexmth.el"))
+       :build/berkeley-unix (("sed" "-i" "" "s/ from yatex.el//" "yatexmth.el"))
+       :build/darwin (("env" "LANG=C" "LC_ALL=C" "sed" "-i" "" "s/ from yatex.el//" "yatexmth.el")))


### PR DESCRIPTION
I fixed `:build` for yatex. It correctly worked on my linux environment and my mac environment.