### PR TITLE
Fix nxhtml recipe

### DIFF
--- a/recipes/nxhtml.rcp
+++ b/recipes/nxhtml.rcp
@@ -2,8 +2,8 @@
        :type emacsmirror
        :description "An addon for Emacs mainly for web development."
        :build `((,el-get-emacs
-                 "-batch" "-q" "-no-site-file" "-L" "."
+                 "-batch" "-q" "-no-site-file" "-L" "./elisp"
                  "-l" "nxhtmlmaint.el"
                  "--eval" "(setq inhibit-read-only t)" ; `web-vcs-message-with-face' writes to `*Messages*' buffer.
                  "-f" "nxhtmlmaint-start-byte-compilation"))
-       :load "autostart.el")
+       :load "elisp/autostart.el")


### PR DESCRIPTION
It seems that nxhtml has placed all elisp files under the 'elisp' folder. This fix simply loads files from that directory instead of the repo root.