### PR TITLE
recipes: added recipe for dts-mode

### DIFF
--- a/recipes/dts-mode.rcp
+++ b/recipes/dts-mode.rcp
@@ -1,0 +1,4 @@
+(:name dts-mode
+       :description "Major mode for Devicetree source code"
+       :type github
+       :pkgname "bgamari/dts-mode")


### PR DESCRIPTION
This PR adds a recipe for basic syntax highlighting of device tree source files used e.g. in the Linux kernel.