### PR TITLE
Add missing dependencies for lsp-mode

### DIFF
--- a/recipes/lsp-mode.rcp
+++ b/recipes/lsp-mode.rcp
@@ -1,5 +1,6 @@
 (:name lsp-mode
        :website "https://github.com/emacs-lsp/lsp-mode"
        :description "Emacs client/library for the Language Server Protocol"
+       :depends (dash f ht spinner)
        :type github
-:pkgname "emacs-lsp/lsp-mode")
+       :pkgname "emacs-lsp/lsp-mode")


### PR DESCRIPTION
Lsp-mode requires some dependencies. This patch adds the missing dependencies to the recipe.