### PR TITLE
Update magit recipes

### DIFF
--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -5,8 +5,7 @@
        :pkgname "magit/magit"
        :branch "master"
        :minimum-emacs-version "24.4"
-       :depends (dash)
-       :provide (with-editor)
+       :depends (dash with-editor emacs-async)
        :info "Documentation"
        :load-path "lisp/"
        :compile "lisp/"

--- a/recipes/with-editor.rcp
+++ b/recipes/with-editor.rcp
@@ -1,0 +1,4 @@
+(:name with-editor
+       :description "Use the Emacsclient as $EDITOR"
+       :type github
+       :pkgname "magit/with-editor")


### PR DESCRIPTION
- Update magit dependencies
- with-editor is hosted own repository now
- Add async recipe

See also
- https://github.com/milkypostman/melpa/pull/3542
- https://github.com/magit/magit/blob/b549e4e0e7d57954eef9011329a53641f3807dcf/lisp/magit.el#L19
