### PR TITLE
Make list of secure protocols customizable

### DIFF
--- a/el-get-custom.el
+++ b/el-get-custom.el
@@ -614,8 +614,17 @@ platforms where this recipe should apply"
 
 ;; TODO: this should be nil; change at the next major version bump
 (defcustom el-get-allow-insecure t
-  "Allow packages to be installed over insecure connections."
+  "Allow packages to be installed over insecure connections.
+
+See `el-get-insecure-check'."
   :group 'el-get
   :type 'boolean)
+
+(defcustom el-get-secure-protocols '("https" "ssh" "git+ssh" "bzr+ssh" "sftp")
+  "List of secure protocols.
+
+See `el-get-insecure-check'."
+  :group 'el-get
+  :type '(repeat string))
 
 (provide 'el-get-custom)

--- a/el-get-methods.el
+++ b/el-get-methods.el
@@ -24,6 +24,7 @@
 
 (defun el-get-insecure-check (package url)
   (when (and (not el-get-allow-insecure)
+             (not (string-match "^file:///" url))
              (not (string-match "^https://" url))
              (not (string-match "^[-_\.A-Za-z0-9]+@" url))
              (not (string-match "^ssh" url)))

--- a/el-get-methods.el
+++ b/el-get-methods.el
@@ -30,8 +30,9 @@
     ;; If we have :checksum, we can rely on `el-get-post-install' for
     ;; security.
     (unless (plist-get (el-get-package-def package) :checksum)
-      (error (concat "Attempting to install insecure package "
+      (error (concat "Attempting to install package "
                      (el-get-as-string package)
+                     " from insecure URL " url
                      " without `el-get-allow-insecure'.")))))
 
 (require 'el-get-apt-get)

--- a/el-get-methods.el
+++ b/el-get-methods.el
@@ -34,6 +34,9 @@
                (not (string-match "^file:///" url))
                (not (string-match "^https://" url))
                (not (string-match "^[-_\.A-Za-z0-9]+@" url))
+               (not (string-match "^sftp://" url))
+               (not (string-match "^bzr\\+ssh://" url))
+               (not (string-match "^git\\+ssh://" url))
                (not (string-match "^ssh" url)))
       ;; With not empty :checksum, we can rely on `el-get-post-install' calling
       ;; `el-get-verify-checksum' for security.

--- a/test/el-get-tests.el
+++ b/test/el-get-tests.el
@@ -129,7 +129,13 @@ Following variables are bound to temporal values:
 (defconst insecure-urls '("http://example.com"
                           "ftp://example.com"
                           "file://example.com/home/user"
-                          ":pserver:anonymous@example.com"))
+                          ":pserver:anonymous@example.com"
+                        "
+https://example.com"
+                        "
+file:///home/user"
+                        "
+John.Doe-123_@example.com"))
 
 (ert-deftest el-get-insecure-check-insecure ()
   "Insecure URL for a package without :checksum"

--- a/test/el-get-tests.el
+++ b/test/el-get-tests.el
@@ -125,3 +125,33 @@ Following variables are bound to temporal values:
      (should-not (featurep pkg))
      (el-get 'sync (mapcar 'el-get-source-name el-get-sources))
      (should (featurep pkg)))))
