### PR TITLE
Use branch "stable" for c-xrefactory

### DIFF
--- a/recipes/c-xrefactory.rcp
+++ b/recipes/c-xrefactory.rcp
@@ -4,7 +4,7 @@
        :branch "stable"
        :website "https://github.com/thoni56/c-xrefactory"
        :pkgname "thoni56/c-xrefactory"
-       :load-path "env/emacs"
+       :load-path "editors/emacs"
        :build (("make"))
        :load "env/emacs/c-xrefactory.el"
        :post-init (progn

--- a/recipes/c-xrefactory.rcp
+++ b/recipes/c-xrefactory.rcp
@@ -1,6 +1,6 @@
 (:name c-xrefactory
        :description "c-xrefactory - a refactoring browser for C and Java."
-       :type "github"
+       :type github
        :branch "stable"
        :website "https://github.com/thoni56/c-xrefactory"
        :pkgname "thoni56/c-xrefactory"

--- a/recipes/c-xrefactory.rcp
+++ b/recipes/c-xrefactory.rcp
@@ -1,6 +1,7 @@
 (:name c-xrefactory
        :description "c-xrefactory - a refactoring browser for C and Java."
-       :type github
+       :type "github"
+       :branch "stable"
        :website "https://github.com/thoni56/c-xrefactory"
        :pkgname "thoni56/c-xrefactory"
        :load-path "env/emacs"


### PR DESCRIPTION
The "stable" branch will always have passed all tests, so let's use that instead.