### PR TITLE
Add recipe for mu4e-alert

### DIFF
--- a/recipes/mu4e-alert.rcp
+++ b/recipes/mu4e-alert.rcp
@@ -1,0 +1,5 @@
+(:name mu4e-alert
+       :description "Desktop notification and mode-line display for mu4e."
+       :type github
+       :depends (mu4e alert s)
+       :pkgname "iqbalansari/mu4e-alert")


### PR DESCRIPTION
This adds the recipe for `mu4e-alert`. The package provides desktop notifications for unread emails in `mu4e`. I have tested the recipe using 

```bash
test/test-recipe-interactive.sh mu4e-alert
```

It installed without problems

Thanks