### PR TITLE
Update: goto-chg.rcp type, emacswiki -> github

### DIFF
--- a/recipes/goto-chg.rcp
+++ b/recipes/goto-chg.rcp
@@ -1,3 +1,4 @@
 (:name goto-chg
        :description "Goto the point of the most recent edit in the buffer."
-       :type emacswiki)
+       :type github
+       :pkgname "emacs-evil/goto-chg")


### PR DESCRIPTION
The [maintainer](https://github.com/wasamasa) of [evil](https://github.com/emacs-evil/evil) on melpa changed evil to point to [goto-chg](https://github.com/emacs-evil/goto-chg) on github rather than the emacswiki, and has in fact [updated](https://github.com/emacs-evil/goto-chg/commit/4c32adf65aaef21b215eb6e5585b31700b51e2d9) a bit of the code as well for goto-chg.

- Relevant [github PR](https://github.com/melpa/melpa/pull/5008) leading up to the change on github for evil dependencies (comment by @wasamasa).
