### PR TITLE
Added markdown-mode into dependencies for lsp-mode recipe

### DIFF
--- a/recipes/lsp-mode.rcp
+++ b/recipes/lsp-mode.rcp
@@ -1,6 +1,6 @@
 (:name lsp-mode
        :website "https://github.com/emacs-lsp/lsp-mode"
        :description "Emacs client/library for the Language Server Protocol"
-       :depends (dash f ht hydra spinner)
+       :depends (dash f ht hydra spinner markdown-mode)
        :type github
        :pkgname "emacs-lsp/lsp-mode")


### PR DESCRIPTION
Added markdown-mode into dependencies for lsp-mode recipe as it is mentioned in original requirements
https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-mode.el