### PR TITLE
Added company-coq recipe

### DIFF
--- a/recipes/company-coq.rcp
+++ b/recipes/company-coq.rcp
@@ -1,0 +1,7 @@
+(:name company-coq
+       :description "A collection of company-mode based extensions to Proof General's Coq mode.  Do `M-x company-coq-tutorial' after installation to open a tutorial."
+       :type github
+       :pkgname "cpitclaudel/company-coq"
+       :depends (cl-lib company-math company-mode dash yasnippet)
+       :prepare (add-hook 'coq-mode-hook 'company-coq-mode)
+       :website "https://github.com/cpitclaudel/company-coq/")

--- a/recipes/company-coq.rcp
+++ b/recipes/company-coq.rcp
@@ -2,6 +2,6 @@
        :description "A collection of company-mode based extensions to Proof General's Coq mode.  Do `M-x company-coq-tutorial' after installation to open a tutorial."
        :type github
        :pkgname "cpitclaudel/company-coq"
-       :depends (cl-lib company-math company-mode dash yasnippet)
+       :depends (cl-lib company-math company-mode dash proof-general yasnippet)
        :prepare (add-hook 'coq-mode-hook 'company-coq-mode)
        :website "https://github.com/cpitclaudel/company-coq/")


### PR DESCRIPTION
Company-coq is a collection of company-mode based extensions to Proof General's Coq mode.

Here's the output of M-x el-get-check-recipe:

/Users/raghu/etc/emacs/pkg/recipes/company-coq.rcp: 0 error(s) found.

I've also tested it successfully with test-recipe.sh.