### PR TITLE
Monitor: Add (documentation) build phase

### DIFF
--- a/recipes/monitor.rcp
+++ b/recipes/monitor.rcp
@@ -2,6 +2,7 @@
        :description "Utilities for monitoring expressions"
        :type github
        :pkgname "GuiltyDolphin/monitor"
+       :build `(("make" "-C" "doc" "monitor.info"))
        :info "doc"
        :branch "master"
        :depends dash)


### PR DESCRIPTION
Ensure that monitor's documentation (monitor.info) is built during the build phase.