### PR TITLE
Add ht dependency to mu4e-alert.

### DIFF
--- a/recipes/mu4e-alert.rcp
+++ b/recipes/mu4e-alert.rcp
@@ -1,5 +1,5 @@
 (:name mu4e-alert
        :description "Desktop notification and mode-line display for mu4e."
        :type github
-       :depends (mu4e alert s)
+       :depends (mu4e alert s ht)
        :pkgname "iqbalansari/mu4e-alert")


### PR DESCRIPTION
An ht dependency has been recently introduced in mu4e-alert, but is not yet reflected in the el-get recipe. See https://github.com/iqbalansari/mu4e-alert/commit/bf6e0d614d199f1403e846ff2616698097fb4039