### PR TITLE
Update forge and magit-popup dependencies

### DIFF
--- a/recipes/forge.rcp
+++ b/recipes/forge.rcp
@@ -5,7 +5,7 @@
        :pkgname "magit/forge"
        :branch "master"
        :minimum-emacs-version "25.1"
-       :depends (closql dash emacsql-sqlite ghub graphql let-alist magit magit-popup markdown-mode)
+       :depends (closql dash emacsql-sqlite ghub graphql let-alist magit markdown-mode)
        :info "docs"
        :load-path "lisp/"
        :compile "lisp/"

--- a/recipes/magit-popup.rcp
+++ b/recipes/magit-popup.rcp
@@ -3,4 +3,4 @@
        :description "Define prefix-infix-suffix command combos"
        :type github
        :pkgname "magit/magit-popup"
-       :depends (emacs-async dash))
+       :depends (dash))


### PR DESCRIPTION
Cc @tarsius

Forge no longer needs magit-popup. Also, I take it from #2690 that magit-popup does not need emacs-async with el-get.