### PR TITLE
Update clang-format to point at code in GitHub

### DIFF
--- a/recipes/clang-format.rcp
+++ b/recipes/clang-format.rcp
@@ -1,7 +1,7 @@
 (:name clang-format
        :description "Clang-format emacs integration for use with C/Objective-C/C++."
        :type http
-       :url "https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format.el"
+       :url "https://raw.githubusercontent.com/llvm/llvm-project/main/clang/tools/clang-format/clang-format.el"
        :depends (json)
        :prepare (progn
                   (autoload 'clang-format-region "clang-format" nil t)


### PR DESCRIPTION
`clang-format.el` is now distributed from GitHub instead of self-hosted subversion repository in llvm.org.