### PR TITLE
Remove autoload and auto-mode-alist preparation (integrated upstream)

### DIFF
--- a/recipes/ass-mode.rcp
+++ b/recipes/ass-mode.rcp
@@ -2,9 +2,4 @@
        :description "Major mode for editing ASS/SSA subtitle files"
        :type github
        :pkgname "disbeliever/ass-mode"
-       :depends (s)
-       :prepare (progn
-                  (add-to-list auto-mode-alist '("\\.ssa$" . ass-mode))
-                  (autoload 'ass-mode "ass-mode"
-                    "Major mode for editing SSA/ASS ((Advanced) SubStation Alpha) subtitles"
-                    t t)))
+       :depends (s))


### PR DESCRIPTION
This pull request reverts PR https://github.com/dimitri/el-get/pull/2717, since the necessary autoload cookis have been integrated upstream in commit https://github.com/disbeliever/ass-mode/commit/ae9391e5b3c51fb021e12ee18601238e582a0c55.

I apologize for this successive PRs with a null net result. Next time, I will try to get the changes made upstream instead of bugging the el-get developers.