### PR TITLE
etags-select now uses emacsmirror type

### DIFF
--- a/recipes/etags-select.rcp
+++ b/recipes/etags-select.rcp
@@ -1,5 +1,4 @@
 (:name etags-select
        :description "Select from multiple tags"
-       :type http
-       :url "http://www.emacswiki.org/cgi-bin/wiki/download/etags-select.el"
+       :type emacsmirror
        :features etags-select)


### PR DESCRIPTION
emacsmirror type tends to be lot more reliable then emacswiki.