### PR TITLE
transient.rcp: Don't call make on windows/nt

### DIFF
--- a/recipes/transient.rcp
+++ b/recipes/transient.rcp
@@ -13,4 +13,6 @@
        ;; handle compilation and autoloads on its own.
        :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info"))
        :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
-                               "info")))
+                               "info"))
+       ;; Assume windows lacks a build environment.
+       :build/windows-nt (with-temp-file "lisp/transient-autoloads.el" nil))


### PR DESCRIPTION
```
The same as we do for magit.rcp.
```

This should fix the problem reported in https://github.com/dimitri/el-get/issues/2034#issuecomment-578505215