### PR TITLE
fix dependency for racket-mode  in recipe

### DIFF
--- a/recipes/racket-mode.rcp
+++ b/recipes/racket-mode.rcp
@@ -1,4 +1,5 @@
 (:name racket-mode
        :description "Major mode for Racket language."
        :type github
-       :pkgname "greghendershott/racket-mode")
+       :pkgname "greghendershott/racket-mode"
+       :depends (s))


### PR DESCRIPTION
racket mode depends on `s` .
Thank you.