### PR TITLE
add recipe for helm-frame

### DIFF
--- a/recipes/helm-frame.rcp
+++ b/recipes/helm-frame.rcp
@@ -1,0 +1,6 @@
+(:name helm-frame
+       :type git
+       :description "open helm buffers in a dedicated frame"
+       :website "https://gitlab.com/chee/helm-frame"
+       :depends (helm)
+       :url "https://gitlab.com/chee/helm-frame.git")


### PR DESCRIPTION
opens your helm buffer in a dedicated frame in the middle of the screen, similar to rofi or Alfred.

![screenshot of helm-frame working in sandbox](https://snake.dog/s/xotol/mivot.png)
^ screenshot of it working in a sandbox with only `helm` and `helm-frame` installed