### PR TITLE
Update oef-mode.rcp

### DIFF
--- a/recipes/oef-mode.rcp
+++ b/recipes/oef-mode.rcp
@@ -2,5 +2,5 @@
        :description "Provide oef-mode (Online Exercise Format for WIMS) to emacs"
        :type github
        :pkgname "raoulhatterer/oef-mode"
-       :depends (emmet-mode company-mode rainbow-delimiters rainbow-mode yafolding auctex wrap-region expand-region cl-lib)
+       :depends (emmet-mode company-mode rainbow-delimiters yafolding auctex expand-region cl-lib)
        :info ".")


### PR DESCRIPTION
`rainbow-mode` and `wrap-region` removed from `:depends` because during installation el-get is going to marmalade  and that gives me an unwanted warning for a certificate.