### PR TITLE
Add a series of recipes required to install the org-brain package.

### DIFF
--- a/recipes/helm-org.rcp
+++ b/recipes/helm-org.rcp
@@ -1,0 +1,8 @@
+(:name helm-org
+       :description "Helm for org headlines and keywords completion."
+       :type github
+       :depends (org-mode helm)
+       ;; Generates autoloads which require helm-easymenu, which is
+       ;; not on the loadpath.
+       :autoloads nil
+       :pkgname "emacs-helm/helm-org")

--- a/recipes/org-brain.rcp
+++ b/recipes/org-brain.rcp
@@ -1,0 +1,5 @@
+(:name org-brain
+       :description "Org-mode wiki + concept-mapping."
+       :type github
+       :depends (org-mode org-ql helm-org)
+       :pkgname "Kungsgeten/org-brain")

--- a/recipes/org-ql.rcp
+++ b/recipes/org-ql.rcp
@@ -1,0 +1,5 @@
+(:name org-ql
+       :description "An Org-mode query language, including search commands and saved views."
+       :type github
+       :depends (dash f org-mode org-super-agenda ov peg s ts)
+       :pkgname "alphapapa/org-ql")

--- a/recipes/org-super-agenda.rcp
+++ b/recipes/org-super-agenda.rcp
@@ -1,0 +1,5 @@
+(:name org-super-agenda
+       :description "Supercharge your Org daily/weekly agenda by grouping items."
+       :type github
+       :depends (org-mode s dash ht ts)
+       :pkgname "alphapapa/org-super-agenda")

--- a/recipes/ts.rcp
+++ b/recipes/ts.rcp
@@ -1,0 +1,5 @@
+(:name ts
+       :description "Timestamp and date/time library."
+       :type github
+       :depends (dash s)
+       :pkgname "alphapapa/ts.el")


### PR DESCRIPTION
Include all the missing recipes which allow for installation of org-brain. In order of dependent recipes, these are:

- ts
- org-super-agenda (needs ts)
- org-ql (needs org-super-agenda)
- helm-org
- org-brain (needs org-ql, and optionally helm-org)

The only interesting bit in these recipes is the `:autoloads nil ` command in helm-org, as otherwise it creates an autoload for `helm-easymenu` which is non-trivial to satisfy if you've configured `ido` as your primary completion framework and `helm` as your secondary completion framework.