### PR TITLE
need to dependencies for `s`

### DIFF
--- a/recipes/emacs-racer.rcp
+++ b/recipes/emacs-racer.rcp
@@ -2,4 +2,4 @@
        :description "Racer support for Emacs"
        :type github
        :pkgname "racer-rust/emacs-racer"
-       :depends (rust-mode company-mode))
+       :depends (rust-mode company-mode s))


### PR DESCRIPTION
need to dependencies for `s`
```elisp
(require 's)
```
https://github.com/racer-rust/emacs-racer/blob/master/racer.el#L61