### PR TITLE
Fix URLs for chuck-mode recipe

### DIFF
--- a/recipes/chuck-mode.rcp
+++ b/recipes/chuck-mode.rcp
@@ -1,6 +1,6 @@
 (:name chuck-mode
-       :website "https://bitbucket.org/kcfelix/chuck-mode"
+       :website "https://github.com/emacsattic/chuck-mode"
        :description "An editing mode for the chuck language."
        :type http
-       :url "http://bitbucket.org/kcfelix/chuck-mode/raw/d713e29c4c25/chuck-mode.el"
+       :url "https://raw.githubusercontent.com/emacsattic/chuck-mode/master/chuck-mode.el"
        :features "chuck-mode")


### PR DESCRIPTION
The bitbucket.org URLs are broken. as today.  The ones at GitHub used in
this commit are working for me.  The author of the chuck-mode.el file at
GitHub is Kao Cardoso Félix, who was the owner of the now defunct
Bitbucket repository, so the changes in this commit should be okay.