### PR TITLE
Update url to clang-format.el since it has moved to GitHub

### DIFF
--- a/recipes/clang-format.rcp
+++ b/recipes/clang-format.rcp
@@ -1,7 +1,7 @@
 (:name clang-format
        :description "Clang-format emacs integration for use with C/Objective-C/C++."
        :type http
-       :url "https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format.el"
+       :url "https://github.com/llvm/llvm-project/blob/main/clang/tools/clang-format/clang-format.el"
        :depends (json)
        :prepare (progn
                   (autoload 'clang-format-region "clang-format" nil t)


### PR DESCRIPTION
Since llvm/clang has moved to GitHub that is also where the `clang-format.el` is.