### PR TITLE
Remove highlight dependency from eval-sexp-fu recipe

### DIFF
--- a/recipes/eval-sexp-fu.rcp
+++ b/recipes/eval-sexp-fu.rcp
@@ -1,7 +1,5 @@
 (:name eval-sexp-fu
-       :auto-generated t
        :type github
        :pkgname "hchbaw/eval-sexp-fu.el"
-       :depends (highlight)
        :description "Tiny functionality enhancements for evaluating sexps."
        :website "https://github.com/hchbaw/eval-sexp-fu.el")


### PR DESCRIPTION
This dependency is not needed anymore, see
https://github.com/hchbaw/eval-sexp-fu.el/blob/master/eval-sexp-fu.el#L90.

Furthermore, remove `:auto-generated t` because it's (most probably)
not auto generated and it's the only recipe in the repository, which
has this property set.