### PR TITLE
Fix logic when deciding if apt-get package should be installed

### DIFF
--- a/methods/el-get-apt-get.el
+++ b/methods/el-get-apt-get.el
@@ -123,8 +123,8 @@ password prompt."
 (defun el-get-apt-get-install-if-needed (package url post-install-fun)
   "Call `el-get-apt-get-install' if PACKAGE isn't installed yet.
 The installation status is retrieved from the system, not el-get."
-  (when (el-get-dpkg-package-installed-p (or (plist-get (el-get-package-def package) :pkgname)
-					     (el-get-as-string package)))
+  (unless (el-get-dpkg-package-installed-p (or (plist-get (el-get-package-def package) :pkgname)
+                                               (el-get-as-string package)))
     (el-get-apt-get-install package url post-install-fun)))
 
 (defun el-get-apt-get-install (package url post-install-fun)


### PR DESCRIPTION
Install apt-get package only if it's not installed.