### PR TITLE
Remove the marmalade archive from the package recipe

### DIFF
--- a/recipes/package.rcp
+++ b/recipes/package.rcp
@@ -31,8 +31,7 @@
                            "."))
                   "http://"))
                (archives '(("melpa" . "melpa.org/packages/")
-                           ("gnu" . "elpa.gnu.org/packages/")
-                           ("marmalade" . "marmalade-repo.org/packages/"))))
+                           ("gnu" . "elpa.gnu.org/packages/"))))
            (dolist (archive archives)
              (add-to-list 'package-archives
                           (cons (car archive) (concat protocol (cdr archive))))))))


### PR DESCRIPTION
The marmalade archive is dead for quite some time, that's why it's removed. Furthermore, many regression tests (in test/issues) rely on this recipe and fail, because marmalade is unavailable.