### PR TITLE
Adjust the rtags recipe to properly set the path

### DIFF
--- a/recipes/rtags.rcp
+++ b/recipes/rtags.rcp
@@ -7,4 +7,4 @@
                 ("make" ,@el-get-parallel-make-args))
        :compile "src"
        :load-path "src"
-       :post-init (setq rtags-path default-directory))
+       :post-init (setq rtags-path (concat default-directory "/bin/")))


### PR DESCRIPTION
After [this](https://github.com/Andersbakken/rtags/commit/e6d71e090258e58b1fdd84e8161452ef4ecb90a0)
rtags commit the path to the rtags executables needs to be adjusted.