### PR TITLE
Update safe properties in .status.el (whitelist approach)

### DIFF
--- a/el-get-core.el
+++ b/el-get-core.el
@@ -140,11 +140,13 @@ already-defined method DERIVED-FROM-NAME."
 ;; interface to write such structures as raw elisp.
 ;;
 ;;;  "Fuzzy" data structure conversion utilities
-(defun el-get-as-string (symbol-or-string)
-  "If STRING-OR-SYMBOL is already a string, return it.  Otherwise
-convert it to a string and return that."
-  (if (stringp symbol-or-string) symbol-or-string
-    (symbol-name symbol-or-string)))
+(defun el-get-as-string (obj)
+  "Return OBJ as a string."
+  (cond
+   ((stringp obj) obj)
+   ((symbolp obj) (symbol-name obj))
+   ((numberp obj) (number-to-string obj))
+   (t (error "Can't convert %S to string." obj))))
 
 (defun el-get-as-symbol (string-or-symbol)
   "If STRING-OR-SYMBOL is already a symbol, return it.  Otherwise

--- a/el-get-status.el
+++ b/el-get-status.el
@@ -252,7 +252,7 @@ that recipe in the el-get status file.")
 (defconst el-get-status-update-whitelist
   `(:depends
     :build
-    :build/system-type
+    ;; :build/* ; special cased below
     :compile
     :checksum
     :checkout
@@ -280,6 +280,8 @@ to the operation required."
                                               (plist-get source k))))))
         do (setq init (plist-put init k v))
         else if (or (memq k el-get-status-update-whitelist)
+                    ;; All `:build/*' props are update safe, like `:build'.
+                    (string-prefix-p ":build/" (symbol-name k))
                     (if (eq k :url) ; `:http*' methods can handle `:url' changes.
                         (memq type '(http http-tar http-zip
                                           github-tar github-zip

--- a/el-get-status.el
+++ b/el-get-status.el
@@ -366,23 +366,12 @@ t', this error is suppressed (but nothing is updated).
         ;; Emit a verbose message if `noerror' is t (but still quit
         ;; the function).
         (funcall (if noerror 'el-get-verbose-message 'error)
-                 "Tried to add non-whitelisted properties:
-
-%s
-
-and remove non-whitelisted properties:
-
-%s
-
-into/from source:
-
-%s
-Maybe you should use %s`el-get-reinstall' on %s instead?"
-                 (if   added-disallowed (pp-to-string   added-disallowed) "()")
-                 (if removed-disallowed (pp-to-string removed-disallowed) "()")
-                 (pp-to-string cached-recipe)
-                 (if (eq operation 'update) "" "`el-get-update' or")
-                 (el-get-source-name cached-recipe))
+                 (concat "Must %sreinstall `%s' to modify its cached recipe\n"
+                         "  adding:   %s"
+                         "  removing: %s")
+                 (if (eq operation 'update) "" "update or ") package
+                 (if   added-disallowed (pp-to-string   added-disallowed) "()\n")
+                 (if removed-disallowed (pp-to-string removed-disallowed) "()\n"))
       (when update-p
           (el-get-save-package-status package "installed" source))))))
 

--- a/el-get.el
+++ b/el-get.el
@@ -383,7 +383,7 @@ this warning either uninstall one of the el-get or package.el
 version of %s, or call `el-get' before `package-initialize' to
 prevent package.el from loading it."  package package)))
   (when el-get-auto-update-cached-recipes
-    (el-get-merge-properties-into-status package () :noerror t))
+    (el-get-merge-properties-into-status package 'init :noerror t))
   (condition-case err
       (let* ((el-get-sources (el-get-package-status-recipes))
              (source   (el-get-read-package-status-recipe package))
@@ -641,6 +641,7 @@ PACKAGE may be either a string or the corresponding symbol."
 (defun el-get-post-update-build (package)
   "Function to call after building the package while updating it."
   ;; fix trailing failed installs
+  (el-get-merge-properties-into-status package 'update :noerror t)
   (when (string= (el-get-read-package-status package) "required")
     (el-get-save-package-status package "installed"))
   (el-get-invalidate-autoloads package)


### PR DESCRIPTION
Fixes #1817.

This extends the whitelist with a 2nd update whitelist, with special cases for `:builtin` (safe if we haven't "crossed" the Emac version) and `:url` (safe for some recipe types). 

I'm actually considering switching to a blacklist approach instead. Consider that removing (or adding) properties like `:provide` that are unknown to el-get is obviously perfectly safe. Essentially, properties that are not used by a type's update method are safe to change.

The downside of blacklists is it's more dangerous if we get the list wrong of course. But, leaving a stale recipe is also bad if we want to use it (eg a solution for #2232 might want to do that).

Thoughts?