### PR TITLE
Supplement missing dependency in the dockerfile-mode.rcp

### DIFF
--- a/recipes/dockerfile-mode.rcp
+++ b/recipes/dockerfile-mode.rcp
@@ -2,6 +2,7 @@
        :description "An emacs mode for handling Dockerfiles."
        :type github
        :pkgname "spotify/dockerfile-mode"
+       :depends (s)
        :prepare (progn
                   (add-to-list 'auto-mode-alist
                                '("Dockerfile\\'" . dockerfile-mode))))


### PR DESCRIPTION
The dockerfile-mode requires the "s" library.
ref: https://github.com/spotify/dockerfile-mode/commit/52f821c