### PR TITLE
Delete cirrus.rcp

### DIFF
--- a/recipes/cirrus.rcp
+++ b/recipes/cirrus.rcp
@@ -1,6 +1,0 @@
-(:name cirrus
-       :description "Manage amazon load balancer memership through Emacs."
-       :website "https://github.com/pidu/cirrus"
-       :depends json
-       :type github
-       :pkgname "pidu/cirrus")


### PR DESCRIPTION
github.com/pidu/cirrus.git is not accessible any more.