### PR TITLE
Add docker-tramp recipe

### DIFF
--- a/recipes/docker-tramp.rcp
+++ b/recipes/docker-tramp.rcp
@@ -1,0 +1,4 @@
+(:name docker-tramp
+       :description "TRAMP integration for docker containers"
+       :type github
+       :pkgname "emacs-pe/docker-tramp.el" )

--- a/recipes/docker.rcp
+++ b/recipes/docker.rcp
@@ -2,4 +2,4 @@
        :description "Manage docker images & containers from Emacs"
        :type github
        :pkgname "Silex/docker.el"
-       :depends (magit s dash))
+       :depends (magit s dash docker-tramp))


### PR DESCRIPTION
The definition is taken from that of MELPA:
    https://melpa.org/#/docker-tramp

Note this is included in the dependency of recipe/docker.rcp .