### PR TITLE
add type of source in list of packages

### DIFF
--- a/el-get-list-packages.el
+++ b/el-get-list-packages.el
@@ -1,4 +1,4 @@
-;;; el-get --- Manage the external elisp bits and pieces you depend upon
+;;; el-get-list-packages.el --- Manage the external elisp bits and pieces you depend upon
 ;;
 ;; Copyright (C) 2010-2011 Dimitri Fontaine
 ;;
@@ -330,7 +330,7 @@ in el-get package menu."
       (run-mode-hooks 'el-get-package-menu-mode-hook)
     (run-hooks 'el-get-package-menu-mode-hook)))
 
-(defun el-get-print-package (package-name status &optional desc)
+(defun el-get-print-package (package-name status type &optional desc)
   (let ((face
          (cond
           ((string= status "installed")
@@ -349,6 +349,9 @@ in el-get package menu."
     (put-text-property (line-beginning-position) (line-end-position)
                        'font-lock-face face)
     (indent-to 41 1)
+    (insert (propertize (replace-regexp-in-string "\n" " " type)
+                        'font-lock-face face))
+    (indent-to 60 1)
     (when desc
       (insert (propertize (replace-regexp-in-string "\n" " " desc)
                           'font-lock-face face)
@@ -364,6 +367,9 @@ in el-get package menu."
                         #'(lambda (package)
                             (let ((package-name (el-get-as-string (plist-get package :name))))
                               (el-get-read-package-status package-name))))
+                       ((string= el-get-package-menu-sort-key "Type")
+                        #'(lambda (package)
+                            (el-get-as-string (plist-get package :type))))
                        ((string= el-get-package-menu-sort-key "Description")
                         #'(lambda (package)
                             (plist-get package :description)))
@@ -380,6 +386,7 @@ in el-get package menu."
               (let ((package-name (el-get-as-string (plist-get package :name))))
                 (el-get-print-package package-name
                                       (el-get-read-package-status package-name)
+                                      (el-get-as-string (plist-get package :type))
                                       (or (plist-get package :description) ""))))
             packages))
     (goto-char (point-min))
@@ -424,7 +431,8 @@ in el-get package menu."
                             'keymap el-get-package-menu-sort-button-map))))
            '((2 . "Package")
              (30 . "Status")
-             (41 . "Description"))
+             (41 . "Type")
+             (60 . "Description"))
            ""))
     (pop-to-buffer (current-buffer))))
 

--- a/el-get-list-packages.el
+++ b/el-get-list-packages.el
@@ -330,7 +330,7 @@ in el-get package menu."
       (run-mode-hooks 'el-get-package-menu-mode-hook)
     (run-hooks 'el-get-package-menu-mode-hook)))
 
-(defun el-get-print-package (package-name status type &optional desc)
+(defun el-get-print-package (package-name status &optional type desc)
   (let ((face
          (cond
           ((string= status "installed")
@@ -349,8 +349,9 @@ in el-get package menu."
     (put-text-property (line-beginning-position) (line-end-position)
                        'font-lock-face face)
     (indent-to 41 1)
-    (insert (propertize (replace-regexp-in-string "\n" " " type)
-                        'font-lock-face face))
+    (when type
+      (insert (propertize (replace-regexp-in-string "\n" " " type)
+                          'font-lock-face face)))
     (indent-to 60 1)
     (when desc
       (insert (propertize (replace-regexp-in-string "\n" " " desc)


### PR DESCRIPTION
I propose to add the type of the source in the package list. I used this information to solve this problem:  there were some conflicts between a package proposed by "elpa" which depends on another one proposed by github. The version were not matching which leads to an inconsistency.