### PR TITLE
Update all recipes of the Magit organization to follow the new magit conventions

### DIFF
--- a/recipes/epkg.rcp
+++ b/recipes/epkg.rcp
@@ -4,4 +4,11 @@
        :pkgname "emacscollective/epkg"
        :depends (closql dash)
        :minimum-emacs-version "25.1"
-       :compile ("epkg.el" "epkg-ui.el"))
+       :info "docs"
+       :load "lisp/"
+       :compile "lisp/"
+       ;; Use the Makefile to produce the info manual, el-get can
+       ;; handle compilation and autoloads on its own.
+       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info"))
+       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+                               "info")))

--- a/recipes/forge.rcp
+++ b/recipes/forge.rcp
@@ -7,11 +7,13 @@
        :minimum-emacs-version "25.1"
        ;; The package.el dependency is on `emacsql-sqlite', but el-get
        ;; provides that via `emacsql'.
-       :depends (closql dash emacsql ghub let-alist magit markdown-mode transient yaml)
+       :depends (closql dash emacsql ghub let-alist magit markdown-mode
+                        transient yaml)
        :info "docs"
        :load-path "lisp/"
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can
        ;; handle compilation and autoloads on its own.
        :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info"))
-       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs) "info")))
+       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+                               "info")))

--- a/recipes/ghub.rcp
+++ b/recipes/ghub.rcp
@@ -2,4 +2,12 @@
        :type github
        :description "Minuscule client for the Github API"
        :pkgname "magit/ghub"
-       :depends (treepy))
+       :depends (let-alist treepy)
+       :info "docs"
+       :load-path "lisp/"
+       :compile "lisp/"
+       ;; Use the Makefile to produce the info manual, el-get can
+       ;; handle compilation and autoloads on its own.
+       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info"))
+       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+                               "info")))

--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -8,7 +8,7 @@
        ;; Note: `git-commit' is shipped with `magit' code itself.
        ;; Note: `magit-section' is shipped with `magit' code itself.
        :depends (dash transient with-editor)
-       :info "Documentation"
+       :info "docs"
        :load-path "lisp/"
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can

--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -5,6 +5,8 @@
        :pkgname "magit/magit"
        :branch "master"
        :minimum-emacs-version "25.1"
+       ;; Note: `git-commit' is shipped with `magit' code itself.
+       ;; Note: `magit-section' is shipped with `magit' code itself.
        :depends (dash transient with-editor)
        :info "Documentation"
        :load-path "lisp/"

--- a/recipes/transient.rcp
+++ b/recipes/transient.rcp
@@ -5,7 +5,6 @@
        :pkgname "magit/transient"
        :branch "master"
        :minimum-emacs-version "25.1"
-       :depends (dash)
        :info "docs"
        :load-path "lisp/"
        :compile "lisp/"

--- a/recipes/with-editor.rcp
+++ b/recipes/with-editor.rcp
@@ -2,4 +2,11 @@
        :description "Use the Emacsclient as $EDITOR"
        :type github
        :pkgname "magit/with-editor"
-       :load-path ("lisp"))
+       :info "docs"
+       :load-path "lisp/"
+       :compile "lisp/"
+       ;; Use the Makefile to produce the info manual, el-get can
+       ;; handle compilation and autoloads on its own.
+       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info"))
+       :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs)
+                               "info")))


### PR DESCRIPTION
Recently, @tarsius changed the file layout for the majority of his recipes (as described here: https://github.com/melpa/melpa/commit/325cca8031b99c6abe2ee9858a6b547d1af0cdde) 

This breaks the associated el-get recipes. This PR fixes the affected recipes. The following changes are included in the PR on top of 9353309744e4f8a7c9b1adf22ec99536fb2146b0:

      Update recipe for epkg
      Update recipe for ghub
      Update recipe for with-editor
      Update recipe for transient
      Minor style changes to magit and forge recipes

 Summary of changes:

 ```
recipes/epkg.rcp        |  9 ++++++++-
 recipes/forge.rcp       |  6 ++++--
 recipes/ghub.rcp        | 10 +++++++++-
 recipes/magit.rcp       |  2 ++
 recipes/transient.rcp   |  1 -
 recipes/with-editor.rcp |  9 ++++++++-
 7 files changed, 32 insertions(+), 6 deletions(-)
```
