### PR TITLE
Add yaml.el recipe because yaml.el needed by magit/forge

### DIFF
--- a/recipes/forge.rcp
+++ b/recipes/forge.rcp
@@ -7,7 +7,7 @@
        :minimum-emacs-version "25.1"
        ;; The package.el dependency is on `emacsql-sqlite', but el-get
        ;; provides that via `emacsql'.
-       :depends (closql dash emacsql ghub let-alist magit markdown-mode)
+       :depends (closql dash emacsql ghub let-alist magit markdown-mode yaml)
        :info "docs"
        :load-path "lisp/"
        :compile "lisp/"

--- a/recipes/yaml.rcp
+++ b/recipes/yaml.rcp
@@ -1,0 +1,5 @@
+(:name yaml
+       :type github
+       :description "yaml.el is a YAML parser written in Emacs List without any external dependencies."
+       :pkgname "zkry/yaml.el"
+       :minimum-emacs-version (25 1))


### PR DESCRIPTION
Hi, dimitri

magit/forge added dependency yaml.el with this commit
https://github.com/magit/forge/commit/84ef3a7bad5879a2dd179a94655ac0da28be3898

so, I updated the forge recipe and added a new recipe for yaml.el with the new dependency.