### PR TITLE
Unbreak el-get-remove-autoloads for Emacs < 28

### DIFF
--- a/el-get-autoloading.el
+++ b/el-get-autoloading.el
@@ -111,8 +111,17 @@ with the named PACKAGE"
                               (directory-files dir t el-get-autoload-regexp)))
                           (el-get-load-path package)))
            (generated-autoload-file el-get-autoload-file)
-           (load-names (mapcar (lambda (f) (autoload-file-load-name f el-get-autoload-file))
-                               files))
+           (load-names
+            (mapcar
+             (lambda (f)
+               (apply #'autoload-file-load-name
+                      ;; Starting from Emacs 28 auto-file-load-name
+                      ;; needs two parameters, versions before 28 only
+                      ;; one.
+                      (if (> emacs-major-version 27)
+                          `(,f ,el-get-autoload-file)
+                        `(,f))))
+             files))
            (recentf-exclude (cons (regexp-quote el-get-autoload-file)
                                   (bound-and-true-p recentf-exclude)))
            (visited (find-buffer-visiting el-get-autoload-file)))

--- a/el-get-core.el
+++ b/el-get-core.el
@@ -503,7 +503,7 @@ makes it easier to conditionally splice a command into the list.
                      (proc (if shell
                                (start-process-shell-command cname
                                                             cbuf
-                                                            (string-join (cons program args) " "))
+                                                            (mapconcat #'identity (cons program args) " "))
                              (apply #'start-process cname cbuf program args))))
                 ;; add the properties to the process, then set the sentinel
                 (mapc (lambda (x) (process-put proc x (plist-get c x))) c)


### PR DESCRIPTION
Starting from Emacs 28 the function `autoload-file-load-name` takes two non-optional parameters, but versions before Emacs 27 still takes only one. Furthermore, replace `string-join` by `mapconcat`, because `string-join` doesn't exist before Emacs 24.4.

This PR fixes #2833.