### PR TITLE
Check names of added files for sanity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - EMACS_VERSION=24.3
   - EMACS_VERSION=24.5
   - EMACS_VERSION=25.3
-  - EMACS_VERSION=26.1
+  - EMACS_VERSION=26.2
 install:
   - env
   - source test/travis-ci.sh
@@ -17,3 +17,4 @@ script:
   - ert-tests
   - check-recipes -Wno-features -Wno-github -Wno-autoloads recipes/
   - check-whitespace
+  - check-filenames

--- a/recipes/(:name stylus-mode        :description "Emacs major mode for stylus template highlighting."        :type github        :pkgname "vladh/stylus-mode.rcp
+++ b/recipes/(:name stylus-mode        :description "Emacs major mode for stylus template highlighting."        :type github        :pkgname "vladh/stylus-mode.rcp
@@ -1,0 +1,4 @@
+(:name stylus-mode
+       :description "Emacs major mode for stylus template highlighting."
+       :type github
+       :pkgname "vladh/stylus-mode")


### PR DESCRIPTION
Trying to catch problems like the one fixed in #2705 ahead of time.

```
* test/travis-ci.sh (check-filenames): New function.
* .travis.yml: Use it.  Bump Emacs 26 to 26.2.
```