### PR TITLE
Update org-mode URL.

### DIFF
--- a/recipes/org-mode.rcp
+++ b/recipes/org-mode.rcp
@@ -2,7 +2,7 @@
        :website "http://orgmode.org/"
        :description "Org-mode is for keeping notes, maintaining ToDo lists, doing project planning, and authoring with a fast and effective plain-text system."
        :type git
-       :url "https://code.orgmode.org/bzg/org-mode.git"
+       :url "https://git.savannah.gnu.org/git/emacs/org-mode.git"
        :info "doc"
        :checkout "main"
        :build/berkeley-unix `,(mapcar


### PR DESCRIPTION
The org-mode author has added a HTTP redirect from the old source tree to the new one, which confuses git fetch, so this patch fixes the org-mode recipe.