### PR TITLE
Update git URL for doxymacs

### DIFF
--- a/recipes/doxymacs.rcp
+++ b/recipes/doxymacs.rcp
@@ -2,7 +2,7 @@
        :website "http://doxymacs.sourceforge.net/"
        :description "Doxymacs is Doxygen + {X}Emacs."
        :type git
-       :url "git://doxymacs.git.sourceforge.net/gitroot/doxymacs/doxymacs"
+       :url "git://git.code.sf.net/p/doxymacs/code"
        :load-path ("./lisp")
        :build (("./bootstrap") ("./configure") ("make"))
        :build/darwin (("sed" "-i" ""


### PR DESCRIPTION
The stock recipe for doxymacs didn't work for me until I updated the git URL.

I didn't check if this should be done for other Sourceforge repos.