### PR TITLE
Mastodon: missing the load-path parameter

### DIFF
--- a/recipes/mastodon.rcp
+++ b/recipes/mastodon.rcp
@@ -1,0 +1,6 @@
+(:name mastodon
+       :website "https://github.com/jdenen/mastodon.el"
+       :description "Emacs client for Mastodon"
+       :type github
+       :pkgname "jdenen/mastodon.el"
+       )

--- a/recipes/mastodon.rcp
+++ b/recipes/mastodon.rcp
@@ -3,4 +3,5 @@
        :description "Emacs client for Mastodon"
        :type github
        :pkgname "jdenen/mastodon.el"
+       :load-path ("./lisp")
        )

--- a/recipes/mastodon.rcp
+++ b/recipes/mastodon.rcp
@@ -2,10 +2,5 @@
        :website "https://github.com/jdenen/mastodon.el"
        :description "Emacs client for Mastodon"
        :type github
-<<<<<<< HEAD
        :pkgname "jdenen/mastodon.el"
-       :load-path ("./lisp")
-       )
-=======
-       :pkgname "jdenen/mastodon.el")
->>>>>>> e690a8106cabfb4b363516b939b465d2842fb3ef
+       :load-path ("./lisp"))


### PR DESCRIPTION
Sorry, I missed the ``load-path`` parameter. The actual position of ``mastodon.el`` is in the repo's ``lisp`` folder.
(and please forgive me about the typo in the commit message. The rcp is correct and workable now.)