### PR TITLE
Swiper now depends on avy

### DIFF
--- a/recipes/swiper.rcp
+++ b/recipes/swiper.rcp
@@ -1,10 +1,10 @@
 (:name swiper
        :description "Gives you an overview as you search for a regex."
        :type github
-       :depends (cl-lib)
+       :depends (cl-lib avy)
        :pkgname "abo-abo/swiper"
-       :build `(("make" ,(format "emacs=%s" el-get-emacs) "compile")
+       :build `(("make" ,(format "emacs=%s -L %s" el-get-emacs (concat (file-name-as-directory el-get-dir) "avy")) "compile")
                ("makeinfo" "-o" "doc/ivy.info" "doc/ivy.texi"))
-       :build/berkeley-unix `(("gmake" ,(format "emacs=%s" el-get-emacs) "compile")
+       :build/berkeley-unix `(("gmake" ,(format "emacs=%s -L %s" el-get-emacs (concat (file-name-as-directory el-get-dir) "avy")) "compile")
                              ("gmakeinfo" "-o" "doc/ivy.info" "doc/ivy.texi"))
        :info "doc/ivy.info")


### PR DESCRIPTION
Now swiper seems to depend on avy (while `make`).

This change makes using avy installed via el-get, but is slightly hacky.