### PR TITLE
Remove 'info' build process

### DIFF
--- a/recipes/flycheck.rcp
+++ b/recipes/flycheck.rcp
@@ -3,6 +3,4 @@
        :pkgname "flycheck/flycheck"
        :minimum-emacs-version "24.3"
        :description "On-the-fly syntax checking extension"
-       :build '(("makeinfo" "-o" "doc/flycheck.info" "doc/flycheck.texi"))
-       :info "./doc"
        :depends (dash pkg-info let-alist seq))


### PR DESCRIPTION
flycheck switched from texinfo to sphinx and texi file is no longer built. I got following errors by `makeinfo`.

```
% makeinfo -o doc/legacy/flycheck.info doc/legacy/flycheck.texi
doc/legacy/flycheck.texi:64: @pxref reference to nonexistent node `Installation'
doc/legacy/flycheck.texi:108: @xref reference to nonexistent node `Supported languages'
doc/legacy/flycheck.texi:158: @xref reference to nonexistent node `Supported languages'
doc/legacy/flycheck.texi:77: @menu reference to nonexistent node `Installation'
doc/legacy/flycheck.texi:83: @menu reference to nonexistent node `Supported languages'
% echo $?
1
```

See also
- https://github.com/flycheck/flycheck/issues/901
- https://github.com/flycheck/flycheck/pull/923
- https://github.com/flycheck/flycheck/issues/924
