### PR TITLE
Ensime recipe/dependencies - remove auto-complete to prevent popup clashes with company-mode

### DIFF
--- a/recipes/ensime.rcp
+++ b/recipes/ensime.rcp
@@ -2,7 +2,7 @@
        :description "ENhanced Scala Interaction Mode for Emacs"
        :type github
        :pkgname "ensime/ensime-emacs"
-       :depends (s 
+       :depends (s
                  dash
                  popup
                  auto-complete

--- a/recipes/ensime.rcp
+++ b/recipes/ensime.rcp
@@ -5,7 +5,6 @@
        :depends (s
                  dash
                  popup
-                 auto-complete
                  scala-mode
                  sbt-mode
                  company-mode


### PR DESCRIPTION
Removes auto-complete from ensime recipe dependency list, because it clashes with company-mode