### PR TITLE
Update Deft (repository moved to Github)

### DIFF
--- a/recipes/deft.rcp
+++ b/recipes/deft.rcp
@@ -1,4 +1,4 @@
 (:name deft
        :description "Quickly browse, filter, and edit plain text notes."
-       :type git
-       :url "git://jblevins.org/git/deft.git")
+       :type github
+       :pkgname "jrblevin/deft")


### PR DESCRIPTION
Repository is also live at https://jblevins.org/git/deft.git

but author specify Github as reference repo. See: https://jblevins.org/projects/deft/