### PR TITLE
Update recipe for magit

### DIFF
--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -5,7 +5,7 @@
        :pkgname "magit/magit"
        :branch "master"
        :minimum-emacs-version "24.4"
-       :depends (dash with-editor emacs-async magit-popup)
+       :depends (dash emacs-async ghub let-alist magit-popup with-editor)
        :info "Documentation"
        :load-path "lisp/"
        :compile "lisp/"


### PR DESCRIPTION
Magit has started using the new dependencies `ghub` and `let-alist` in https://github.com/magit/magit/commit/80f7d390f53bb65458463f9e2ca990339d3514e8 and https://github.com/magit/magit/commit/ac281d7f1bc92fa301482b75f3a5ebc7b9b4ed0e.
/cc @agsdot