### PR TITLE
Update dependency of docker recipe

### DIFF
--- a/recipes/docker.rcp
+++ b/recipes/docker.rcp
@@ -2,4 +2,4 @@
        :description "Manage docker images & containers from Emacs"
        :type github
        :pkgname "Silex/docker.el"
-       :depends (magit s dash docker-tramp tablist))
+       :depends (magit s dash docker-tramp tablist json-mode))


### PR DESCRIPTION
#2449 is not enough because docker-mode mistook to add `json-mode` dependency(https://github.com/Silex/docker.el/pull/46).