### PR TITLE
Org2blog recipe should depend on htmlize

### DIFF
--- a/recipes/org2blog.rcp
+++ b/recipes/org2blog.rcp
@@ -2,5 +2,5 @@
        :description "Blog from Org mode to wordpress"
        :type github
        :pkgname "punchagan/org2blog"
-       :depends (xml-rpc-el metaweblog org-mode)
+       :depends (xml-rpc-el metaweblog org-mode htmlize)
        :features org2blog)


### PR DESCRIPTION
Trying to install org2blog without this dependency fails. It can also be seen in
[their Readme](https://github.com/org2blog/org2blog#dependencies).