### PR TITLE
Update projectile package recipes

### DIFF
--- a/recipes/helm-projectile.rcp
+++ b/recipes/helm-projectile.rcp
@@ -1,0 +1,5 @@
+(:name helm-projectile
+       :description "Helm integration for Projectile."
+       :type github
+       :pkgname "bbatsov/helm-projectile"
+       :depends (projectile helm dash cl-lib))

--- a/recipes/persp-projectile.rcp
+++ b/recipes/persp-projectile.rcp
@@ -1,0 +1,5 @@
+(:name persp-projectile
+       :description "Perspective integration with Projectile."
+       :type github
+       :pkgname "bbatsov/persp-projectile"
+       :depends (projectile perspective cl-lib))

--- a/recipes/projectile.rcp
+++ b/recipes/projectile.rcp
@@ -2,4 +2,4 @@
        :description "Project navigation and management library for Emacs."
        :type github
        :pkgname "bbatsov/projectile"
-       :depends (dash s f pkg-info))
+       :depends (dash pkg-info))


### PR DESCRIPTION
- Update projectile dependencies
- Add helm-projectile and persp-projectile recipes.
  They are hosted on own repositories now.

See also
- https://github.com/bbatsov/helm-projectile/issues/8