### PR TITLE
[docker] Add missing dependency on tablist

### DIFF
--- a/recipes/docker.rcp
+++ b/recipes/docker.rcp
@@ -2,4 +2,4 @@
        :description "Manage docker images & containers from Emacs"
        :type github
        :pkgname "Silex/docker.el"
-       :depends (magit s dash docker-tramp))
+       :depends (magit s dash docker-tramp tablist))


### PR DESCRIPTION
Dependency on tablist had been instroduced in April [1].

[1] https://github.com/Silex/docker.el/commit/20dafdd98463f0dfffa23a0a3cdcd7e5bc72c2e3