### PR TITLE
Fix the recipe for fold-dwim

### DIFF
--- a/recipes/fold-dwim.rcp
+++ b/recipes/fold-dwim.rcp
@@ -1,5 +1,5 @@
 (:name fold-dwim
        :description "Unified user interface for Emacs folding mode"
-       :type http
-       :url "http://community.dur.ac.uk/p.j.heslin/Software/Emacs/Download/fold-dwim.el.txt"
-       :localname "fold-dwim.el")
+       :website "https://github.com/emacsattic/fold-dwim"
+       :type github
+       :pkgname "emacsattic/fold-dwim")


### PR DESCRIPTION
The old fold-dwim URL is obsolete.