### PR TITLE
Update shell-pop recipe

### DIFF
--- a/recipes/shell-pop.rcp
+++ b/recipes/shell-pop.rcp
@@ -1,5 +1,5 @@
 (:name shell-pop
        :description "Helps you pop up and pop out shell buffer easily."
-       :website "http://www.emacswiki.org/emacs/ShellPop"
-       :type emacswiki
-       :features "shell-pop")
+       :website "https://github.com/kyagi/shell-pop-el"
+       :type github
+       :pkgname "kyagi/shell-pop-el")


### PR DESCRIPTION
It is hosted on github. Emacswiki page is no longer updated.
And remove :features property because it sets autoload cookies correctly.