### PR TITLE
pdf-tools.rcp: Update pkgname to new repo

### DIFF
--- a/recipes/pdf-tools.rcp
+++ b/recipes/pdf-tools.rcp
@@ -4,7 +4,7 @@
        :minimum-emacs-version "24.3"
        ;; On Debian, "libpoppler-glib-dev" "libpoppler-dev"
        ;; "libpoppler-private-dev" are needed to build c code in this package.
-       :pkgname "politza/pdf-tools"
+       :pkgname "vedang/pdf-tools"
        :depends (let-alist tablist)
 
        ;; pdf-tools' code written to find "epdfinfo" executable in the lisp


### PR DESCRIPTION
pdf-tools has a new maintainer @vedang, the same change was made on
MELPA.

https://github.com/melpa/melpa/blob/master/recipes/pdf-tools