### PR TITLE
Correct shrink-path.rcp migrated project location

### DIFF
--- a/recipes/shrink-path.rcp
+++ b/recipes/shrink-path.rcp
@@ -1,6 +1,6 @@
 (:name shrink-path
-       :website "https://github.com/c0001/shrink-path.el"
+       :website "https://gitlab.com/bennya/shrink-path.el"
        :description "Small utility functions that allow for fish-style trunctated directories in eshell and for example modeline."
        :depends (dash f s)
-       :type github
-       :pkgname "c0001/shrink-path.el")
+       :type git
+       :url "https://gitlab.com/bennya/shrink-path.el.git")


### PR DESCRIPTION
shrink-path has moved from GitHub to GitLab.

Fixes #2746