### PR TITLE
Fix mu4e could not find mu4e/mu4e.info

### DIFF
--- a/recipes/mu4e.rcp
+++ b/recipes/mu4e.rcp
@@ -11,7 +11,9 @@
                           "mu"
                           (el-get-package-directory 'mu4e))))
        :build `(("./autogen.sh")
-                ("make"))
+                ("make")
+                ;; generate mu4e/mu4e.info
+                ("sh" "-c" "cd mu4e && make"))
        :load-path "mu4e"
        :info "mu4e/mu4e.info"
        )


### PR DESCRIPTION
While I'm installing `mu4e` via el-get, I got an error that no `mu4e/mu4e.info` file, I have fixed that problem, please review.