### PR TITLE
Fix Recipes for Rust Development

### DIFF
--- a/recipes/emacs-racer.rcp
+++ b/recipes/emacs-racer.rcp
@@ -2,4 +2,4 @@
        :description "Racer support for Emacs"
        :type github
        :pkgname "racer-rust/emacs-racer"
-       :depends (rust-mode company-mode s))
+       :depends (rust-mode company-mode dash s))

--- a/recipes/rust-racer.rcp
+++ b/recipes/rust-racer.rcp
@@ -6,7 +6,5 @@
        :pkgname "phildawes/racer"
        :description "Rust code completion and code navigation"
        :build '(("cargo" "build" "--release"))
-       :depends (rust-mode company-mode)
-       :load-path "editors/emacs"
-       :prepare (add-hook 'rust-mode-hook #'racer-activate)
-       :post-init (setq racer-cmd (concat default-directory "/target/release/racer")))
+       :prepare (setq racer-cmd (concat default-directory "/target/release/racer"))
+       :post-init (add-hook 'racer-mode-hook #'eldoc-mode))


### PR DESCRIPTION
The file extension .rs is now automatically associated with rust-mode. Racer is the code-completion mechanism for Rust. The Emacs integration between Rust-mode and rust-racer was split into the existing recipe emacs-racer.rcp, but the recipes did not reflect this. Finally, add dependencies so that emacs-racer runs without errors.