### PR TITLE
Move iedit and livescript-mode origins

### DIFF
--- a/recipes/iedit.rcp
+++ b/recipes/iedit.rcp
@@ -1,4 +1,7 @@
 (:name iedit
        :description "Edit multiple regions with the same content simultaneously."
-       :type emacswiki
+       :type github
+       :pkgname "victorhge/iedit"
+       ;; We load iedit so that it inserts iedit-toggle-key-default into the
+       ;; global key map.
        :features iedit)

--- a/recipes/livescript-mode.rcp
+++ b/recipes/livescript-mode.rcp
@@ -1,5 +1,5 @@
 (:name livescript-mode
-       :description "An Emacs major mode for LiveScript, a language that compiles to Javascript"
-       :website "https://github.com/bdowning/livescript-mode"
+       :description "LiveScript major mode"
+       :website "https://github.com/piotrklibert/livescript-mode"
        :type github
-       :pkgname "bdowning/livescript-mode")
+       :pkgname "piotrklibert/livescript-mode")


### PR DESCRIPTION
emacswiki points from https://www.emacswiki.org/emacs/Iedit to https://github.com/victorhge/iedit . The version at github has bugfixes and improvements.

Neither version of livescript mode has been updated in two years, and there are no (known) further forks, but the version at https://github.com/piotrklibert/livescript-mode is one valuable commit ahead of https://github.com/bdowning/livescript-mode (it recognizes hyphenated names as single tokens).