### PR TITLE
* recipes/ido-completing-read-plus.rcp: ido-ubiquitous subsumed into this

### DIFF
--- a/recipes/ido-completing-read-plus.rcp
+++ b/recipes/ido-completing-read-plus.rcp
@@ -1,0 +1,6 @@
+(:name ido-completing-read-plus
+       :description "Fancy completion all over Emacs, not just for buffers and files."
+       :website "https://github.com/DarwinAwardWinner/ido-completing-read-plus"
+       :type github
+       :depends (cl-lib s memoize)
+       :pkgname "DarwinAwardWinner/ido-completing-read-plus")


### PR DESCRIPTION
old ido-ubiquitous package should to be removed with this. But lets keep for a while, since there is procedure for old users to get informed about this change.