### PR TITLE
Remove :features property

### DIFF
--- a/recipes/quickrun.rcp
+++ b/recipes/quickrun.rcp
@@ -2,5 +2,4 @@
        :description "Run commands quickly"
        :website "https://github.com/syohex/emacs-quickrun"
        :type github
-       :pkgname "syohex/emacs-quickrun"
-       :features "quickrun")
+       :pkgname "syohex/emacs-quickrun")


### PR DESCRIPTION
Because quickrun sets autoload cookie correctly and it should be loaded
at first using time, not initializing time.