### PR TITLE
Bring some recipes up-to-date, add a bunch of other recipes

### DIFF
--- a/recipes/all-the-icons-dired.rcp
+++ b/recipes/all-the-icons-dired.rcp
@@ -1,0 +1,5 @@
+(:name all-the-icons-dired
+       :description "Shows icons for each file in dired mode."
+       :type github
+       :pkgname "jtbm37/all-the-icons-dired"
+       :depends (all-the-icons))

--- a/recipes/all-the-icons-ibuffer.rcp
+++ b/recipes/all-the-icons-ibuffer.rcp
@@ -1,0 +1,5 @@
+(:name all-the-icons-ibuffer
+       :description "Shows icons for each buffer in ibuffer."
+       :type github
+       :pkgname "seagle0128/all-the-icons-ibuffer"
+       :depends (all-the-icons))

--- a/recipes/ansible.rcp
+++ b/recipes/ansible.rcp
@@ -1,0 +1,6 @@
+(:name ansible
+       :description "Syntax highlighting for Ansible playbooks"
+       :minimum-emacs-version "25"
+       :type github
+       :pkgname "k1LoW/emacs-ansible"
+       :depends (s f))

--- a/recipes/cljstyle.rcp
+++ b/recipes/cljstyle.rcp
@@ -1,0 +1,4 @@
+(:name cljstyle
+       :description "Emacs integration with cljstyle for Clojure file formatting."
+       :type github
+       :pkgname "jstokes/cljstyle-mode")

--- a/recipes/code-compass.rcp
+++ b/recipes/code-compass.rcp
@@ -1,0 +1,6 @@
+(:name code-compass
+       :type github
+       :description "A set of code analyses that assist you in tackling software complexity."
+       :pkgname "ag91/code-compass"
+       :depends (emacs-async dash f s simple-httpd)
+       :minimum-emacs-version (26 1))

--- a/recipes/company-ansible.rcp
+++ b/recipes/company-ansible.rcp
@@ -1,0 +1,8 @@
+(:name company-ansible
+       :type github
+       :pkgname "krzysztof-magosa/company-ansible"
+       :description "Company mode backend providing autocompletion for ansible keywords"
+       :minimum-emacs-version "25"
+       :depends (company-mode)
+       :prepare (with-eval-after-load 'company
+                  (add-to-list 'company-backends #'company-ansible)))

--- a/recipes/dash-docs.rcp
+++ b/recipes/dash-docs.rcp
@@ -1,4 +1,5 @@
 (:name "dash-docs"
        :description "This package provides an elisp interface to query and show documenation using Dash docsets."
        :type github
-       :pkgname "dash-docs-el/dash-docs")
+       :pkgname "dash-docs-el/dash-docs"
+       :depends (emacs-async esqlite))

--- a/recipes/deadgrep.rcp
+++ b/recipes/deadgrep.rcp
@@ -1,0 +1,5 @@
+(:name deadgrep
+       :description "Deadgrep is the fast, beautiful text search that your Emacs deserves."
+       :type github
+       :pkgname "Wilfred/deadgrep"
+       :depends (dash s spinner))

--- a/recipes/docker.rcp
+++ b/recipes/docker.rcp
@@ -2,4 +2,5 @@
        :description "Manage docker images & containers from Emacs"
        :type github
        :pkgname "Silex/docker.el"
-       :depends (magit s dash docker-tramp tablist json-mode))
+       :minimum-emacs-version "24.5"
+       :depends (magit s dash docker-tramp tablist transient json-mode))

--- a/recipes/eglot.rcp
+++ b/recipes/eglot.rcp
@@ -1,0 +1,5 @@
+(:name eglot
+       :type github
+       :description "Client for Language Server Protocol (LSP) servers"
+       :pkgname "joaotavora/eglot"
+       :minimum-emacs-version "26.1")

--- a/recipes/elpher.rcp
+++ b/recipes/elpher.rcp
@@ -1,0 +1,5 @@
+(:name elpher
+       :description "A friendly gopher and gemini client"
+       :website "http://thelambdalab.xyz/elpher"
+       :type elpa
+       :repo ("melpa" . "http://melpa.org/packages/"))

--- a/recipes/emacs-emojify.rcp
+++ b/recipes/emacs-emojify.rcp
@@ -1,0 +1,5 @@
+(:name emacs-emojify
+       :description "Display emojis in Emacs"
+       :type github
+       :pkgname "iqbalansari/emacs-emojify"
+       :depends (seq ht))

