### PR TITLE
Swiper depends on hydra and wgrep

### DIFF
--- a/recipes/swiper.rcp
+++ b/recipes/swiper.rcp
@@ -1,10 +1,28 @@
 (:name swiper
        :description "Gives you an overview as you search for a regex."
        :type github
-       :depends (cl-lib avy)
+       :depends (cl-lib avy hydra wgrep)
        :pkgname "abo-abo/swiper"
-       :build `(("make" ,(format "emacs=%s -L %s" el-get-emacs (concat (file-name-as-directory el-get-dir) "avy")) "compile")
-               ("makeinfo" "-o" "doc/ivy.info" "doc/ivy.texi"))
-       :build/berkeley-unix `(("gmake" ,(format "emacs=%s -L %s" el-get-emacs (concat (file-name-as-directory el-get-dir) "avy")) "compile")
-                             ("gmakeinfo" "-o" "doc/ivy.info" "doc/ivy.texi"))
+       :build
+       `(("make" ,(let ((make-path
+                         (lambda (dir)
+                           (concat (file-name-as-directory el-get-dir) dir))))
+                   (format "emacs=%s -L %s -L %s -L %s"
+                           el-get-emacs
+                           (funcall make-path "avy")
+                           (funcall make-path "hydra")
+                           (funcall make-path "wgrep")))
+          "compile")
+         ("makeinfo" "-o" "doc/ivy.info" "doc/ivy.texi"))
+       :build/berkeley-unix
+       `(("gmake" ,(let ((make-path
+                          (lambda (dir)
+                            (concat (file-name-as-directory el-get-dir) dir))))
+                     (format "emacs=%s -L %s -L %s -L %s"
+                             el-get-emacs
+                             (funcall make-path "avy")
+                             (funcall make-path "hydra")
+                             (funcall make-path "wgrep")))
+          "compile")
+         ("gmakeinfo" "-o" "doc/ivy.info" "doc/ivy.texi"))
        :info "doc/ivy.info")


### PR DESCRIPTION
According to https://github.com/abo-abo/swiper/blob/7489968257a74f176c0d1de7ec8bd1e2011f0db4/targets/install-deps.el#L17 which is called by `make deps`, swiper depends on avy, hydra, and wgrep.

This change adds the load path of hydra and wgrep for `make compile`. At least I got an error without hydra.
