### PR TITLE
add info to swiper recipe

### DIFF
--- a/recipes/swiper.rcp
+++ b/recipes/swiper.rcp
@@ -1,4 +1,6 @@
 (:name swiper
        :description "Gives you an overview as you search for a regex."
        :type github
-       :pkgname "abo-abo/swiper")
+       :pkgname "abo-abo/swiper"
+       :build (("makeinfo" "-o" "doc/ivy.info" "doc/ivy.texi"))
+       :info "doc/ivy.info")


### PR DESCRIPTION
The swiper package contains the ivy documentation but only in texi (or
org) format, so first use makeinfo to generate the info file.