### PR TITLE
Make the Daredevil SKK updatable

### DIFF
--- a/recipes/ddskk.rcp
+++ b/recipes/ddskk.rcp
@@ -11,4 +11,4 @@
        ;; thus here we are trying to emulate the Makefile behaviour.
        :build `((,el-get-emacs "-batch" "-q" "-no-site-file" "-l" "SKK-MK" "-f" "SKK-MK-compile")
                 (,el-get-emacs "-batch" "-q" "-no-site-file" "-l" "SKK-MK" "-f" "SKK-MK-compile-info")
-                ("mv" "skk-setup.el.in" "skk-setup.el")))
+                ("cp" "skk-setup.el.in" "skk-setup.el")))


### PR DESCRIPTION
Using a cp command instead of a mv command to enable re-execute the build step.