### PR TITLE
Update nim mode recipe and add commenter recipe

### DIFF
--- a/recipes/commenter.rcp
+++ b/recipes/commenter.rcp
@@ -1,0 +1,8 @@
+(:name commenter
+       :website "https://github.com/yuutayamada/commenter#readme"
+       :description "multiline-comment support package"
+       :type github
+       :pkgname "yuutayamada/commenter"
+       :branch "master"
+       :minimum-emacs-version "24.4"
+       :depends (let-alist))

--- a/recipes/nim-mode.rcp
+++ b/recipes/nim-mode.rcp
@@ -1,4 +1,8 @@
 (:name nim-mode
+       :website "https://github.com/nim-lang/nim-mode#readme"
+       :description "Major mode for the Nim programming language"
        :type github
-       :pkgname "reactormonk/nim-mode"
-       :description "Major mode for the Nim programming language")
+       :pkgname "nim-lang/nim-mode"
+       :branch "master"
+       :minimum-emacs-version "24.4"
+       :depends (flycheck company-mode epc let-alist commenter))


### PR DESCRIPTION
The nim-mode's repository was moved to nim-lang from reactormonk's and
the nim-mode is depending on commenter package, so I just added the recipe as well.
(https://github.com/nim-lang/Nim/wiki/editor-support)