### PR TITLE
Use direct URL in edit-server recipe

### DIFF
--- a/recipes/edit-server.rcp
+++ b/recipes/edit-server.rcp
@@ -1,4 +1,4 @@
 (:name edit-server
        :description "Emacs edit-server. This provides an edit server to respond to requests from the Chrome Emacs Chrome plugin."
        :type http
-       :url "http://github.com/stsquad/emacs_chrome/raw/master/servers/edit-server.el")
+       :url "https://raw.githubusercontent.com/stsquad/emacs_chrome/master/servers/edit-server.el")


### PR DESCRIPTION
The previous URL in the edit-server recipe [1] redirects to another
URL [2]. For some unknown reason, installing the edit-server package
through el-get yields the follwowing error message:

"Failed to find end of headers in HTTP response from
http://github.com/stsquad/emacs_chrome/raw/master/servers/edit-server.el
for package edit-server; see buffer * http github.com:443 *"

Changing the URL to the redirected one fixes the problem for me.

[1] http://github.com/stsquad/emacs_chrome/raw/master/servers/edit-server.el
[2] https://raw.githubusercontent.com/stsquad/emacs_chrome/master/servers/edit-server.el