### PR TITLE
org-mode.rcp: don't load contrib directory

### DIFF
--- a/recipes/org-mode.rcp
+++ b/recipes/org-mode.rcp
@@ -12,5 +12,5 @@
                  (lambda (target)
                    (list "make" target (concat "EMACS=" (shell-quote-argument el-get-emacs))))
                  '("oldorg"))
-       :load-path ("." "contrib/lisp" "lisp")
+       :load-path ("." "lisp")
        :load ("lisp/org-loaddefs.el"))


### PR DESCRIPTION
The contrib directory was removed from Org's repository, keeping it in
load path generates an error.

https://code.orgmode.org/bzg/org-mode/raw/master/etc/ORG-NEWS