### PR TITLE
Fix for helm installation

### DIFF
--- a/recipes/helm.rcp
+++ b/recipes/helm.rcp
@@ -3,9 +3,13 @@
        :type github
        :pkgname "emacs-helm/helm"
        :autoloads "helm-autoloads"
-       :build (("make"))
+       :build (("sed" "-i" "s/elpa/el-get/g" "Makefile")
+               ("sed" "-i" "s/async-\[.0-9\]*/emacs-async/g" "Makefile")
+               ("make"))
        :depends (emacs-async)
-       :build/darwin `(("make" ,(format "EMACS_COMMAND=%s" el-get-emacs)))
+       :build/darwin `(("sed" "-i" ".old" "s/elpa/el-get/g" "Makefile")
+                       ("sed" "-i" ".old" "s/async-\[.0-9\]*/emacs-async/g" "Makefile")
+                       ("make" ,(format "EMACS_COMMAND=%s" el-get-emacs)))
        ;; Windows probably doesn't have make available so we fake it.
        :build/windows-nt
        (let ((generated-autoload-file (expand-file-name "helm-autoloads.el")) \

--- a/recipes/helm.rcp
+++ b/recipes/helm.rcp
@@ -3,13 +3,12 @@
        :type github
        :pkgname "emacs-helm/helm"
        :autoloads "helm-autoloads"
-       :build (("sed" "-i" "s/elpa/el-get/g" "Makefile")
-               ("sed" "-i" "s/async-\[.0-9\]*/emacs-async/g" "Makefile")
-               ("make"))
+       :build `(("make"
+                 ,(concat "ASYNC_ELPA_DIR=" (el-get-package-directory 'emacs-async))))
        :depends (emacs-async)
-       :build/darwin `(("sed" "-i" ".old" "s/elpa/el-get/g" "Makefile")
-                       ("sed" "-i" ".old" "s/async-\[.0-9\]*/emacs-async/g" "Makefile")
-                       ("make" ,(format "EMACS_COMMAND=%s" el-get-emacs)))
+       :build/darwin `(("make"
+                        ,(concat "ASYNC_ELPA_DIR=" (el-get-package-directory 'emacs-async))
+                        ,(format "EMACS_COMMAND=%s" el-get-emacs)))
        ;; Windows probably doesn't have make available so we fake it.
        :build/windows-nt
        (let ((generated-autoload-file (expand-file-name "helm-autoloads.el")) \


### PR DESCRIPTION
This PR is a fix to install the latest helm.

Latest helm requires installing via elpa. (See the changes in https://github.com/emacs-helm/helm/commit/b133fb3e8a77b4d476e4b3e3ffd7aff9663506e8)

I added some patches into the helm recipe to build on el-get. I have tested on linux and macOS.

This PR also fixes #2534.