### PR TITLE
Remove :features property

### DIFF
--- a/recipes/goto-chg.rcp
+++ b/recipes/goto-chg.rcp
@@ -1,4 +1,3 @@
 (:name goto-chg
        :description "Goto the point of the most recent edit in the buffer."
-       :type emacswiki
-       :features goto-chg)
+       :type emacswiki)

--- a/recipes/io-mode.rcp
+++ b/recipes/io-mode.rcp
@@ -1,5 +1,4 @@
 (:name io-mode
        :description "Major mode to edit Io language files in Emacs"
        :type github
-       :pkgname "superbobry/io-mode"
-       :features io-mode)
+       :pkgname "superbobry/io-mode")

--- a/recipes/julia-mode.rcp
+++ b/recipes/julia-mode.rcp
@@ -1,5 +1,4 @@
 (:name julia-mode
        :type http
        :url "https://raw.githubusercontent.com/JuliaLang/julia-emacs/master/julia-mode.el"
-       :description "Edit jl files in emacs."
-       :features julia-mode)
+       :description "Edit jl files in emacs.")

--- a/recipes/nyan-mode.rcp
+++ b/recipes/nyan-mode.rcp
@@ -1,5 +1,4 @@
 (:name nyan-mode
        :description "Nyan Cat for Emacs! Nyanyanyanyanyanyanyanyanyan!"
        :type github
-       :pkgname "TeMPOraL/nyan-mode"
-       :features nyan-mode)
+       :pkgname "TeMPOraL/nyan-mode")

--- a/recipes/ruby-end.rcp
+++ b/recipes/ruby-end.rcp
@@ -1,5 +1,4 @@
 (:name ruby-end
        :description "Emacs minor mode for automatic insertion of end blocks for Ruby"
        :type http
-       :url "https://github.com/rejeep/ruby-end/raw/master/ruby-end.el"
-       :features ruby-end)
+       :url "https://github.com/rejeep/ruby-end/raw/master/ruby-end.el")

--- a/recipes/scss-mode.rcp
+++ b/recipes/scss-mode.rcp
@@ -1,5 +1,4 @@
 (:name scss-mode
        :description "Major mode for editing SCSS files(http://sass-lang.com)"
        :type github
-       :pkgname "antonj/scss-mode"
-       :features scss-mode)
+       :pkgname "antonj/scss-mode")

--- a/recipes/vline.rcp
+++ b/recipes/vline.rcp
@@ -1,3 +1,3 @@
 (:name vline
        :description "show vertical line (column highlighting) mode."
-       :type emacswiki :features vline)
+       :type emacswiki)

--- a/recipes/yalinum.rcp
+++ b/recipes/yalinum.rcp
@@ -2,5 +2,4 @@
        :description "Yet another display line numbers."
        :website "https://github.com/tm8st/emacs-yalinum/"
        :type github
-       :pkgname "tm8st/emacs-yalinum"
-       :features "yalinum")
+       :pkgname "tm8st/emacs-yalinum")

--- a/recipes/yascroll.rcp
+++ b/recipes/yascroll.rcp
@@ -2,5 +2,4 @@
        :description "Yet Another Scroll Bar Mode"
        :website "https://github.com/m2ym/yascroll-el"
        :type github
-       :pkgname "m2ym/yascroll-el"
-       :features "yascroll")
+       :pkgname "m2ym/yascroll-el")


### PR DESCRIPTION
Because they set autoload cookie correctly and users need not to
load them at initializing time.