### PR TITLE
* recipes/ess.rcp: Disable el-get's autoload handling.

### DIFF
--- a/recipes/ess.rcp
+++ b/recipes/ess.rcp
@@ -7,8 +7,6 @@
        :build `(("make" "clean" "all" ,(concat "EMACS=" (shell-quote-argument
                                                          el-get-emacs))))
        :load-path ("./lisp")
+       ;; Use the make-generated autoload file instead of ours.
        :load "lisp/ess-autoloads.el"
-       :prepare (progn
-                  (autoload 'R-mode "ess-site" nil t)
-                  (autoload 'Rd-mode "ess-site" nil t)
-                  (autoload 'Rnw-mode "ess-site" nil t)))
+       :autoloads nil)


### PR DESCRIPTION
Probably fixes emacs-ess/ESS#917.