### PR TITLE
Add info field for monitor recipe

### DIFF
--- a/recipes/monitor.rcp
+++ b/recipes/monitor.rcp
@@ -2,5 +2,6 @@
        :description "Utilities for monitoring expressions"
        :type github
        :pkgname "GuiltyDolphin/monitor"
+       :info "doc"
        :branch "master"
        :depends dash)


### PR DESCRIPTION
Fills out the `info` field as appropriate for monitor.