### PR TITLE
Don't use builtin CEDET by default

### DIFF
--- a/recipes/cedet.rcp
+++ b/recipes/cedet.rcp
@@ -1,5 +1,7 @@
 (:name cedet
-       :builtin "23.3"
+       ;; While CEDET is builtin since Emacs 23.3, CEDET users
+       ;; probably want the latest from git.
+       ;; :builtin "23.3"
        :website "http://cedet.sourceforge.net/"
        :description "CEDET is a Collection of Emacs Development Environment Tools written with the end goal of creating an advanced development environment in Emacs."
        :type git
@@ -17,12 +19,7 @@
          ("gmake" ,(format "EMACS=%s" (shell-quote-argument el-get-emacs)) "-C" "contrib"))
        :build/windows-nt
        `(("sh" "-c" "touch `/usr/bin/find . -name Makefile` && make FIND=/usr/bin/find"))
-       :features nil
-       ;; This package isn't really non-lazy, but we want to call the
-       ;; post-init immediately, because it handles the lazy autoload
-       ;; setup.
-       :lazy nil
-       :post-init
+       :prepare
        (if (or (featurep 'cedet-devel-load)
                (featurep 'eieio))
            (message (concat "Emacs' built-in CEDET has already been loaded!  Restart"


### PR DESCRIPTION
@MHOOO wrote at https://github.com/dimitri/el-get/commit/85eca62e323303531cfd17b97b06f09e69446248#commitcomment-20000437

> Isnt el-get supposed to stay up-to-date, instead of using builtins?

There's not really a hard rule about it, but since CEDET has been builtin since 23.3 which is earlier than the earliest Emacs we support anyway, probably anyone installing it would want the git version. Somehow I didn't think of it when I merged that change.

> This broke my config, since cedet is no longer being loaded from git.

I will a wait bit before merging to see if anyone else has some comments about this, but you can add `(:name cedet :builtin nil)` to `el-get-sources` to fix this in the meantime.

---

```
Users installing CEDET via el-get probably wanted the git version.  For
those who want the builtin, they can add (:name cedet :builtin "23.3")
to `el-get-sources'.

Also move the :post-init block to :prepare so that the :lazy nil hack
becomes redundant.
```