### PR TITLE
helm-bibtex requires biblio.el.  Added both.

### DIFF
--- a/recipes/biblio.rcp
+++ b/recipes/biblio.rcp
@@ -1,0 +1,5 @@
+(:name biblio
+       :type github
+       :description "Bibliography utilities for Emacs."
+       :pkgname "cpitclaudel/biblio.el"
+       :depends (let-alist seq dash))

--- a/recipes/helm-bibtex.rcp
+++ b/recipes/helm-bibtex.rcp
@@ -2,4 +2,4 @@
        :type github
        :description "A bibliography manager for Emacs."
        :pkgname "tmalsburg/helm-bibtex"
-       :depends (helm parsebib dash s f))
+       :depends (helm parsebib dash s f biblio))


### PR DESCRIPTION
helm-bibtex now requires cpitclaudel/biblio.el

This PR adds a recipe for biblio and adds that as a dependency to helm-bibtex.

el-get-check-recipe returns the following:

`/home/spauldo/repos/el-get/recipes/biblio.rcp: 0 error(s) found.`
`/home/spauldo/repos/el-get/recipes/helm-bibtex.rcp: 0 error(s) found.`