### PR TITLE
update helm-bibtex and add ivy-bibtex

### DIFF
--- a/recipes/helm-bibtex.rcp
+++ b/recipes/helm-bibtex.rcp
@@ -2,4 +2,5 @@
        :type github
        :description "A BibTeX bibliography manager based on Helm."
        :pkgname "tmalsburg/helm-bibtex"
-       :depends (helm parsebib s dash f cl-lib biblio))
+       :depends (helm parsebib s dash f cl-lib biblio)
+       :compile ("bibtex-completion.el" "helm-bibtex.el"))

--- a/recipes/helm-bibtex.rcp
+++ b/recipes/helm-bibtex.rcp
@@ -1,5 +1,5 @@
 (:name helm-bibtex
        :type github
-       :description "A bibliography manager for Emacs."
+       :description "A BibTeX bibliography manager based on Helm."
        :pkgname "tmalsburg/helm-bibtex"
-       :depends (helm parsebib dash s f biblio))
+       :depends (helm parsebib s dash f cl-lib biblio))

--- a/recipes/ivy-bibtex.rcp
+++ b/recipes/ivy-bibtex.rcp
@@ -1,0 +1,5 @@
+(:name helm-bibtex
+       :type github
+       :description "A BibTeX bibliography manager based on Ivy."
+       :pkgname "tmalsburg/helm-bibtex"
+       :depends (swiper parsebib s dash f cl-lib biblio))

--- a/recipes/ivy-bibtex.rcp
+++ b/recipes/ivy-bibtex.rcp
@@ -1,5 +1,6 @@
-(:name helm-bibtex
+(:name ivy-bibtex
        :type github
        :description "A BibTeX bibliography manager based on Ivy."
        :pkgname "tmalsburg/helm-bibtex"
-       :depends (swiper parsebib s dash f cl-lib biblio))
+       :depends (swiper parsebib s dash f cl-lib biblio)
+       :compile ("bibtex-completion.el" "ivy-bibtex.el"))


### PR DESCRIPTION
There is now an additional package ivy-bibtex in the
tmalbsburg/helm-bibtex repository (and on MELPA). Helm-bibtex.el and ivy-bibtex.el are now two alternative
backends for the backend-independent bibtex-completion.el. The former
backend depends on helm whereas the latter depends on ivy (swiper).

So I updated the helm-bibtex and added the ivy-bibtex recipes, using the current
descriptions and dependencies.

Note that ideally, one should exclude the helm-bibtex.el file from the
ivy-bibtex package and the ivy-bibtex.el file from the helm-bibtex
package (as is done on MELPA). But I didn't find how to do this with el-get.

cc @tmalsburg, the author of helm-bibtex and ivy-bibtex.