### PR TITLE
No magit.info when installing via el-get

### DIFF
--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -6,7 +6,7 @@
        :branch "master"
        :minimum-emacs-version "25.1"
        :depends (dash transient with-editor)
-       :info "Documentation"
+       :info nil
        :load-path "lisp/"
        :compile "lisp/"
        ;; Use the Makefile to produce the info manual, el-get can


### PR DESCRIPTION
Hey guys I tried to install magit in a new system via el-get and I kept getting an error. that magit can't find magit.info. Following hints from this: https://github.com/dimitri/el-get/issues/2574 I removed Documentation from `:info` to `nil` and it now works.

I am not sure if this is an error in the recipe or something I do not understand about how it should work, but I am opening a PR to gather some feedback