### PR TITLE
Allow the user to chose between sync/async el-get.

### DIFF
--- a/el-get-bundle.el
+++ b/el-get-bundle.el
@@ -253,9 +253,14 @@ same.  If you wish to `require' more than one feature, then use
 `:features' property in FORM.
 
 The initialization FORM may start with a property list that
-describes a local recipe.  The FORM after the property list is
-treated as initialization code, which is actually an `:after'
-property of the local recipe.
+describes a local recipe.  The property list may include the keyword
+`:bundle-sync' with a value of either `t' or `nil' to request that
+`el-get-bundle' invoke `el-get' synchronously (respectively asynchronously).
+The keyword `:bundle-async' is the inverse of `:bundle-sync'.
+\(Note that the request to run el-get synchronously may not be respected in all
+circumstances: see the definition of `el-get-bundle-el-get' for details.)
+The FORM after the property list is treated as initialization code,
+which is actually an `:after' property of the local recipe.
 
 A copy of the initialization code is stored in a directory
 specified by `el-get-bundle-init-directory' and its byte-compiled

--- a/el-get-bundle.el
+++ b/el-get-bundle.el
@@ -274,7 +274,7 @@ version is used if `el-get-bundle-byte-compile' is non-nil."
       (setq form (nthcdr 2 form) require t))
     ;; parse keywords
     (while (keywordp (nth 0 form))
-      (cl-case (nth 0 form)
+      (case (nth 0 form)
         (:bundle-sync (setq sync (nth 1 form)))
         (:bundle-async (setq sync (not (nth 1 form))))
         (t (setq src (plist-put src (nth 0 form) (nth 1 form)))))
@@ -295,7 +295,7 @@ version is used if `el-get-bundle-byte-compile' is non-nil."
     ;; init script
     (setq src (plist-put src :after form))
 
-    `(el-get-bundle-el-get ',src ,(and sync ''sync))))
+    `(el-get-bundle-el-get ',src ',(when sync 'sync))))
 
 ;;;###autoload
 (defmacro el-get-bundle! (package &rest args)


### PR DESCRIPTION
Prior to that change el-get bundle forced the `sync` argument to el-get to `'sync` (and then set  it to `nil` in some circumstances where `'sync` wouldn't work.  This change gives user the option to more finely control whether el-get is being run synchronously or asynchronously by the `el-get-bundle` macro.