### PR TITLE
Use leger-mode repo instead of ledger

### DIFF
--- a/recipes/ledger-mode.rcp
+++ b/recipes/ledger-mode.rcp
@@ -1,8 +1,6 @@
 (:name ledger-mode
        :description "A major mode for editing ledger .dat files"
        :type github
-       :pkgname "ledger/ledger"
-       :checkout "v3.1"
-       :load-path "lisp"
+       :pkgname "ledger/ledger-mode"
        :prepare (progn
                   (add-to-list 'auto-mode-alist '("\\.dat$" . ledger-mode))))


### PR DESCRIPTION
Ledger-moe has its own repository. Use this instead of cloning the whole
ledger source.

Signed-off-by: Sébastien Gross <seb•ɑƬ•chezwam•ɖɵʈ•org>