### PR TITLE
Don't try do build and install :builtin packages

### DIFF
--- a/recipes/cedet.rcp
+++ b/recipes/cedet.rcp
@@ -23,8 +23,9 @@
        ;; setup.
        :lazy nil
        :post-init
-       (if (or (featurep 'cedet-devel-load)
-               (featurep 'eieio))
-           (message (concat "Emacs' built-in CEDET has already been loaded!  Restart"
-                            " Emacs to load CEDET from el-get instead."))
-         (load (expand-file-name "cedet-devel-load.el" pdir))))
+       (unless (eq (el-get-package-method 'cedet) 'builtin)
+         (if (or (featurep 'cedet-devel-load)
+                 (featurep 'eieio))
+             (message (concat "Emacs' built-in CEDET has already been loaded!  Restart"
+                              " Emacs to load CEDET from el-get instead."))
+           (load (expand-file-name "cedet-devel-load.el" pdir)))))


### PR DESCRIPTION
Fixes #2533.
```
* el-get-build.el (el-get-build-commands): Do nothing if package is
:builtin.
* recipes/cedet.rcp (:post-init): Don't load if it's :builtin.
```