### PR TITLE
Update flycheck dependency

### DIFF
--- a/recipes/flycheck.rcp
+++ b/recipes/flycheck.rcp
@@ -1,7 +1,8 @@
 (:name flycheck
        :type github
        :pkgname "flycheck/flycheck"
+       :minimum-emacs-version "24.3"
        :description "On-the-fly syntax checking extension"
        :build '(("makeinfo" "-o" "doc/flycheck.info" "doc/flycheck.texi"))
        :info "./doc"
-       :depends (dash pkg-info let-alist cl-lib))
+       :depends (dash pkg-info let-alist seq))


### PR DESCRIPTION
- Set minimum-emacs version and remove cl-lib.el.
  cl-lib.el was bundled since Emacs 24.3.
- Add seq.el