### PR TITLE
Allow latest org-mode git url to shallow clone

### DIFF
--- a/methods/el-get-git.el
+++ b/methods/el-get-git.el
@@ -25,7 +25,7 @@
   :group 'el-get
   :type 'boolean)
 
-(defcustom el-get-git-known-smart-domains '("www.github.com" "www.bitbucket.org" "repo.or.cz")
+(defcustom el-get-git-known-smart-domains '("www.github.com" "www.bitbucket.org" "repo.or.cz" "code.orgmode.org")
   "List of domains which are known to support shallow clone, el-get will not make
 explicit checks for these"
   :group 'el-get


### PR DESCRIPTION
* Add `code.orgmode.org` to el-get-git-known-smart-domains
* Gogs not support HEAD request for now so `el-get-git-is-host-smart-http-p' check fails

https://github.com/dimitri/el-get/pull/2590
https://github.com/gogits/gogs/issues/2857