### PR TITLE
Add ob-ipython recipe

### DIFF
--- a/recipes/ob-ipython.rcp
+++ b/recipes/ob-ipython.rcp
@@ -1,0 +1,5 @@
+(:name ob-ipython
+       :description "org-babel integration with Jupyter for evaluation of (Python by default) code blocks"
+       :type github
+       :pkgname "gregsexton/ob-ipython"
+       :depends (dash s f))


### PR DESCRIPTION
org-babel integration with Jupyter for evaluation of (Python by default) code
blocks