### PR TITLE
Fix for Emacs 28 or higher versions

### DIFF
--- a/el-get-core.el
+++ b/el-get-core.el
@@ -499,9 +499,10 @@ makes it easier to conditionally splice a command into the list.
                         (funcall final-func package)))))
               ;; async case
               (el-get-verbose-message "Running commands asynchronously: %S" commands)
-              (let* ((startf (if shell #'start-process-shell-command #'start-process))
-                     (process-connection-type nil) ; pipe, don't pretend we're a pty
-                     (proc (apply startf cname cbuf program args)))
+              (let* ((process-connection-type nil) ; pipe, don't pretend we're a pty
+                     (proc (if shell
+                               (start-process-shell-command cname cbuf (mapconcat #'identity (cons program args) " "))
+                             (apply #'start-process cname cbuf program args))))
                 ;; add the properties to the process, then set the sentinel
                 (mapc (lambda (x) (process-put proc x (plist-get c x))) c)
                 (process-put proc :el-get-sources el-get-sources)


### PR DESCRIPTION
### Problem

el-get-update, el-get-update-all fails with latest emacs(28.0.50)

### Detail

start-process-shell-command no longer takes rest argument since
Emacs 28. So passing more than three arguments raises
wrong-number-of-arguments exception.

### Reference

Commit
- https://github.com/emacs-mirror/emacs/commit/ecb5ebf156280be1859f181208306e4c55af3e80#diff-e16fa4bdce4bf5bf6122ca90034ac2e3aa60d58085cf20fb1483f4544ad37919

Latest implementation
- https://github.com/emacs-mirror/emacs/blob/ac9c4ca8c9456ea4e0cbfea2317579ac57b13289/lisp/subr.el#L3726-L3737
