### PR TITLE
Fix emms recipe

### DIFF
--- a/recipes/emms.rcp
+++ b/recipes/emms.rcp
@@ -3,13 +3,12 @@
        :type git
        :url "git://git.sv.gnu.org/emms.git"
        :info "doc"
-       :load-path ("./lisp")
        :features emms-setup
        :build `(("mkdir" "-p" ,(expand-file-name (format "%s/emms" user-emacs-directory)))
                 ("make" ,(format "EMACS=%s" el-get-emacs)
                  ,(format "SITEFLAG=--no-site-file")
-                 "autoloads" "lisp" "docs"))
+                 "all"))
        :build/berkeley-unix `(("mkdir" "-p" ,(expand-file-name (format "%s/emms" user-emacs-directory)))
                               ("gmake" ,(format "EMACS=%s" el-get-emacs)
                                ,(format "SITEFLAG=--no-site-file")
-                               "autoloads" "lisp" "docs")))
+                               "all")))


### PR DESCRIPTION
Without this commit, installation of emms fails with:

```
make: *** No rule to make target 'autoloads'.  Stop.
```