### PR TITLE
Add hydra to lsp-mode dependencies

### DIFF
--- a/recipes/lsp-mode.rcp
+++ b/recipes/lsp-mode.rcp
@@ -1,6 +1,6 @@
 (:name lsp-mode
        :website "https://github.com/emacs-lsp/lsp-mode"
        :description "Emacs client/library for the Language Server Protocol"
-       :depends (dash f ht spinner)
+       :depends (dash f ht hydra spinner)
        :type github
        :pkgname "emacs-lsp/lsp-mode")


### PR DESCRIPTION
The latest version of lsp-mode depends on "lv" which is located in hydra.