+
+(defconst insecure-urls '("http://example.com"
+                          "ftp://example.com"
+                          ":pserver:anonymous@example.com"))
+
+(ert-deftest el-get-insecure-check-insecure ()
+  "Insecure URL for a package without :checksum"
+  (dolist (url insecure-urls)
+    (let ((el-get-allow-insecure nil)
+          (el-get-sources '((:name "dummy" :type github))))
+      ;; TODO check for error message?
+      (should-error (el-get-insecure-check "dummy" url) :type 'error))))
+
+(defconst secure-urls '("https://example.com"
+                        "ssh://example.com"
+                        "John.Doe-123_@example.com"))
+
+(ert-deftest el-get-insecure-check-secure ()
+  "Secure URL for a package without :checksum doesn't matter"
+  (dolist (url secure-urls)
+    (let ((el-get-allow-insecure nil)
+          (el-get-sources '((:name "dummy" :type github))))
+      (should-not (el-get-insecure-check "dummy" url)))))
+
+(ert-deftest el-get-insecure-check-checksum ()
+  "Either secure or insecure URL for a package with :checksum"
+  (dolist (url (append insecure-urls secure-urls))
+    (let ((el-get-allow-insecure nil)
+          (el-get-sources '((:name "dummy" :type github :checksum "checksum"))))
+      (should-not (el-get-insecure-check "dummy" url)))))

--- a/test/el-get-tests.el
+++ b/test/el-get-tests.el
@@ -129,9 +129,6 @@ Following variables are bound to temporal values:
 (defconst insecure-urls '("http://example.com"
                           "ftp://example.com"
                           "file://example.com/home/user"
-                          "git+ssh://example.com/"
-                          "bzr+ssh://example.com/"
-                          "sftp://example.com/"
                           ":pserver:anonymous@example.com"))
 
 (ert-deftest el-get-insecure-check-insecure ()
@@ -144,6 +141,9 @@ Following variables are bound to temporal values:
 
 (defconst secure-urls '("https://example.com"
                         "ssh://example.com"
+                        "git+ssh://example.com/"
+                        "bzr+ssh://example.com/"
+                        "sftp://example.com/"
                         "file:///home/user"
                         "file:///c|/WINDOWS/clock.avi"
                         "file:///c:/WINDOWS/clock.avi"

--- a/test/el-get-tests.el
+++ b/test/el-get-tests.el
@@ -129,6 +129,9 @@ Following variables are bound to temporal values:
 (defconst insecure-urls '("http://example.com"
                           "ftp://example.com"
                           "file://example.com/home/user"
+                          "git+ssh://example.com/"
+                          "bzr+ssh://example.com/"
+                          "sftp://example.com/"
                           ":pserver:anonymous@example.com"))
 
 (ert-deftest el-get-insecure-check-insecure ()

--- a/test/el-get-tests.el
+++ b/test/el-get-tests.el
@@ -128,6 +128,7 @@ Following variables are bound to temporal values:
 
 (defconst insecure-urls '("http://example.com"
                           "ftp://example.com"
+                          "file://example.com/home/user"
                           ":pserver:anonymous@example.com"))
 
 (ert-deftest el-get-insecure-check-insecure ()
@@ -140,6 +141,9 @@ Following variables are bound to temporal values:
 
 (defconst secure-urls '("https://example.com"
                         "ssh://example.com"
+                        "file:///home/user"
+                        "file:///c|/WINDOWS/clock.avi"
+                        "file:///c:/WINDOWS/clock.avi"
                         "John.Doe-123_@example.com"))
 
 (ert-deftest el-get-insecure-check-secure ()

--- a/test/el-get-tests.el
+++ b/test/el-get-tests.el
@@ -159,3 +159,12 @@ Following variables are bound to temporal values:
     (let ((el-get-allow-insecure nil)
           (el-get-sources '((:name "dummy" :type github :checksum "checksum"))))
       (should-not (el-get-insecure-check "dummy" url)))))
+
+(ert-deftest el-get-insecure-check-checksum-empty ()
+  "Insecure URL for a package with empty :checksum"
+  (dolist (url insecure-urls)
+    (dolist (checksum '("" "   "))
+      (let ((el-get-allow-insecure nil)
+            (el-get-sources '((:name "dummy" :type github :checksum checksum))))
+        ;; TODO check for error message?
+        (should-error (el-get-insecure-check "dummy" url) :type 'error)))))


### PR DESCRIPTION
Via 'el-get-secure-protocols, user can customize list of URL protocols
considered by 'el-get-insecure-check as secure.

By default, these protocols are considered as secure:
- https
- ssh
- git+ssh
- bzr+ssh
- sftp
