### PR TITLE
Add recipe for prop-menu, update idris-mode deps

### DIFF
--- a/recipes/idris-mode.rcp
+++ b/recipes/idris-mode.rcp
@@ -2,5 +2,6 @@
        :website "https://github.com/idris-hackers/idris-mode"
        :description "Major mode for the Idris language"
        :type github
+       :depends (prop-menu)
        :pkgname "idris-hackers/idris-mode"
        :features idris-mode)

--- a/recipes/prop-menu.rcp
+++ b/recipes/prop-menu.rcp
@@ -1,0 +1,6 @@
+(:name prop-menu
+      :website "https://github.com/david-christiansen/prop-menu-el"
+      :description "Compute pop-up menus from text and overlay properties "
+      :type github
+      :pgkname "david-christiansen/prop-menu-el"
+      :features prop-menu)

--- a/recipes/prop-menu.rcp
+++ b/recipes/prop-menu.rcp
@@ -2,5 +2,4 @@
       :website "https://github.com/david-christiansen/prop-menu-el"
       :description "Compute pop-up menus from text and overlay properties "
       :type github
-      :pgkname "david-christiansen/prop-menu-el"
-      :features prop-menu)
+      :pgkname "david-christiansen/prop-menu-el")


### PR DESCRIPTION
Idris mode reqires prop-menu to be installed, but that package wasn't availablein el-get. This commit adds a recipe for prop-menu, and updates the idris-mode recipe to depend on prop-menu.