### PR TITLE
Use original up-to-date request.el for the recipe

### DIFF
--- a/recipes/request.rcp
+++ b/recipes/request.rcp
@@ -2,6 +2,6 @@
        :description "Easy HTTP request for Emacs Lisp"
        :type github
        :submodule nil
-       :pkgname "abingham/emacs-request"
+       :pkgname "tkf/emacs-request"
        :depends (deferred)
        :provide (request-deferred))


### PR DESCRIPTION
A newer version from original maintainer is still supported so I think it will be more natural to use.

abingham's request.el is 0.2.0 and I suppose it is abandoned
tkf's request.el is 0.3.2

Reason to change:
vuiet.el and lastfm.el and probably some others require latest capabilities of request.el