### PR TITLE
Remove go-oracle recipe.

### DIFF
--- a/recipes/go-oracle.rcp
+++ b/recipes/go-oracle.rcp
@@ -1,8 +1,0 @@
-(:name go-oracle
-       :description "Integration of the Go 'oracle' analysis tool into Emacs"
-       :type go
-       :pkgname "golang.org/x/tools/cmd/oracle"
-       :load-path "src/golang.org/x/tools/cmd/oracle"
-       :post-init (progn
-                    (setq go-oracle-command (concat default-directory "bin/oracle"))
-                    (load "oracle.el")))


### PR DESCRIPTION
oracle was renamed to guru in the following commit:

  https://github.com/golang/tools/commit/734737930440fc305a816e577cab457fbbc807c1

Emacs support was merged into go-mode:

  https://github.com/golang/tools/commit/69f6f5b782e1f090edb33f68be67d96673a8059e