### PR TITLE
modify org-mode git url

### DIFF
--- a/recipes/org-mode.rcp
+++ b/recipes/org-mode.rcp
@@ -2,7 +2,7 @@
        :website "http://orgmode.org/"
        :description "Org-mode is for keeping notes, maintaining ToDo lists, doing project planning, and authoring with a fast and effective plain-text system."
        :type git
-       :url "git://orgmode.org/org-mode.git"
+       :url "http://orgmode.org/org-mode.git"
        :info "doc"
        :build/berkeley-unix `,(mapcar
                                (lambda (target)


### PR DESCRIPTION
The old org-mode url would result in "fatal: read error: Connection reset by peer". After changed the git url to "http://orgmode.org/org-mode.git", it's now working. I have tested the new one with "test/test-recipe.sh org-mode".