### PR TITLE
Revert "remove tablist.rcp, because it is moved inside pdf-tools' repo."

### DIFF
--- a/recipes/pdf-tools.rcp
+++ b/recipes/pdf-tools.rcp
@@ -5,7 +5,7 @@
        ;; On Debian, "libpoppler-glib-dev" "libpoppler-dev"
        ;; "libpoppler-private-dev" are needed to build c code in this package.
        :pkgname "politza/pdf-tools"
-       :depends (let-alist)
+       :depends (let-alist tablist)
 
        ;; pdf-tools' code written to find "epdfinfo" executable in the lisp
        ;; directory. we preset following variable to avoid that.

--- a/recipes/tablist.rcp
+++ b/recipes/tablist.rcp
@@ -1,0 +1,5 @@
+(:name tablist
+       :description "Extended Emacs tabulated-list-mode."
+       :website "https://github.com/politza/tablist"
+       :type github
+       :pkgname "politza/tablist")


### PR DESCRIPTION
fixes #2367.
```
This reverts commit fe2533e234cab4c04488382b9176ac569b0e8d2a.

pdf-tools removed tablist again [1].

[1]: https://github.com/politza/pdf-tools/commit/0277eec38107c4d9a5263d7817e297ff0cf0d3dc
```