### PR TITLE
Add some new recipes, update clj-refactor recipe

### DIFF
--- a/recipes/clj-refactor.rcp
+++ b/recipes/clj-refactor.rcp
@@ -1,6 +1,6 @@
 (:name clj-refactor
        :description "A collection of simple clojure refactoring functions"
        :type github
-       :depends (dash s clojure-mode yasnippet paredit multiple-cursors cider
-                      edn jump hydra)
+       :depends (seq yasnippet paredit multiple-cursors clojure-mode cider
+                     parseedn inflections hydra)
        :pkgname "clojure-emacs/clj-refactor.el")

--- a/recipes/keycast.rcp
+++ b/recipes/keycast.rcp
@@ -1,0 +1,4 @@
+(:name keycast
+       :description "Show current command and its key in the mode line."
+       :type github
+       :pkgname "tarsius/keycast")

--- a/recipes/link-hint.rcp
+++ b/recipes/link-hint.rcp
@@ -1,0 +1,5 @@
+(:name link-hint
+       :description "Pentadactyl-like Link Hinting in Emacs with Avy."
+       :type github
+       :depends (avy)
+       :pkgname "noctuid/link-hint.el")

--- a/recipes/org-chef.rcp
+++ b/recipes/org-chef.rcp
@@ -1,0 +1,5 @@
+(:name org-chef
+       :description "A package for making a cookbook and managing recipes with org-mode."
+       :type github
+       :depends (org-mode)
+       :pkgname "Chobbes/org-chef")

--- a/recipes/org-cliplink.rcp
+++ b/recipes/org-cliplink.rcp
@@ -1,0 +1,4 @@
+(:name org-cliplink
+       :description "Insert org-mode links from the clipboard."
+       :type github
+       :pkgname "rexim/org-cliplink")

--- a/recipes/org-noter.rcp
+++ b/recipes/org-noter.rcp
@@ -1,0 +1,5 @@
+(:name org-noter
+       :description "Emacs document annotator, using org-mode."
+       :type github
+       :depends (org-mode cl-lib)
+       :pkgname "weirdNox/org-noter")


### PR DESCRIPTION
Add the following recipes:

- Add a recipe for keycast: Show current command and its key in the mode line.
- Add a recipe for org-noter: Emacs document annotator, using org-mode.
- Add a recipe for org-cliplink: Insert org-mode links from the clipboard.
- Add a recipe for org-chef: A package for making a cookbook and managing recipes with org-mode.
- Add a recipe for link-hint: Pentadactyl-like Link Hinting in Emacs with Avy.

Update the following recipe:
- clj-refactor: The dependencies of the package have changed.