### PR TITLE
Don't generate autoloads for proof-general

### DIFF
--- a/recipes/proof-general.rcp
+++ b/recipes/proof-general.rcp
@@ -7,5 +7,5 @@
                 ("makeinfo" "doc/ProofGeneral.texi" "-o" "doc")
                 ("makeinfo" "doc/PG-adapting.texi" "-o" "doc"))
        :info "doc"
-       :load "generic/proof-site.el"
+       :autoloads "generic/proof-site.el"
        :website "http://proofgeneral.inf.ed.ac.uk/")


### PR DESCRIPTION
Fixes #2543.
```
It has some autoloaded statements which depend on the file they are
evaluated from, which breaks when the destination autoload file is
'~/.emacs.d/el-get/.loaddefs.el'.  The existing
'generic/proof-site.el' file already provides sufficient autoload
definitions.
```