### PR TITLE
jdee: repository moved to github

### DIFF
--- a/recipes/jdee.rcp
+++ b/recipes/jdee.rcp
@@ -1,7 +1,6 @@
 (:name jdee
        :website "http://jdee.sourceforge.net/"
        :description "The JDEE is an add-on software package that turns Emacs into a comprehensive system for creating, editing, debugging, and documenting Java applications."
-       :type svn
-       :url "https://svn.code.sf.net/p/jdee/code/trunk/jdee/"
-       ;; :build ("touch `find . -name Makefile`" "make")
-       :load-path ("lisp"))
+       :type github
+       :pkgname "jdee-emacs/jdee"
+       :load-path ("."))


### PR DESCRIPTION
The repository for jdee moved from sourceforge to github. This patch updates the
recipie accordingly.