### PR TITLE
Add `el-get-eval-lexical` option to eval forms with lexical scoping.

### DIFF
--- a/el-get-custom.el
+++ b/el-get-custom.el
@@ -126,6 +126,11 @@ operations."
   :group 'el-get
   :type 'boolean)
 
+(defcustom el-get-eval-lexical nil
+  "Non-nil means evaluate forms with lexical scoping."
+  :group 'el-get
+  :type 'boolean)
+
 (defcustom el-get-byte-compile-at-init nil
   "Whether or not to byte-compile packages at init.
 

--- a/el-get.el
+++ b/el-get.el
@@ -333,7 +333,7 @@ which defaults to the first element in `el-get-recipe-path'."
       ;; don't forget to make some variables available
       (let* ((pdir (el-get-package-directory package))
              (default-directory pdir))
-        (eval form)))))
+        (eval form el-get-eval-lexical)))))
 
 (defun el-get-lazy-run-package-support (form fname package)
   "Like `el-get-run-package-support', but using `eval-after-load' to wait until PACKAGE is loaded."


### PR DESCRIPTION
Default is nil which should preserve existing behaviour.