### PR TITLE
Fix for users who disable GnuTLS

### DIFF
--- a/el-get-install.el
+++ b/el-get-install.el
@@ -21,7 +21,7 @@
         (or (bound-and-true-p el-get-dir)
             (concat (file-name-as-directory user-emacs-directory) "el-get")))))
 
-  (unless (gnutls-available-p)
+  (unless (and (fboundp 'gnutls-available-p) (gnutls-available-p))
     (display-warning
      'el-get
      (concat "Your Emacs doesn't support HTTPS (TLS)"


### PR DESCRIPTION
Emacs which is built with '--without-gnutls' does not have
gnutls-available-p.

This ~~is related to~~ fixes #2282.
CC: @hershaw