### PR TITLE
circe: Fix load-path

### DIFF
--- a/recipes/circe-notifications.rcp
+++ b/recipes/circe-notifications.rcp
@@ -1,0 +1,7 @@
+(:name circe-notifications
+       :website "https://github.com/eqyiel/circe-notifications"
+       :description "Add desktop notifications to Circe"
+       :type github
+       :pkgname "eqyiel/circe-notifications"
+       :depends (circe cl-lib s)
+       :load-path ("."))

--- a/recipes/circe.rcp
+++ b/recipes/circe.rcp
@@ -4,4 +4,4 @@
        :type github
        :pkgname "jorgenschaefer/circe"
        :depends cl-lib
-       :load-path ("lisp"))
+       :load-path ("."))


### PR DESCRIPTION
Fix `load-path` in recipe for the CIRCE Emacs IRC client.