### PR TITLE
Fix typo in prop-menu recipe.

### DIFF
--- a/recipes/prop-menu.rcp
+++ b/recipes/prop-menu.rcp
@@ -2,4 +2,4 @@
       :website "https://github.com/david-christiansen/prop-menu-el"
       :description "Compute pop-up menus from text and overlay properties "
       :type github
-      :pgkname "david-christiansen/prop-menu-el")
+      :pkgname "david-christiansen/prop-menu-el")


### PR DESCRIPTION
:pkgname is misspelled as :pgkname which results in errors like:

`while installing prop-menu: :pkgname "username/reponame" is mandatory for github recipe 'prop-menu`