### PR TITLE
update projectile dependencies

### DIFF
--- a/recipes/projectile.rcp
+++ b/recipes/projectile.rcp
@@ -2,4 +2,4 @@
        :description "Project navigation and management library for Emacs."
        :type github
        :pkgname "bbatsov/projectile"
-       :depends (dash pkg-info))
+       :depends pkg-info)


### PR DESCRIPTION
`projectile` no longer depends on `dash`.

/cc @bbatsov , `projectile` maintainer