### PR TITLE
Give scala-mode name to ensime/emacs-scala-mode

### DIFF
--- a/recipes/ensime.rcp
+++ b/recipes/ensime.rcp
@@ -6,7 +6,7 @@
                  dash
                  popup
                  auto-complete
-                 scala-mode2
+                 scala-mode
                  sbt-mode
                  company-mode
                  yasnippet)

--- a/recipes/scala-mode.rcp
+++ b/recipes/scala-mode.rcp
@@ -1,7 +1,5 @@
 (:name scala-mode
-       :description "Major mode for editing Scala code."
-       :type git
-       :url "https://github.com/scala/scala-tool-support.git"
-       :build `(("make" "-C" "tool-support/emacs" "all" ,(concat "ELISP_COMMAND=" el-get-emacs)))
-       :load-path ("tool-support/emacs")
-       :features scala-mode-auto)
+       :description "The definitive scala-mode for emacs"
+       :type github
+       :website "http://ensime.org"
+       :pkgname "ensime/emacs-scala-mode")

--- a/recipes/scala-mode2.rcp
+++ b/recipes/scala-mode2.rcp
@@ -1,4 +1,0 @@
-(:name scala-mode2
-       :description "A new scala-mode for Emacs 24."
-       :type github
-       :pkgname "hvesalai/scala-mode2")


### PR DESCRIPTION
```
This is what MElPA uses.  There is no longer a scala-mode2 package.
hvesalai/scala-mode2, which was previously scala-mode2, is a lagging
fork of ensime/emacs-scala-mode so it's not needed.

The old scala-mode from scala/scala-tool-support.git has not been
updated for 2 years.
```

Fixes #2394.