### PR TITLE
Update all-the-icons-ivy.rcp

### DIFF
--- a/recipes/all-the-icons-ivy.rcp
+++ b/recipes/all-the-icons-ivy.rcp
@@ -2,4 +2,4 @@
        :description "all-the-icons integration for ivy/counsel."
        :type github
        :pkgname "asok/all-the-icons-ivy"
-       :depends (ivy all-the-icons))
+       :depends (swiper all-the-icons))


### PR DESCRIPTION
There's no separate `ivy` recipe. Correcting the dependency to `swiper`.