### PR TITLE
Switching to more current version of filladapt.el from emacsmirror

### DIFF
--- a/recipes/filladapt.rcp
+++ b/recipes/filladapt.rcp
@@ -1,5 +1,4 @@
 (:name filladapt
        :description "Filladapt enhances the behavior of Emacs' fill functions by guessing the proper fill prefix in many contexts. Emacs has a built-in adaptive fill mode but Filladapt is much better."
-       :type http
-       :url "http://www.wonderworks.com/download/filladapt.el"
+       :type emacsmirror
        :load "filladapt.el")


### PR DESCRIPTION
Version at prior version had 'old-style backticks' issue with current Emacen.