### PR TITLE
Add missing org-ref dependencies

### DIFF
--- a/recipes/org-ref.rcp
+++ b/recipes/org-ref.rcp
@@ -3,4 +3,4 @@
        :description "org-mode modules for citations, cross-references, bibliographies in org-mode and useful bibtex tools to go with it."
        :type github
        :pkgname "jkitchin/org-ref"
-       :depends (dash helm helm-bibtex hydra key-chord))
+       :depends (dash f helm helm-bibtex hydra key-chord pdf-tools s swiper))


### PR DESCRIPTION
The org-ref recipe was missing some dependencies (which can be seen at http://melpa.milkbox.net/#/org-ref) which was preventing it from running correctly.

Note that it appears that `ivy` is called `swiper` in the el-get distribution (I assume these are installed together, seeing as they are in the same repository).