### PR TITLE
Drop font-lock+ dependency for all-the-icons recipe

### DIFF
--- a/recipes/all-the-icons.rcp
+++ b/recipes/all-the-icons.rcp
@@ -4,4 +4,4 @@
        :type github
        :branch "master"
        :pkgname "domtronn/all-the-icons.el"
-       :depends (font-lock+ memoize))
+       :depends (memoize))


### PR DESCRIPTION
since it's not required anymore, see
https://github.com/domtronn/all-the-icons.el/commit/52d1f2d36468146c93aaf11399f581401a233306