### PR TITLE
recipe/egg: egg autoloads are too aggressive

### DIFF
--- a/recipes/egg.rcp
+++ b/recipes/egg.rcp
@@ -4,4 +4,6 @@
        :pkgname "byplayer/egg"
        :load-path (".")
        :compile nil ;; egg uses eval at places which breaks compilation
-       :features egg)
+       :autoloads nil ;; egg autoloads are too aggresive
+       :features egg
+       )


### PR DESCRIPTION
egg adds autoloads to find-file-hook, that trigger before egg been initalized.