### PR TITLE
Use the GitHub fork for the addressbook package

### DIFF
--- a/recipes/addressbook.rcp
+++ b/recipes/addressbook.rcp
@@ -1,8 +1,6 @@
 (:name addressbook
        :description "Simple vCard based addressbook for Emacs"
-       :type cvs
-       :module "addressbook"
-       :url ":pserver:anoncvs@cvs.savannah.nongnu.org:/sources/addressbook"
-       :build (("make" "abook.info")
-               ("ln" "-fs" "abook.info" "addressbook.info"))
-       :info ".")
+       :type github
+       :pkgname "rlaboiss/addressbook"
+       :build (("make" "all"))
+       :info "./abook.info")


### PR DESCRIPTION
The version in CSV at nongnu,org is buggy (info file building problems)
and apparently went out of maintenance.  I forked the project at GitHub
and fixed the problems.  The recipe file is even simpler now, with the
present commit.