### PR TITLE
Add recipe for toc-org

### DIFF
--- a/recipes/toc-org.rcp
+++ b/recipes/toc-org.rcp
@@ -1,0 +1,6 @@
+(:name toc-org
+       :website "https://www.github.com/snosov1/toc-org"
+       :description "toc-org is an Emacs utility to have an up-to-date table of contents in the org files without exporting (useful primarily for readme files on GitHub)"
+       :type github
+       :pkgname "snosov1/toc-org"
+       :depends (org))

--- a/recipes/toc-org.rcp
+++ b/recipes/toc-org.rcp
@@ -3,4 +3,4 @@
        :description "toc-org is an Emacs utility to have an up-to-date table of contents in the org files without exporting (useful primarily for readme files on GitHub)"
        :type github
        :pkgname "snosov1/toc-org"
-       :depends (org))
+       :depends (org-mode))


### PR DESCRIPTION
toc-org helps you to have an up-to-date table of contents in org files without exporting (useful primarily for readme files on GitHub).

It is similar to the markdown-toc package, but works for org files.