### PR TITLE
Add writeroom-mode dependency

### DIFF
--- a/recipes/writeroom-mode.rcp
+++ b/recipes/writeroom-mode.rcp
@@ -2,4 +2,4 @@
        :type github
        :description "Writeroom-mode: distraction-free writing for Emacs."
        :pkgname "joostkremers/writeroom-mode"
-       :shallow nil)
+       :depends (visual-fill-column))


### PR DESCRIPTION
writeroom-mode depends on visual-fill-column.  I also
removed ":shallow nil" because I cannot see why it needs to be
there, but feel free to leave it in if someone knows better than
me.