### PR TITLE
Add recipe for seq

### DIFF
--- a/recipes/seq.rcp
+++ b/recipes/seq.rcp
@@ -1,0 +1,5 @@
+(:name seq
+       :description "Sequence manipulation library for Emacs"
+       :builtin "25"
+       :type github
+       :pkgname "NicolasPetton/seq.el")


### PR DESCRIPTION
Upstream says "seq.el", but MELPA says "seq". This is builtin in Emacs
25.