### PR TITLE
Fix broken `go-oracle` recipe

### DIFF
--- a/recipes/go-oracle.rcp
+++ b/recipes/go-oracle.rcp
@@ -3,8 +3,6 @@
        :type go
        :pkgname "golang.org/x/tools/cmd/oracle"
        :load-path "src/golang.org/x/tools/cmd/oracle"
-       :prepare (progn
-                  (autoload 'go-oracle-mode "oracle" nil t)
-                  (add-hook 'go-mode-hook 'go-oracle-mode))
        :post-init (progn
-                    (setq go-oracle-command (concat default-directory "bin/oracle"))))
+                    (setq go-oracle-command (concat default-directory "bin/oracle"))
+                    (load "oracle.el")))


### PR DESCRIPTION
The `go-oracle-mode` is gone from upstream. Load lib like `go-rename`.

Upstream Change: golang/tools@68b5f7541d840b07800dc21d83ebdaa8ca8a771f