### PR TITLE
Update url for `let-alist`

### DIFF
--- a/recipes/let-alist.rcp
+++ b/recipes/let-alist.rcp
@@ -2,4 +2,4 @@
        :description "Easily let-bind values of an assoc-list by their names."
        :builtin "25.0.50"
        :type http
-       :url "http://git.savannah.gnu.org/cgit/emacs.git/plain/lisp/emacs-lisp/let-alist.el")
+       :url "http://git.savannah.gnu.org/cgit/emacs/elpa.git/plain/packages/let-alist/let-alist.el")


### PR DESCRIPTION
The old url isn't valid anymore. The url that the [project
website](http://elpa.gnu.org/packages/let-alist.html) mentions should be used.