### PR TITLE
Set builtin since 24.3 for rst-mode

### DIFF
--- a/recipes/rst-mode.rcp
+++ b/recipes/rst-mode.rcp
@@ -2,4 +2,5 @@
        :website "http://docutils.sourceforge.net/docs/user/emacs.html"
        :description "Mode for viewing and editing reStructuredText-documents."
        :type svn
+       :builtin "24.3"
        :url "http://svn.code.sf.net/p/docutils/code/trunk/docutils/tools/editors/emacs")


### PR DESCRIPTION
According to https://docutils.sourceforge.io/docs/user/emacs.html, rst-mode is part of Emacs since version 23.1. But Emacs 24.3 includes a "significantly updated version". For this reason, "builtin" is set to version "24.3".

Alternatively, it might make sense to completely drop the recipe, because el-get doesn't support Emacs versions before 24.3 anymore.