### PR TITLE
Update buffer-move recipe

### DIFF
--- a/recipes/buffer-move.rcp
+++ b/recipes/buffer-move.rcp
@@ -1,4 +1,5 @@
 (:name buffer-move
        :description "Swap buffers without typing C-x b on each window"
-       :type emacswiki
-       :features buffer-move)
+       :website "https://github.com/lukhas/buffer-move"
+       :type github
+       :pkgname "lukhas/buffer-move")


### PR DESCRIPTION
It moves github now. And remove :features property because it sets
autoload cookie correctly.