### PR TITLE
rcp/es mode

### DIFF
--- a/recipes/es-mode.rcp
+++ b/recipes/es-mode.rcp
@@ -3,4 +3,4 @@
        :description "An Emacs major mode for editing Elasticsearch requests"
        :type github
        :pkgname "dakrone/es-mode"
-       :features es-mode)
+       :depends (dash cl-lib spark))

--- a/recipes/spark.rcp
+++ b/recipes/spark.rcp
@@ -1,0 +1,5 @@
+(:name spark
+       :website "https://github.com/alvinfrancis/spark"
+       :description "Port of cl-spark to emacs lisp. Generates a sparkline string for a list of numbers."
+       :type github
+       :pkgname "alvinfrancis/spark")


### PR DESCRIPTION
- Adds a new recipe, `spark`, which is a es-mode dependency
- Updates the `es-mode` recipe and adds the `:depends` property