### PR TITLE
Add bsd build support

### DIFF
--- a/recipes/pdf-tools.rcp
+++ b/recipes/pdf-tools.rcp
@@ -13,5 +13,6 @@
                       (concat (el-get-package-directory "pdf-tools")
                               "server/epdfinfo"))
        :build (("make"))
+       :build/berkeley-unix (("gmake"))
        :load-path (("lisp"))
        :compile ("lisp/"))

--- a/recipes/swiper.rcp
+++ b/recipes/swiper.rcp
@@ -4,4 +4,6 @@
        :pkgname "abo-abo/swiper"
        :build (("make" "compile")
                ("makeinfo" "-o" "doc/ivy.info" "doc/ivy.texi"))
+       :build/berkeley-unix (("gmake" "compile")
+                             ("gmakeinfo" "-o" "doc/ivy.info" "doc/ivy.texi"))
        :info "doc/ivy.info")


### PR DESCRIPTION
Add support of BSD build for `pdf-tools` and `swiper`.

Tested on OpenBSD only.