### PR TITLE
Add when argument to define-obsolete-function-alias

### DIFF
--- a/el-get-status.el
+++ b/el-get-status.el
@@ -173,7 +173,7 @@
   (plist-get (cdr (assq (el-get-as-symbol package) (el-get-read-status-file)))
              'status))
 
-(define-obsolete-function-alias 'el-get-package-status 'el-get-read-package-status)
+(define-obsolete-function-alias 'el-get-package-status 'el-get-read-package-status "20120306")
 
 (defun el-get-read-package-status-recipe (package)
   "return current status recipe for PACKAGE"


### PR DESCRIPTION
This will be required in Emacs 28