### PR TITLE
Replace missing dependency inflection with jump on clj-refactor

### DIFF
--- a/recipes/clj-refactor.rcp
+++ b/recipes/clj-refactor.rcp
@@ -2,5 +2,5 @@
        :description "A collection of simple clojure refactoring functions"
        :type github
        :depends (dash s clojure-mode yasnippet paredit multiple-cursors cider
-                      edn inflections hydra)
+                      edn jump hydra)
        :pkgname "magnars/clj-refactor.el")

--- a/recipes/helm-rails.rcp
+++ b/recipes/helm-rails.rcp
@@ -2,5 +2,5 @@
        :description "Helm extension for Rails projects"
        :type github
        :pkgname "asok/helm-rails"
-       :depends (helm magit inflections)
+       :depends (helm magit jump)
        :features helm-rails-loaddefs)

--- a/recipes/inflections.rcp
+++ b/recipes/inflections.rcp
@@ -1,3 +1,0 @@
-(:name inflections
-       :description "Convert english words between singular and plural"
-       :type elpa)

--- a/recipes/jump.rcp
+++ b/recipes/jump.rcp
@@ -1,0 +1,5 @@
+(:name jump
+       :description "Defining function which contextually jump between files"
+       :type github
+       :pkgname "eschulte/jump.el"
+       :website "https://github.com/eschulte/jump.el")

--- a/recipes/projectile-rails.rcp
+++ b/recipes/projectile-rails.rcp
@@ -2,4 +2,4 @@
        :type github
        :pkgname "asok/projectile-rails"
        :description "Minor mode for Rails projects based on projectile-mode"
-       :depends (projectile inflections inf-ruby f rake))
+       :depends (projectile jump  inf-ruby f rake))

--- a/recipes/projectile-rails.rcp
+++ b/recipes/projectile-rails.rcp
@@ -2,4 +2,4 @@
        :type github
        :pkgname "asok/projectile-rails"
        :description "Minor mode for Rails projects based on projectile-mode"
-       :depends (projectile jump  inf-ruby f rake))
+       :depends (projectile jump inf-ruby f rake))


### PR DESCRIPTION
"inflection" is no longer part of elpa and it is now found in
the "jump" package.