### PR TITLE
`rename.el` renamed to `go-rename.el` in upstream

### DIFF
--- a/recipes/go-rename.rcp
+++ b/recipes/go-rename.rcp
@@ -5,4 +5,4 @@
        :load-path "src/golang.org/x/tools/refactor/rename"
        :post-init (progn
                     (setq go-rename-command (concat default-directory "bin/gorename"))
-                    (load "rename.el")))
+                    (load "go-rename.el")))


### PR DESCRIPTION
Change was here: golang/tools@f941d540e399747b10540b096ff9300cb3a35ad9

Old version made `go-rename` uninstallable