### PR TITLE
c-xrefactory.rcp: Use stable branch from repo and use new dir for elisp files

### DIFF
--- a/recipes/c-xrefactory.rcp
+++ b/recipes/c-xrefactory.rcp
@@ -4,7 +4,7 @@
        :branch "stable"
        :website "https://github.com/thoni56/c-xrefactory"
        :pkgname "thoni56/c-xrefactory"
-       :load-path "env/emacs"
+       :load-path "editors/emacs"
        :build (("make"))
        :load "env/emacs/c-xrefactory.el"
        :post-init (progn

--- a/recipes/c-xrefactory.rcp
+++ b/recipes/c-xrefactory.rcp
@@ -1,6 +1,6 @@
 (:name c-xrefactory
        :description "c-xrefactory - a refactoring browser for C and Java."
-       :type "github"
+       :type github
        :branch "stable"
        :website "https://github.com/thoni56/c-xrefactory"
        :pkgname "thoni56/c-xrefactory"

--- a/recipes/c-xrefactory.rcp
+++ b/recipes/c-xrefactory.rcp
@@ -1,6 +1,7 @@
 (:name c-xrefactory
        :description "c-xrefactory - a refactoring browser for C and Java."
-       :type github
+       :type "github"
+       :branch "stable"
        :website "https://github.com/thoni56/c-xrefactory"
        :pkgname "thoni56/c-xrefactory"
        :load-path "env/emacs"


### PR DESCRIPTION
The previous PR (https://github.com/dimitri/el-get/pull/2757) never got anywhere, and I wanted to do another small fix so here it is.

- Use "stable" branch from `c-xrefactory` to ensure it builds ok
- The directory for elisp files was renamed to `editors` rather than `env`