### PR TITLE
Update recipe for org-evil

### DIFF
--- a/recipes/evil-org.rcp
+++ b/recipes/evil-org.rcp
@@ -1,7 +1,0 @@
-(:name evil-org
-       :description "Evil extensions for Org-mode"
-       :website "https://github.com/GuiltyDolphin/evil-org"
-       :type github
-       :pkgname "GuiltyDolphin/evil-org"
-       :branch "master"
-       :depends (dash emaps evil hook))

--- a/recipes/org-evil.rcp
+++ b/recipes/org-evil.rcp
@@ -1,0 +1,7 @@
+(:name org-evil
+       :description "Evil extensions for Org-mode"
+       :website "https://github.com/GuiltyDolphin/org-evil"
+       :type github
+       :pkgname "GuiltyDolphin/org-evil"
+       :branch "master"
+       :depends (dash evil hook))

--- a/recipes/org-evil.rcp
+++ b/recipes/org-evil.rcp
@@ -4,4 +4,4 @@
        :type github
        :pkgname "GuiltyDolphin/org-evil"
        :branch "master"
-       :depends (dash evil hook))
+       :depends (dash evil monitor))


### PR DESCRIPTION
Package was renamed (from evil-org to org-evil). (Young package, so shouldn't have any issues).

Also removed 'emaps dependency.

---

No warnings from test.