### PR TITLE
Use method emacswiki instead of http for retrieving the package

### DIFF
--- a/recipes/eimp.rcp
+++ b/recipes/eimp.rcp
@@ -1,6 +1,3 @@
 (:name eimp
-       :description "Emacs Image Manipulation Package"
-       :website "https://mph-emacs-pkgs.alioth.debian.org/EimpEl.html"
-       :type http
-       :url "https://alioth.debian.org/scm/viewvc.php/*checkout*/mph-emacs-pkgs/elisp/eimp.el?root=mph-emacs-pkgs"
-       :localname "eimp.el")
+       :type emacswiki
+       :description "Emacs Image Manipulation Package")


### PR DESCRIPTION
The previous URL at alioth.debian.org is not available anymore.