### PR TITLE
Fix several regression tests

### DIFF
--- a/recipes/whole-line-or-region.rcp
+++ b/recipes/whole-line-or-region.rcp
@@ -1,4 +1,4 @@
 (:name whole-line-or-region
        :description "Operate on current line if region undefined"
-       :type http
-       :url "http://www.northbound-train.com/emacs/whole-line-or-region.el")
+       :type github
+       :pkgname "purcell/whole-line-or-region")

--- a/test/issues/el-get-issue-1006.el
+++ b/test/issues/el-get-issue-1006.el
@@ -7,12 +7,14 @@
 ;;; DO_NOT_CLEAN=t ./run-test.sh 1006
 ;;; DO_NOT_CLEAN=t ./run-test.sh 1006 # fails on second run
 
+(require 'cl-lib)
+
 (setq el-get-sources '((:name whole-line-or-region
-                              :after (whole-line-or-region-mode))))
+                              :after (whole-line-or-region-local-mode))))
 
 ;;; setting el-get-is-lazy makes it work
                                         ;(setq el-get-is-lazy t)
 
 (el-get 'sync 'whole-line-or-region)
 
-(assert (fboundp 'whole-line-or-region-mode))
+(cl-assert (fboundp 'whole-line-or-region-local-mode))

--- a/test/issues/el-get-issue-1189.el
+++ b/test/issues/el-get-issue-1189.el
@@ -1,6 +1,8 @@
 ;;; When installing a package whose name is a prefix of an already
 ;;; installed package, `el-get-elpa-package-directory' gets confused.
 
+(require 'cl-lib)
+
 (setq el-get-sources
       '((:name load-dir ; I tried to pick the smallest package
                :type elpa
@@ -9,8 +11,8 @@
 
 (el-get 'sync 'load-dir)
 
-(assert (not (equal (el-get-elpa-package-directory 'load)
-                    (el-get-elpa-package-directory 'load-dir)))
-        nil
-        "a package name `load' shouldn't use the same directory
+(cl-assert (not (equal (el-get-elpa-package-directory 'load)
+                       (el-get-elpa-package-directory 'load-dir)))
+           nil
+           "a package name `load' shouldn't use the same directory
 as `load-dir'.")

--- a/test/issues/el-get-issue-1454.el
+++ b/test/issues/el-get-issue-1454.el
@@ -2,6 +2,8 @@
 ;;
 ;; Bootstrapping package.el when installing it and then an ELPA recipe
 
+(require 'cl-lib)
+
 (setq debug-on-error t
       el-get-verbose t
       el-get-is-lazy t)
@@ -13,6 +15,6 @@
 
 (let ((elpa-requiring-pkg 'svg-clock))
   (el-get 'sync (list 'package elpa-requiring-pkg))
-  (assert (el-get-package-installed-p 'package))
-  (assert (featurep 'package))
-  (assert (el-get-package-installed-p elpa-requiring-pkg)))
+  (cl-assert (el-get-package-installed-p 'package))
+  (cl-assert (featurep 'package))
+  (cl-assert (el-get-package-installed-p elpa-requiring-pkg)))

--- a/test/issues/el-get-issue-1752.el
+++ b/test/issues/el-get-issue-1752.el
@@ -3,6 +3,6 @@
  '((:name el-get-install
           :type http
           :url "https://github.com/dimitri/el-get/raw/master/el-get-install.el"
-          :checksum "b3a5ada02e27597894210fa1ae2c857579a457ae")))
+          :checksum "9495f609e1635dde17d70a89f021003fbc0372c8")))
 
 (el-get 'sync 'el-get-install)

--- a/test/issues/el-get-issue-407.el
+++ b/test/issues/el-get-issue-407.el
@@ -9,30 +9,29 @@
 ;;
 ;; The basic setup installer should make el-get available immediately.
 
-
-(require 'cl)
+(require 'cl-lib)
 ;; Unload el-get and delete it from the load path
 
 (when (require 'el-get nil t)
   ;; Remove from load-path
   (setq load-path
-        (remove-if (apply-partially
-                    #'string-prefix-p
-                    (expand-file-name
-                     "."
-                     (file-name-directory
-                      (symbol-file 'el-get 'defun))))
-                   load-path))
+        (cl-remove-if (apply-partially
+                       #'string-prefix-p
+                       (expand-file-name
+                        "."
+                        (file-name-directory
+                         (symbol-file 'el-get 'defun))))
+                      load-path))
   ;; Unload features
-  (loop for feat in features
-        if (string-prefix-p "el-get" (symbol-name feat))
-        do (progn
-             (unload-feature feat 'force)
-             (assert (not (require feat nil t)) Nil
-                     "%s should not be loadable now" feat)))
-  (assert (not (or (require 'el-get nil t)
-                   (boundp 'el-get-sources))) nil
-          "el-get should not be loadable now"))
+  (cl-loop for feat in features
+           if (string-prefix-p "el-get" (symbol-name feat))
+           do (progn
+                (unload-feature feat 'force)
+                (cl-assert (not (require feat nil t)) Nil
+                           "%s should not be loadable now" feat)))
+  (cl-assert (not (or (require 'el-get nil t)
+                      (boundp 'el-get-sources))) nil
+                      "el-get should not be loadable now"))
 
 (unless (require 'el-get nil t)
   (with-current-buffer
@@ -43,5 +42,5 @@
       (eval-print-last-sexp)))
   (message "el-get is ready now"))
 
-(assert (and (featurep 'el-get)
-             (boundp 'el-get-sources)) nil "el-get MUST have been loaded!")
+(cl-assert (and (featurep 'el-get)
+                (boundp 'el-get-sources)) nil "el-get MUST have been loaded!")

--- a/test/issues/el-get-issue-446.el
+++ b/test/issues/el-get-issue-446.el
@@ -1,6 +1,8 @@
 ;;; https://github.com/dimitri/el-get/issues/446
 ;;; el-get-remove doesn't remove autoloads from .loaddefs
 
+(require 'cl-lib)
+
 (el-get-register-method-alias :test :builtin)
 
 (setq
@@ -28,6 +30,6 @@
 ;; reload current autoload file
 (el-get-eval-autoloads)
 
-(assert (not (fboundp 'a-utoloaded-func)) nil
-        "autoloads for `a' should have been removed from %s"
-        el-get-autoload-file)
+(cl-assert (not (fboundp 'a-utoloaded-func)) nil
+           "autoloads for `a' should have been removed from %s"
+           el-get-autoload-file)

--- a/test/issues/el-get-issue-548.el
+++ b/test/issues/el-get-issue-548.el
@@ -2,11 +2,13 @@
 ;;
 ;; Use `default-directory' in :post-init and similar recipe init hooks.
 
+(require 'cl-lib)
+
 (setq debug-on-error t
       el-get-verbose t)
 
 (el-get 'sync 'pcmpl-git)
 (el-get-init 'pcmpl-git)
 ;; Verify that the option in :post-init was set correctly
-(assert (string= pcmpl-git-options-file
-                 (expand-file-name "git-options" (el-get-package-directory 'pcmpl-git))))
+(cl-assert (string= pcmpl-git-options-file
+                    (expand-file-name "git-options" (el-get-package-directory 'pcmpl-git))))

--- a/test/issues/el-get-issue-583.el
+++ b/test/issues/el-get-issue-583.el
@@ -4,6 +4,8 @@
 ;;
 ;; Also related: https://github.com/dimitri/el-get/issues/576
 
+(require 'cl-lib)
+
 (setq el-get-default-process-sync t
       el-get-verbose t
       el-get-sources
@@ -23,5 +25,5 @@
 (el-get-remove 'a)
 ;; Try to install a again, this fails and only inits b and c.
 (el-get-install 'a)
-(assert (el-get-package-is-installed 'a) nil
-        "Package A should be installed but isn't.")
+(cl-assert (el-get-package-is-installed 'a) nil
+           "Package A should be installed but isn't.")

--- a/test/issues/el-get-issue-589.el
+++ b/test/issues/el-get-issue-589.el
@@ -2,6 +2,8 @@
 ;;
 ;; Lazy loading is broken
 
+(require 'cl-lib)
+
 (setq debug-on-error t
       el-get-default-process-sync t
       el-get-verbose t
@@ -15,16 +17,16 @@
                (setq post-init-function-ran t)
                :lazy t)))
 
-(assert (not post-init-function-ran) nil
-        "Post-init function should not run before installation")
+(cl-assert (not post-init-function-ran) nil
+           "Post-init function should not run before installation")
 (el-get 'sync 'test-pkg)
-(assert prepare-function-ran nil
-        "Prepare function should have run after package installation.")
-(assert (not post-init-function-ran) nil
-        "Post-init function should not run during installation")
+(cl-assert prepare-function-ran nil
+           "Prepare function should have run after package installation.")
+(cl-assert (not post-init-function-ran) nil
+           "Post-init function should not run during installation")
 (el-get-init 'test-pkg)
-(assert (not post-init-function-ran) nil
-        "Post-init function should not run during init")
+(cl-assert (not post-init-function-ran) nil
+           "Post-init function should not run during init")
 (require 'ido)
-(assert post-init-function-ran nil
-        "Post-init function should have run when package feature was required")
+(cl-assert post-init-function-ran nil
+           "Post-init function should have run when package feature was required")

--- a/test/issues/el-get-issue-613.el
+++ b/test/issues/el-get-issue-613.el
@@ -1,6 +1,8 @@
 ;; https://github.com/dimitri/el-get/issues/613
 ;;
 ;; Do recipe autoloads in :prepare instead of :post-init
+
+(require 'cl-lib)
 (require 'loadhist)
 
 (setq debug-on-error t
@@ -9,14 +11,14 @@
       el-get-is-lazy t)
 
 (el-get 'sync 'n3-mode)
-(assert (not (file-loadhist-lookup "n3-mode")) nil
-        "n3-mode package should not be loaded because el-get is lazy")
-(assert (functionp 'n3-mode) nil
-        "n3-mode function should be defined because it is autoloaded")
-(assert (equal 'autoload (car (symbol-function 'n3-mode))) nil
-        "n3-mode function definition should be an autoload")
+(cl-assert (not (file-loadhist-lookup "n3-mode")) nil
+           "n3-mode package should not be loaded because el-get is lazy")
+(cl-assert (functionp 'n3-mode) nil
+           "n3-mode function should be defined because it is autoloaded")
+(cl-assert (equal 'autoload (car (symbol-function 'n3-mode))) nil
+           "n3-mode function definition should be an autoload")
 (with-temp-buffer (n3-mode))
-(assert (file-loadhist-lookup "n3-mode") nil
-        "n3-mode package should be loaded after calling n3-mode function")
-(assert (not (equal 'autoload (car-safe (symbol-function 'n3-mode)))) nil
-        "n3-mode function should no longer be an autoload after calling it")
+(cl-assert (file-loadhist-lookup "n3-mode") nil
+           "n3-mode package should be loaded after calling n3-mode function")
+(cl-assert (not (equal 'autoload (car-safe (symbol-function 'n3-mode)))) nil
+           "n3-mode function should no longer be an autoload after calling it")

--- a/test/issues/el-get-issue-615.el
+++ b/test/issues/el-get-issue-615.el
@@ -2,7 +2,9 @@
 ;;
 ;; Allow methods to provide default-website guesser
 
+(require 'cl-lib)
+
 (el-get-describe 'js2-mode)
 (with-current-buffer "*Help*"
-  (assert (string-match-p "Website:" (buffer-string)) nil
-          "Js2-mode should have a website"))
+  (cl-assert (string-match-p "Website:" (buffer-string)) nil
+             "Js2-mode should have a website"))

--- a/test/issues/el-get-issue-632.el
+++ b/test/issues/el-get-issue-632.el
@@ -2,20 +2,21 @@
 ;;
 ;; Do not add package directory to load-path if :load-path property is nil
 
-(require 'cl)
+(require 'cl-lib)
+
 (let* ((debug-on-error t)
        (el-get-verbose t)
        ;; Just need to install something
-       (pkg1 'zenburn-theme)
+       (pkg1 'color-theme-zenburn)
        (pkg2 'color-theme)
        (el-get-sources
         (list `(:name ,pkg1 :load-path nil)
               `(:name ,pkg2))))
   (el-get 'sync pkg1 pkg2)
-  (assert (el-get-package-is-installed pkg1))
-  (assert (el-get-package-is-installed pkg2))
-  (assert (plist-member (el-get-package-def pkg1) :load-path))
-  (assert (not (plist-member (el-get-package-def pkg2) :load-path)))
+  (cl-assert (el-get-package-is-installed pkg1))
+  (cl-assert (el-get-package-is-installed pkg2))
+  (cl-assert (plist-member (el-get-package-def pkg1) :load-path))
+  (cl-assert (not (plist-member (el-get-package-def pkg2) :load-path)))
   (let ((normalized-load-path
          (mapcar #'file-name-as-directory
                  (mapcar #'expand-file-name load-path)))
@@ -23,9 +24,9 @@
          (lambda (pkg)
            (member (file-name-as-directory (el-get-package-directory pkg))
                    normalized-load-path))))
-    (assert (not (funcall pkg-in-load-path pkg1))
-            nil "Package directory of %s should not be in `load-path'"
-            pkg1)
-    (assert (funcall pkg-in-load-path pkg2)
-            nil "Package directory of %s should be in `load-path'"
-            pkg2)))
+    (cl-assert (not (funcall pkg-in-load-path pkg1))
+               nil "Package directory of %s should not be in `load-path'"
+               pkg1)
+    (cl-assert (funcall pkg-in-load-path pkg2)
+               nil "Package directory of %s should be in `load-path'"
+               pkg2)))

--- a/test/issues/el-get-issue-642.el
+++ b/test/issues/el-get-issue-642.el
@@ -2,6 +2,8 @@
 ;;
 ;; Reinstall on type change
 
+(require 'cl-lib)
+
 (setq debug-on-error t
       el-get-verbose t
       el-get-default-process-sync t)
@@ -11,10 +13,10 @@
        (list `(:name pkg
                      :type builtin))))
   (el-get 'sync 'pkg))
-(assert (eq 'builtin
-            (el-get-package-method (el-get-read-package-status-recipe 'pkg)))
-        t
-        "Package type should be 'builtin.")
+(cl-assert (eq 'builtin
+               (el-get-package-method (el-get-read-package-status-recipe 'pkg)))
+           t
+           "Package type should be 'builtin.")
 ;; Even though "no-op" is an alias for the same behavior as
 ;; "builtin", they are still considered different types. Thus, this
 ;; should trigger a reinstall.
@@ -22,7 +24,7 @@
        (list `(:name pkg
                      :type no-op))))
   (el-get-update 'pkg))
-(assert (eq 'no-op
-            (el-get-package-method (el-get-read-package-status-recipe 'pkg)))
-        t
-        "Package type should now be 'no-op, not 'builtin.")
+(cl-assert (eq 'no-op
+               (el-get-package-method (el-get-read-package-status-recipe 'pkg)))
+           t
+           "Package type should now be 'no-op, not 'builtin.")

--- a/test/issues/el-get-issue-652.el
+++ b/test/issues/el-get-issue-652.el
@@ -2,6 +2,8 @@
 ;;
 ;; Handle changing dependencies in `el-get-update'
 
+(require 'cl-lib)
+
 (setq el-get-default-process-sync t
       el-get-verbose t
       el-get-sources
@@ -19,8 +21,8 @@
 ;; Install a and some deps
 (el-get-install 'a)
 ;; Make sure deps got installed
-(assert (el-get-package-is-installed 'd) nil
-        "Package D should be installed after installing A.")
+(cl-assert (el-get-package-is-installed 'd) nil
+           "Package D should be installed after installing A.")
 ;; Add some more deps
 (setf (car el-get-sources)
       '(:name a
@@ -28,5 +30,5 @@
               :depends (b c d e f g)))
 ;; Run update with the new dependencies
 (el-get-update 'a)
-(assert (el-get-package-is-installed 'g) nil
-        "Package G should be installed after updating A.")
+(cl-assert (el-get-package-is-installed 'g) nil
+           "Package G should be installed after updating A.")

--- a/test/issues/el-get-issue-672.el
+++ b/test/issues/el-get-issue-672.el
@@ -2,6 +2,8 @@
 ;;
 ;; Status file migration fails with removed and unavailable recipe
 
+(require 'cl-lib)
+
 ;; Just install some package to make sure el-get creates the
 ;; appropriate directories
 (setq el-get-sources
@@ -28,4 +30,4 @@
 
 ;; Now the list of package status recipes should be nil because no
 ;; packages are installed.
-(assert (equal (el-get-package-status-recipes) nil) nil)
+(cl-assert (equal (el-get-package-status-recipes) nil) nil)

--- a/test/issues/el-get-issue-683.el
+++ b/test/issues/el-get-issue-683.el
@@ -2,18 +2,20 @@
 ;;
 ;; el-get-remove needs to be more flexible
 
+(require 'cl-lib)
+
 (setq el-get-sources (list '(:name a :type builtin))
       el-get-default-process-sync t)
 
 (defun assert-package-fully-removed (pkg)
-  (assert (null (el-get-read-package-status pkg))
-          nil
-          "Package %s should have status `nil', but actually has status \"%s\"."
-          pkg (el-get-read-package-status pkg))
-  (assert (not (or (file-exists-p (el-get-package-directory pkg))
-                   (file-symlink-p (el-get-package-directory pkg))))
-          nil
-          "Package directory for %s should not exist, but it does" pkg))
+  (cl-assert (null (el-get-read-package-status pkg))
+             nil
+             "Package %s should have status `nil', but actually has status \"%s\"."
+             pkg (el-get-read-package-status pkg))
+  (cl-assert (not (or (file-exists-p (el-get-package-directory pkg))
+                      (file-symlink-p (el-get-package-directory pkg))))
+             nil
+             "Package directory for %s should not exist, but it does" pkg))
 
 ;; Try to just install and remove
 (el-get-install 'a)
@@ -62,7 +64,7 @@
 
 ;; Install, then set the recipe to nil in the status file, then uninstall
 (el-get-install 'a)
-(flet ((el-get-package-def (&rest ignored) nil))
+(cl-flet ((el-get-package-def (&rest ignored) nil))
   (el-get-save-package-status 'a "installed"))
 (el-get-remove 'a)
 (assert-package-fully-removed 'a)

--- a/test/issues/el-get-issue-730.el
+++ b/test/issues/el-get-issue-730.el
@@ -2,6 +2,8 @@
 ;;
 ;; el-get-remove needs to be more flexible
 
+(require 'cl-lib)
+
 (setq versions-to-test (list 0 10 23 24 25 40 500 "24.1.50.1" "21.4" "500.2.3" '(23 3 50 1))
       recipes-to-test (mapcar (lambda (version)
                                 `(:name a :type builtin :minimum-emacs-version ,version))
@@ -9,25 +11,25 @@
       el-get-default-process-sync t)
 
 ;; Simulate same version, higher version, and lower version
-(loop for version in versions-to-test
-      do
-      (let* ((version-list (el-get-version-to-list version))
-             (should-install (not (version-list-< (version-to-list emacs-version)
-                                                  version-list)))
-             (el-get-sources
-              (list `(:name a :type builtin :minimum-emacs-version ,version))))
-        (message "Testing installing a package requiring version %S. Current emacs version is %s. Package install is expected to %s."
-                 version emacs-version (if should-install "succeed" "fail"))
-        (if should-install
-            (progn
-              (el-get-install 'a)
-              (el-get-init 'a)
-              (el-get-remove 'a))
-          (condition-case err
-              (progn
-                (el-get-install 'a)
-                (el-get-init 'a)
-                (el-get-remove 'a)
-                (signal 'test-failure
-                        '("Package should have thrown an error due to unmet emacs version, but it didn't.")))
-            (error (message "Installing package with unmet emacs version failed as expected. The error message was: %S" err))))))
+(cl-loop for version in versions-to-test
+         do
+         (let* ((version-list (el-get-version-to-list version))
+                (should-install (not (version-list-< (version-to-list emacs-version)
+                                                     version-list)))
+                (el-get-sources
+                 (list `(:name a :type builtin :minimum-emacs-version ,version))))
+           (message "Testing installing a package requiring version %S. Current emacs version is %s. Package install is expected to %s."
+                    version emacs-version (if should-install "succeed" "fail"))
+           (if should-install
+               (progn
+                 (el-get-install 'a)
+                 (el-get-init 'a)
+                 (el-get-remove 'a))
+             (condition-case err
+                 (progn
+                   (el-get-install 'a)
+                   (el-get-init 'a)
+                   (el-get-remove 'a)
+                   (signal 'test-failure
+                           '("Package should have thrown an error due to unmet emacs version, but it didn't.")))
+               (error (message "Installing package with unmet emacs version failed as expected. The error message was: %S" err))))))

--- a/test/issues/el-get-issue-810.el
+++ b/test/issues/el-get-issue-810.el
@@ -1,6 +1,8 @@
 ;;; https://github.com/dimitri/el-get/issues/810
 ;;; :autoloads nil as no effect
 
+(require 'cl-lib)
+
 (el-get-register-method-alias :test :builtin)
 
 (setq
@@ -23,11 +25,11 @@
 (el-get 'sync 'a)
 
 ;;; check nothing was loaded (this fails)
-(assert (not (or (fboundp 'a-nother-func)
-                 (fboundp 'a-utoloaded-func))))
+(cl-assert (not (or (fboundp 'a-nother-func)
+                    (fboundp 'a-utoloaded-func))))
 
 ;;; check we can load everything (for sanity)
 (require 'a)
 
-(assert (and (fboundp 'a-nother-func)
-             (fboundp 'a-utoloaded-func)))
+(cl-assert (and (fboundp 'a-nother-func)
+                (fboundp 'a-utoloaded-func)))

--- a/test/issues/el-get-issue-new-2.el
+++ b/test/issues/el-get-issue-new-2.el
@@ -3,7 +3,7 @@
 
 ;;; Utility
 
-(defun* create-package-archive (path &key name desc version)
+(cl-defun create-package-archive (path &key name desc version)
   "Creates local archive at PATH that provides signle package
 with NAME, DESCRIPTION and VERSION specified according to
 values provided in arguments after corresponding keys."

--- a/test/issues/el-get-issue-new.el
+++ b/test/issues/el-get-issue-new.el
@@ -3,7 +3,7 @@
 
 ;;; Utility
 
-(defun* create-package-archive (path &key name desc version)
+(cl-defun create-package-archive (path &key name desc version)
   "Creates local archive at PATH that provides signle package
 with NAME, DESCRIPTION and VERSION specified according to
 values provided in arguments after corresponding keys."


### PR DESCRIPTION
Many regression tests broke after the removal of `cl`, because they assumed `cl` is implicitly loaded. Others regression tests broke for other reasons.

The commit fixes _not_ all regression tests. This is meant to be the first wave.