### PR TITLE
Fix flycheck-package dependencies and create missing package-lint recipe

### DIFF
--- a/recipes/flycheck-package.rcp
+++ b/recipes/flycheck-package.rcp
@@ -2,7 +2,7 @@
        :type github
        :description "Flycheck checker for elisp package metadata"
        :pkgname "purcell/flycheck-package"
-       :depends (flycheck)
+       :depends (flycheck package-lint)
        :minimum-emacs-version "24"
        :prepare
        (eval-after-load "flycheck"

--- a/recipes/package-lint.rcp
+++ b/recipes/package-lint.rcp
@@ -1,0 +1,6 @@
+(:name package-lint
+       :website "https://github.com/purcell/package-lint"
+       :description "A linting library for elisp package metadata"
+       :depends (cl-lib)
+       :type github
+       :pkgname "purcell/package-lint")


### PR DESCRIPTION
Flycheck-package depends on package-lint, but this dependency is not declared nor is there any recipe yet. This PR introduces the missing package-lint recipe and declares the dependency in the flycheck-package recipe.