### PR TITLE
recipes/julia-mode.rcp: url moved

### DIFF
--- a/recipes/julia-mode.rcp
+++ b/recipes/julia-mode.rcp
@@ -1,4 +1,4 @@
 (:name julia-mode
        :type http
-       :url "https://raw.githubusercontent.com/JuliaLang/julia-emacs/master/julia-mode.el"
+       :url "https://raw.githubusercontent.com/JuliaEditorSupport/julia-emacs/master/julia-mode.el"
        :description "Edit jl files in emacs.")


### PR DESCRIPTION
Now found under https://github.com/JuliaEditorSupport