### PR TITLE
Fix wrong url for go-def

### DIFF
--- a/recipes/go-def.rcp
+++ b/recipes/go-def.rcp
@@ -1,5 +1,5 @@
 (:name go-def
        :description "Required for go-mode godef functions"
        :type go
-       :pkgname "code.google.com/p/rog-go/exp/cmd/godef"
+       :pkgname "github.com/rogpeppe/godef"
        :post-init (add-to-list 'exec-path (concat default-directory "bin")))


### PR DESCRIPTION
The URL for go-def seems broken, this fixes it to the correct URL