--- a/recipes/emacs-tree-sitter.rcp
+++ b/recipes/emacs-tree-sitter.rcp
@@ -1,0 +1,10 @@
+(:name emacs-tree-sitter
+       :description "Emacs Lisp bindings for tree-sitter, an incremental parsing library."
+       :type github
+       :pkgname "vedang/emacs-tree-sitter"
+       :load-path ("core" "lisp" "langs")
+       :load ("lisp/tree-sitter.el"
+              "lisp/tree-sitter-hl.el"
+              "langs/tree-sitter-langs.el"
+              "lisp/tree-sitter-debug.el"
+              "lisp/tree-sitter-query.el"))

--- a/recipes/enlive.rcp
+++ b/recipes/enlive.rcp
@@ -1,0 +1,4 @@
+(:name enlive
+       :description "Query html document with css selectors in elisp"
+       :type github
+       :pkgname "zweifisch/enlive")

--- a/recipes/fancy-battery.rcp
+++ b/recipes/fancy-battery.rcp
@@ -1,0 +1,4 @@
+(:name fancy-battery
+       :description "Display battery in Emacs Mode line."
+       :type github
+       :pkgname "emacsorphanage/fancy-battery")

--- a/recipes/flycheck-inline.rcp
+++ b/recipes/flycheck-inline.rcp
@@ -1,0 +1,5 @@
+(:name flycheck-inline
+       :description "A minor-mode for displaying errors from Flycheck right below their reporting location, using overlays."
+       :type github
+       :pkgname "flycheck/flycheck-inline"
+       :depends (flycheck))

--- a/recipes/forge.rcp
+++ b/recipes/forge.rcp
@@ -7,7 +7,7 @@
        :minimum-emacs-version "25.1"
        ;; The package.el dependency is on `emacsql-sqlite', but el-get
        ;; provides that via `emacsql'.
-       :depends (closql dash emacsql ghub let-alist magit markdown-mode yaml)
+       :depends (closql dash emacsql ghub let-alist magit markdown-mode transient yaml)
        :info "docs"
        :load-path "lisp/"
        :compile "lisp/"

--- a/recipes/gcmh.rcp
+++ b/recipes/gcmh.rcp
@@ -1,0 +1,4 @@
+(:name gcmh
+       :description "The Garbage Collector Magic Hack"
+       :type github
+       :pkgname "emacsmirror/gcmh")

--- a/recipes/helm-notmuch.rcp
+++ b/recipes/helm-notmuch.rcp
@@ -1,0 +1,5 @@
+(:name helm-notmuch
+       :description "Searches emails using notmuch-search, displays results using helm."
+       :type github
+       :pkgname "emacs-helm/helm-notmuch"
+       :depends (helm notmuch))

--- a/recipes/helm-system-packages.rcp
+++ b/recipes/helm-system-packages.rcp
@@ -1,0 +1,5 @@
+(:name helm-system-packages
+       :description "A Helm interface to the package manager of your operating system."
+       :type github
+       :pkgname "emacs-helm/helm-system-packages"
+       :depends (helm seq))

--- a/recipes/kibit-helper.rcp
+++ b/recipes/kibit-helper.rcp
@@ -1,0 +1,5 @@
+(:name kibit-helper
+       :description "Conveniently use the Kibit Leiningen plugin from Emacs"
+       :type github
+       :depends (s)
+       :pkgname "brunchboy/kibit-helper")

--- a/recipes/language-detection.rcp
+++ b/recipes/language-detection.rcp
@@ -1,0 +1,4 @@
+(:name language-detection
+       :description "Automatic programming language detection of code snippets, in Emacs Lisp."
+       :type github
+       :pkgname "andreasjansson/language-detection.el")

--- a/recipes/linkd.rcp
+++ b/recipes/linkd.rcp
@@ -1,4 +1,5 @@
 (:name linkd
+       :website "https://www.emacswiki.org/emacs/download/linkd.el"
        :type github
        :description "Make hypertext with active links in any buffer"
        :pkgname "emacsorphanage/linkd")

--- a/recipes/magit-delta.rcp
+++ b/recipes/magit-delta.rcp
@@ -1,0 +1,5 @@
+(:name magit-delta
+       :description "Use dandavison/delta when viewing diffs in Magit "
+       :type github
+       :pkgname "dandavison/magit-delta"
+       :depends (magit xterm-color))

--- a/recipes/move-text.rcp
+++ b/recipes/move-text.rcp
@@ -1,0 +1,4 @@
+(:name move-text
+       :description "Move current line or region using M-up / M-down"
+       :type github
+       :pkgname "emacsfodder/move-text")

