### PR TITLE
fixed deprecated repository for org-mime

### DIFF
--- a/recipes/org-mime.rcp
+++ b/recipes/org-mime.rcp
@@ -1,4 +1,4 @@
 (:name org-mime
        :type github
        :description "org html export for text/html MIME emails"
-       :pkgname "redguardtoo/org-mime")
+       :pkgname "org-mime/org-mime")


### PR DESCRIPTION
The repository `redguardtoo/org-mime` is deprecated, see the readme inside the repository. Fixed the fixed the repository in the org-mime recipe to the correct one.