### PR TITLE
Fix Git HTTP smart host detection

### DIFF
--- a/methods/el-get-git.el
+++ b/methods/el-get-git.el
@@ -33,6 +33,12 @@ explicit checks for these"
   :group 'el-get
   :type 'list)
 
+;; The following variables are declared here to silence the byte
+;; compiler "reference to variable" warning. The package "url-http"
+;; provides these variables.
+(defvar url-http-content-type)
+(defvar url-http-response-status)
+
 (defun el-get-git-executable ()
   "Return git executable to use, or signal an error when not
 found."

--- a/test/issues/el-get-issue-1920.el
+++ b/test/issues/el-get-issue-1920.el
@@ -1,35 +1,36 @@
-;; Test for testing `el-get-git-shallow-clone-supported-p' function
-;; the function detects whether shallow clone is supported for url
+;;; Test for testing `el-get-git-shallow-clone-supported-p' function
+;;; the function detects whether shallow clone is supported for url
 
 (require 'cl-lib)
 
-;; Tests for lower level function [el-get-git-url-from-known-smart-domains-p]
+;;; Tests for lower level function [el-get-git-url-from-known-smart-domains-p]
 (cl-assert (el-get-git-shallow-clone-supported-p "https://www.bitbucket.org/alfaromurillo/org-passwords.el.git"))
 (cl-assert (el-get-git-url-from-known-smart-domains-p "https://www.github.com/dimitri/el-get"))
 (cl-assert (el-get-git-url-from-known-smart-domains-p "https://bitbucket.org/alfaromurillo/org-passwords.el.git"))
 (cl-assert (el-get-git-url-from-known-smart-domains-p "https://github.com/dimitri/el-get"))
 
-;; Tests for lower level function [el-get-git-is-host-smart-http-p]
+;;; Tests for lower level function [el-get-git-is-host-smart-http-p]
+;; responses to GET, but not HEAD
 (cl-assert (el-get-git-is-host-smart-http-p "https://github.com/dimitri/el-get.git"))
-(cl-assert (el-get-git-is-host-smart-http-p "http://repo.or.cz/r/anything-config.git"))
-(cl-assert (not (el-get-git-is-host-smart-http-p "http://www.dr-qubit.org/git/undo-tree.git")))
+;; responses to HEAD
+(cl-assert (el-get-git-is-host-smart-http-p "https://repo.or.cz/r/anything-config.git"))
+(cl-assert (el-get-git-is-host-smart-http-p "https://gitlab.com/tsc25/undo-tree.git"))
 
-;; Function should not fail for urls without '.git' prefix
+;;; Function should not fail for urls without '.git' prefix
 (cl-assert (el-get-git-is-host-smart-http-p "https://github.com/dimitri/el-get"))
 (cl-assert (el-get-git-is-host-smart-http-p "http://repo.or.cz/r/anything-config"))
-(cl-assert (not (el-get-git-is-host-smart-http-p "http://www.dr-qubit.org/git/undo-tree")))
+(cl-assert (el-get-git-is-host-smart-http-p "https://gitlab.com/tsc25/undo-tree"))
 
-;; Tests for function [el-get-git-shallow-clone-supported-p]
-;; `git', `ssh' and `file' support shallow clones
+;;; Tests for function [el-get-git-shallow-clone-supported-p]
+;;; `git', `ssh' and `file' support shallow clones
 (cl-assert (el-get-git-shallow-clone-supported-p "git://gitorious.org/evil/evil.git"))
 (cl-assert (el-get-git-shallow-clone-supported-p "file:///opt/git/project.git"))
 (cl-assert (el-get-git-shallow-clone-supported-p "ssh://some_user@some_server/some_project.git"))
 
-;; The following repos support shallow clones
+;;; The following repos support shallow clones
 (cl-assert (el-get-git-shallow-clone-supported-p "http://repo.or.cz/r/anything-config.git"))
 (cl-assert (el-get-git-shallow-clone-supported-p "https://github.com/dimitri/el-get"))
 (cl-assert (el-get-git-shallow-clone-supported-p "https://bitbucket.org/alfaromurillo/org-passwords.el.git"))
 
-;; The following do not support shallow clones
-(cl-assert (not (el-get-git-shallow-clone-supported-p "http://www.dr-qubit.org/git/undo-tree.git/")))
+;;; The following do not support shallow clones
 (cl-assert (not (el-get-git-shallow-clone-supported-p "http://michael.orlitzky.com/git/nagios-mode.git")))


### PR DESCRIPTION
regression test test/issues/el-get-issue-1920.el revealed that Git HTTP smart host detection is broken. Not all hosts support the HEAD HTTP request method. For example, github.com for HEAD

```elisp
(let ((url-request-method "HEAD"))
  (url-retrieve-synchronously
   "https://github.com/dimitri/el-get.git/info/refs\?service\=git-upload-pack"))
```

responds

```
HTTP/1.1 405 Method Not Allowed
Server: GitHub Babel 2.0
Content-Type: text/plain
Content-Security-Policy: default-src 'none'; sandbox
Content-Length: 0
X-Frame-Options: DENY
X-GitHub-Request-Id: C1DA:12E32:2B6C9D7:302B1C2:61C9A4E8
```

while for GET

```elisp
(let ((url-request-method "GET"))
  (url-retrieve-synchronously
   "https://github.com/dimitri/el-get.git/info/refs\?service\=git-upload-pack"))
```

responds

```
HTTP/1.1 200 OK
Server: GitHub Babel 2.0
Content-Type: application/x-git-upload-pack-advertisement
Content-Security-Policy: default-src 'none'; sandbox
Transfer-Encoding: chunked
expires: Fri, 01 Jan 1980 00:00:00 GMT
pragma: no-cache
Cache-Control: no-cache, max-age=0, must-revalidate
Vary: Accept-Encoding
X-Frame-Options: DENY
X-GitHub-Request-Id: C22C:5E15:3923777:3D822AC:61CA332A
```

Other hosts like git.sr.ht do support HEAD, of course.

Furthermore, the HTTP status code wasn't checked, that's why hosts like github.com would be classified as "dumb" hosts.

This commit checks the HTTP status code, and if the status is not 200 or 304 for the HEAD HTTP request method, it tries GET. HEAD is tried first, because GET might be more expensive for big repositories.

The regression test is adapted as well.