### PR TITLE
Fix load path for ess recipe

### DIFF
--- a/recipes/ess.rcp
+++ b/recipes/ess.rcp
@@ -6,7 +6,8 @@
        :info "doc/info/"
        :build `(("make" "clean" "all" ,(concat "EMACS=" (shell-quote-argument
                                                          el-get-emacs))))
-       :load "ess-autoloads.el"
+       :load-path ("./lisp")
+       :load "lisp/ess-autoloads.el"
        :prepare (progn
                   (autoload 'R-mode "ess-site" nil t)
                   (autoload 'Rd-mode "ess-site" nil t)


### PR DESCRIPTION
It seems that the `ess` package has changed the location of the `.el` files to the `lisp` folder.
Now the recipe works again.