### PR TITLE
Add new package Orgalist from Elpa

### DIFF
--- a/recipes/orgalist.rcp
+++ b/recipes/orgalist.rcp
@@ -1,0 +1,6 @@
+(:name orgalist
+       :description
+       "Manage Org-like lists in non-Org buffers."
+       :website "https://elpa.gnu.org/packages/orgalist.html"
+       :depends (org-mode)
+       :type elpa)


### PR DESCRIPTION
This library provides Org mode's plain lists in non-Org buffers, as a
minor mode.