### PR TITLE
python-mode: they switched from bzr to git (finally)

### DIFF
--- a/recipes/python-mode.rcp
+++ b/recipes/python-mode.rcp
@@ -1,7 +1,7 @@
 (:name python-mode
        :description "Major mode for editing Python programs"
-       :type bzr
-       :url "lp:python-mode"
+       :type git
+       :url "https://gitlab.com/python-mode-devs/python-mode"
        :load-path ("." "test")
        :compile nil
        :prepare (progn


### PR DESCRIPTION
new url as stated at
http://bazaar.launchpad.net/~python-mode-devs/python-mode/python-mode/files