### PR TITLE
Added proof-general recipe

### DIFF
--- a/recipes/proof-general.rcp
+++ b/recipes/proof-general.rcp
@@ -1,0 +1,11 @@
+(:name proof-general
+       :description "A generic Emacs interface for interactive proof assistants."
+       :type github
+       :pkgname "ProofGeneral/PG"
+       :build `(("make" "clean")
+                ("make" ,(concat "EMACS=" el-get-emacs) "compile")
+                ("makeinfo" "doc/ProofGeneral.texi" "-o" "doc")
+                ("makeinfo" "doc/PG-adapting.texi" "-o" "doc"))
+       :info "doc"
+       :load "generic/proof-site.el"
+       :website "http://proofgeneral.inf.ed.ac.uk/")


### PR DESCRIPTION
ProofGeneral.rcp in the current distribution of el-get packages an old version of Proof General from http://proofgeneral.inf.ed.ac.uk/releases/ProofGeneral-4.2.tgz

Proof General has since moved to GitHub, see http://coq-club.inria.narkive.com/Dp5A2NzL/proof-general-has-moved-to-github#post1

The recipe I'm submitting packages the GitHub version of Proof General.  I've named it proof-general.rcp to avoid a clash with the current ProofGeneral.rcp.  The output of the recipe checker is attached as a text file.

[proof-general.txt](https://github.com/dimitri/el-get/files/235236/proof-general.txt)
