### PR TITLE
beeminder should depend on org-mode, not org

### DIFF
--- a/recipes/beeminder.rcp
+++ b/recipes/beeminder.rcp
@@ -1,5 +1,5 @@
 (:name beeminder
        :description "Submit data to Beeminder from within Emacs. Also integrates with org-mode."
-       :depends org
+       :depends org-mode
        :type github
        :pkgname "Sodaware/beeminder.el")


### PR DESCRIPTION
Depending on org will result in the ELPA code installing a
conflicting version of org-mode.

This was my fault for getting the original submission wrong.