--- a/recipes/nm.rcp
+++ b/recipes/nm.rcp
@@ -1,0 +1,7 @@
+(:name nm
+       :description "NEVERMORE: an email interface for Notmuch"
+       :type github
+       :pkgname "emacsattic/nm"
+       :depends (notmuch peg company-mode)
+       :prepare (with-eval-after-load 'company
+                  (require 'nm-company)))

--- a/recipes/nov.el.rcp
+++ b/recipes/nov.el.rcp
@@ -1,0 +1,5 @@
+(:name nov.el
+       :description "Featureful EPUB reader mode."
+       :type git
+       :url "https://depp.brause.cc/nov.el.git"
+       :depends (dash esxml))

--- a/recipes/org-books.rcp
+++ b/recipes/org-books.rcp
@@ -1,0 +1,5 @@
+(:name org-books
+       :description "Reading list management with org mode."
+       :type github
+       :depends (org-mode org-contrib s dash helm helm-org enlive)
+       :pkgname "lepisma/org-books")

--- a/recipes/org-brain.rcp
+++ b/recipes/org-brain.rcp
@@ -1,5 +1,5 @@
 (:name org-brain
        :description "Org-mode wiki + concept-mapping."
        :type github
-       :depends (org-mode org-ql helm-org)
+       :depends (org-mode org-ql org-contrib helm-org)
        :pkgname "Kungsgeten/org-brain")

--- a/recipes/org-contrib.rcp
+++ b/recipes/org-contrib.rcp
@@ -1,0 +1,7 @@
+(:name org-contrib
+       :website "https://git.sr.ht/~bzg/org-contrib"
+       :description "This repository contains add-ons to Org."
+       :type git
+       :url "https://git.sr.ht/~bzg/org-contrib"
+       :depends (org-mode)
+       :load-path ("lisp"))

--- a/recipes/org-mode-crate.rcp
+++ b/recipes/org-mode-crate.rcp
@@ -1,0 +1,5 @@
+(:name org-mode-crate
+       :description "A pre-defined org environment for the consummate gtd'er"
+       :type github
+       :depends (org-mode org-board)
+       :pkgname "vedang/org-mode-crate")

--- a/recipes/org-mode.rcp
+++ b/recipes/org-mode.rcp
@@ -4,6 +4,7 @@
        :type git
        :url "https://code.orgmode.org/bzg/org-mode.git"
        :info "doc"
+       :checkout "main"
        :build/berkeley-unix `,(mapcar
                                (lambda (target)
                                  (list "gmake" target (concat "EMACS=" (shell-quote-argument el-get-emacs))))

--- a/recipes/org-protocol-capture-html.rcp
+++ b/recipes/org-protocol-capture-html.rcp
@@ -1,0 +1,5 @@
+(:name org-protocol-capture-html
+       :description "Capture HTML from the browser selection into Emacs as org-mode content."
+       :type github
+       :pkgname "alphapapa/org-protocol-capture-html"
+       :depends (org-mode s))

--- a/recipes/org-superstar.rcp
+++ b/recipes/org-superstar.rcp
@@ -1,0 +1,4 @@
+(:name org-superstar
+       :description "Make org-mode stars a little more super."
+       :type github
+       :pkgname "integral-dw/org-superstar-mode")

--- a/recipes/org-web-tools.rcp
+++ b/recipes/org-web-tools.rcp
@@ -1,0 +1,5 @@
+(:name org-web-tools
+       :description "View, capture, and archive Web pages in Org-mode."
+       :type github
+       :pkgname "alphapapa/org-web-tools"
+       :depends (org-mode dash esxml s request))

--- a/recipes/orgit-forge.rcp
+++ b/recipes/orgit-forge.rcp
@@ -1,0 +1,5 @@
+(:name orgit-forge
+       :description "Org links to Forge issue buffers"
+       :type github
+       :depends (org-mode org-contrib magit forge orgit)
+       :pkgname "magit/orgit-forge")

--- a/recipes/orgit.rcp
+++ b/recipes/orgit.rcp
@@ -1,0 +1,5 @@
+(:name orgit
+       :description "Support for Org links to Magit buffers."
+       :type github
+       :depends (org-mode org-contrib magit)
+       :pkgname "magit/orgit")

--- a/recipes/parinfer-rust-mode.rcp
+++ b/recipes/parinfer-rust-mode.rcp
@@ -1,0 +1,5 @@
+(:name parinfer-rust-mode
+       :description "An interface for the parinfer-rust library"
+       :type github
+       :pkgname "justinbarclay/parinfer-rust-mode"
+       :minimum-emacs-version (26 1))

--- a/recipes/pinboard.rcp
+++ b/recipes/pinboard.rcp
@@ -1,0 +1,5 @@
+(:name pinboard
+       :description "A pinboard.in client in Emacs"
+       :type github
+       :pkgname "davep/pinboard.el"
+       :depends (cl-lib))

--- a/recipes/propcheck.rcp
+++ b/recipes/propcheck.rcp
@@ -1,0 +1,6 @@
+(:name propcheck
+       :description "quickcheck/hypothesis style testing for elisp"
+       :type github
+       :pkgname "Wilfred/propcheck"
+       :minimum-emacs-version "26.1"
+       :depends (dash))

--- a/recipes/rustic.rcp
+++ b/recipes/rustic.rcp
@@ -1,0 +1,6 @@
+(:name rustic
+       :description "Rust development environment for Emacs"
+       :type github
+       :pkgname "brotzeit/rustic"
+       :minimum-emacs-version "26.1"
+       :depends (rust-mode dash f let-alist markdown-mode project s seq spinner xterm-color))

--- a/recipes/saveplace-pdf-view.rcp
+++ b/recipes/saveplace-pdf-view.rcp
@@ -1,0 +1,4 @@
+(:name saveplace-pdf-view
+       :description "Extend the built-in save-place mode to support pdf-tools and doc-view."
+       :type github
+       :pkgname "nicolaisingh/saveplace-pdf-view")

--- a/recipes/shrface.rcp
+++ b/recipes/shrface.rcp
@@ -1,0 +1,5 @@
+(:name shrface
+       :description "Extend shr/eww with org features and analysis capability."
+       :type github
+       :pkgname "chenyanming/shrface"
+       :depends (org-mode language-detection))

--- a/recipes/solaire-mode.rcp
+++ b/recipes/solaire-mode.rcp
@@ -1,0 +1,6 @@
+(:name solaire-mode
+       :description "Make certain buffers grossly incandescent"
+       :minimum-emacs-version "25"
+       :type github
+       :pkgname "hlissner/emacs-solaire-mode"
+       :depends (cl-lib))

--- a/recipes/yaml-imenu.rcp
+++ b/recipes/yaml-imenu.rcp
@@ -1,0 +1,5 @@
+(:name yaml-imenu
+       :type github
+       :pkgname "knu/yaml-imenu.el"
+       :description "IMenu support for yaml-mode"
+       :depends (yaml-mode))

--- a/recipes/zoxide.el.rcp
+++ b/recipes/zoxide.el.rcp
@@ -1,0 +1,4 @@
+(:name zoxide.el
+       :description "Find file by zoxide"
+       :type github
+       :pkgname "emacsmirror/zoxide")


### PR DESCRIPTION
Hello,

I've been using these recipes for a long time now. I'm hoping that by contributing back to the master repo they will be available to others as well. 

The PR contains the following changes on top of commit 960f3fb962c35d3196bab20b2a3f6d6228119277:

 ``` 
      Org mode master branch has been renamed to Main
      Create a new recipe for org-contrib
      Update org-brain recipe to depend on org-contrib
      Add website to linkd recipe
      Add missing transient dependency to forge recipe
      Add missing transient dependency to docker recipe
      Add missing dependencies to dash-docs
      Add new recipe for zoxide.el
      Add recipe for yaml-imenu
      Add recipe for solaire-mode
      Add recipe for shrface
      Add recipe for saveplace-pdf-view
      Add recipe for rustic
      Add recipe for propcheck
      Add recipe for pinboard
      Add recipe for parinfer-rust-mode
      Add recipe for orgit
      Add recipe for orgit-forge
      Add recipe for org-web-tools
      Add recipe for org-superstar
      Add recipe for org-protocol-capture-html
      Add recipe for org-mode-crate
      Add recipe for org-books
      Add recipe for nov
      Add recipe for nm
      Add recipe for move-text
      Add recipe for magit-delta
      Add recipe for language-detection
      Add recipe for kibit-helper
      Add recipe for helm-system-packages
      Add recipe for helm-notmuch
      Add recipe for gcmh
      Add recipe for flycheck-inline
      Add recipe for fancy-battery
      Add recipe for enlive
      Add recipe for emacs-tree-sitter
      Add recipe for emacs-emojify
      Add recipe for elpher
      Add recipe for eglot
      Add recipe for deadgrep
      Add recipe for company-ansible
      Add recipe for code-compass
      Add recipe for cljstyle
      Add recipe for ansible
      Add recipe for all-the-icons-ibuffer
      Add recipe for all-the-icons-dired
```