### PR TITLE
ensure req-package gets required

### DIFF
--- a/recipes/req-package.rcp
+++ b/recipes/req-package.rcp
@@ -1,5 +1,6 @@
 (:name req-package
        :description "req-package is a macro wrapper on top of use-package. It's goal is to simplify package dependencies management, when using use-package for your .emacs."
        :type github
+       :features (req-package)
        :depends (use-package dash log4e)
        :pkgname "edvorg/req-package")


### PR DESCRIPTION
Without specifying `:features`, it doesn't get required, so is not usable after `el-get-do-init`.