### PR TITLE
Add general, convenience wrappers for keybindings

### DIFF
--- a/recipes/general.rcp
+++ b/recipes/general.rcp
@@ -1,0 +1,7 @@
+(:name general
+       :website "https://github.com/noctuid/general.el"
+       :description "More convenient key definitions in emacs"
+       :type github
+       :pkgname "noctuid/general.el"
+       :features general
+       :depends (cl-lib))


### PR DESCRIPTION
Rather than using [evil-leader](https://github.com/cofi/evil-leader), some people use general.el for their keybindings in evil. 

And as an added bonus, [general](https://github.com/noctuid/general.el) can "provides a more convenient way to bind keys in emacs for **both** evil and non-evil users."