### PR TITLE
Fix w32 elpa directory copy for Emacs 26.1

### DIFF
--- a/methods/el-get-elpa.el
+++ b/methods/el-get-elpa.el
@@ -140,8 +140,14 @@ the recipe, then return nil."
       (if (memq system-type '(ms-dos windows-nt))
           ;; in windows, we have to actually copy the directories,
           ;; since symlink is not exactly reliable on those systems
-          (copy-directory (el-get-elpa-package-directory package)
-                          (file-name-as-directory (expand-file-name package el-get-dir)))
+          (let ((arglist (list (el-get-elpa-package-directory package)
+                               (file-name-as-directory (expand-file-name package el-get-dir))
+                               nil nil t)))
+            ;; The COPY-CONTENTS argument is new in 24.1.
+            (condition-case ()
+                (apply #'copy-directory arglist)
+              (wrong-number-of-arguments
+               (apply #'copy-directory (nbutlast arglist 3)))))
         (let ((default-directory el-get-dir))
           (make-symbolic-link elpa-dir package))))))
 

--- a/test/el-get-tests.el
+++ b/test/el-get-tests.el
@@ -111,6 +111,23 @@ Following variables are bound to temporal values:
        (when (featurep pkg)
          (unload-feature pkg))))))
 
+(ert-deftest el-get-elpa-install ()
+  "Test installation with ELPA type."
+  (el-get-with-temp-home
+   (require 'package-x) ; create local package archive
+   (let* ((pkg 'el-get-test-package)
+          (package-archive-upload-base (expand-file-name "pkg-repo" user-emacs-directory))
+          (package-archives nil)
+          (el-get-sources
+           `((:name package :post-init nil) ; avoid adding other repos
+             (:name el-get-test-package
+                    :type elpa
+                    :repo ("test-repo" . ,package-archive-upload-base)))))
+     (make-directory package-archive-upload-base t)
+     (package-upload-file (expand-file-name "pkgs/el-get-test-package.el"
+                                            el-get-test-files-dir))
+     (el-get 'sync (mapcar 'el-get-source-name el-get-sources)))))
+
 (ert-deftest el-get-elpa-feature ()
   "`:features' option should work for ELPA type recipe."
   :expected-result :failed


### PR DESCRIPTION
Fixes #2633.
```
In Emacs 26, copy-directory copies the directory itself, based on
whether NEWNAME is directory name (ends with a "/").  Earlier Emacs
versions actually checked whether NEWNAME was existing directory, so
we happened to get the right behaviour most of the time.

Pass t for COPY-CONTENTS to ensure the correct behaviour all of the
time.
```