### PR TITLE
helm-projectile no longer depends on dash

### DIFF
--- a/recipes/helm-projectile.rcp
+++ b/recipes/helm-projectile.rcp
@@ -2,4 +2,4 @@
        :description "Helm integration for Projectile."
        :type github
        :pkgname "bbatsov/helm-projectile"
-       :depends (projectile helm dash cl-lib))
+       :depends (projectile helm cl-lib))


### PR DESCRIPTION
This is a similar #2455 PR

See
- dash.el dependency was drop by https://github.com/bbatsov/helm-projectile/pull/45