### PR TITLE
Update: session 2.4b

### DIFF
--- a/recipes/session.rcp
+++ b/recipes/session.rcp
@@ -2,6 +2,5 @@
        :description "When you start Emacs, package Session restores various variables (e.g., input histories) from your last session. It also provides a menu containing recently changed/visited files and restores the places (e.g., point) of such a file when you revisit it."
        :type http-tar
        :options ("xzf")
-       :load-path ("lisp")
-       :url "http://downloads.sourceforge.net/project/emacs-session/session/session-2.3a.tar.gz"
+       :url "http://downloads.sourceforge.net/project/emacs-session/session-2.4b.tar.gz"
        )


### PR DESCRIPTION
Apparently session's update have been overlooked for almost two years!

- Updated `url`.
- Removed `load-path` as the author have changed the directory structure. The archive is now composed of a single file: `session.el`.