### PR TITLE
AucTeX needs GNU Make, not UNIX Make.

### DIFF
--- a/recipes/auctex.rcp
+++ b/recipes/auctex.rcp
@@ -4,13 +4,14 @@
        :type git
        :module "auctex"
        :url "git://git.savannah.gnu.org/auctex.git"
-       :build `(("./autogen.sh")
+       :build `(("export" "MAKE=gmake")
+                ("./autogen.sh")
                 ("./configure"
                  "--without-texmf-dir"
                  "--with-packagelispdir=$(pwd)"
                  "--with-packagedatadir=$(pwd)"
                  ,(concat "--with-emacs=" el-get-emacs))
-                ("make"))
+                ("gmake"))
        :build/darwin `(("./autogen.sh")
                        ("./configure"
                         "--without-texmf-dir"

--- a/recipes/auctex.rcp
+++ b/recipes/auctex.rcp
@@ -12,13 +12,13 @@
                  ,(concat "--with-emacs=" el-get-emacs))
                 ("make"))
        :build/berkeley-unix `(("./autogen.sh" "MAKE=gmake")
-                ("./configure"
-                 "--without-texmf-dir"
-                 "--with-packagelispdir=$(pwd)"
-                 "--with-packagedatadir=$(pwd)"
-                 ,(concat "--with-emacs=" el-get-emacs)
-                 "MAKE=gmake")
-                ("gmake"))
+                              ("./configure"
+                               "--without-texmf-dir"
+                               "--with-packagelispdir=$(pwd)"
+                               "--with-packagedatadir=$(pwd)"
+                               ,(concat "--with-emacs=" el-get-emacs)
+                               "MAKE=gmake")
+                              ("gmake"))
        :build/darwin `(("./autogen.sh")
                        ("./configure"
                         "--without-texmf-dir"

--- a/recipes/auctex.rcp
+++ b/recipes/auctex.rcp
@@ -4,7 +4,14 @@
        :type git
        :module "auctex"
        :url "git://git.savannah.gnu.org/auctex.git"
-       :build `(("export" "MAKE=gmake")
+       :build `(("./autogen.sh")
+                ("./configure"
+                 "--without-texmf-dir"
+                 "--with-packagelispdir=$(pwd)"
+                 "--with-packagedatadir=$(pwd)"
+                 ,(concat "--with-emacs=" el-get-emacs))
+                ("make"))
+       :build/berkeley-unix `(("export" "MAKE=gmake")
                 ("./autogen.sh")
                 ("./configure"
                  "--without-texmf-dir"

--- a/recipes/auctex.rcp
+++ b/recipes/auctex.rcp
@@ -11,13 +11,13 @@
                  "--with-packagedatadir=$(pwd)"
                  ,(concat "--with-emacs=" el-get-emacs))
                 ("make"))
-       :build/berkeley-unix `(("export" "MAKE=gmake")
-                ("./autogen.sh")
+       :build/berkeley-unix `(("./autogen.sh" "MAKE=gmake")
                 ("./configure"
                  "--without-texmf-dir"
                  "--with-packagelispdir=$(pwd)"
                  "--with-packagedatadir=$(pwd)"
-                 ,(concat "--with-emacs=" el-get-emacs))
+                 ,(concat "--with-emacs=" el-get-emacs)
+                 "MAKE=gmake")
                 ("gmake"))
        :build/darwin `(("./autogen.sh")
                        ("./configure"


### PR DESCRIPTION
As the title says. This goes unnoticed on most GNU/Linux distributions since there, `make` is just a symlink to `gmake`, but on e.g. FreeBSD, `gmake` needs to be called explicitly.