### PR TITLE
Add / Update some `el-get` recipes

### DIFF
--- a/recipes/doom-themes.rcp
+++ b/recipes/doom-themes.rcp
@@ -2,6 +2,7 @@
        :website "https://github.com/hlissner/emacs-doom-themes"
        :description "DOOM Themes is an opinionated UI plugin and pack of themes extracted from my emacs.d, inspired by some of my favorite color themes."
        :depends (all-the-icons cl-lib)
+       :load-path ("." "extensions")
        :type github
        :pkgname "hlissner/emacs-doom-themes"
        :features doom-themes)

--- a/recipes/lispy.rcp
+++ b/recipes/lispy.rcp
@@ -2,4 +2,4 @@
        :description "vi-like paredit."
        :type github
        :pkgname "abo-abo/lispy"
-       :depends (iedit avy swiper hydra))
+       :depends (iedit ace-window swiper hydra zoutline))

--- a/recipes/org-hyperscheduler.rcp
+++ b/recipes/org-hyperscheduler.rcp
@@ -1,0 +1,6 @@
+(:name org-hyperscheduler
+       :description "A package that helps you organize your day"
+       :type github
+       :minimum-emacs-version "26"
+       :depends (websocket)
+       :pkgname "dmitrym0/org-hyperscheduler")

--- a/recipes/org-menu.rcp
+++ b/recipes/org-menu.rcp
@@ -1,0 +1,6 @@
+(:name org-menu
+       :description "A discoverable menu for org-mode using transient"
+       :type github
+       :pkgname "sheijk/org-menu"
+       :minimum-emacs-version "26.1"
+       :depends (transient))

--- a/recipes/org-remark.rcp
+++ b/recipes/org-remark.rcp
@@ -1,0 +1,5 @@
+(:name org-remark
+       :description "Highlight & annotate any text files"
+       :type github
+       :pkgname "nobiot/org-remark"
+       :minimum-emacs-version "27.1")

--- a/recipes/org-transclusion.rcp
+++ b/recipes/org-transclusion.rcp
@@ -1,0 +1,8 @@
+(:name org-transclusion
+       :description "Emacs package to enable transclusion with Org Mode."
+       :type github
+       :pkgname "nobiot/org-transclusion"
+       :minimum-emacs-version "27.1"
+       ;; Requires Org Mode 9.4 as the minimum, hence adding an
+       ;; explicit dependency to fetch the latest version.
+       :depends (org-mode))

--- a/recipes/parseclj.rcp
+++ b/recipes/parseclj.rcp
@@ -2,4 +2,4 @@
        :description "Clojure parser for Emacs Lisp"
        :type github
        :pkgname "clojure-emacs/parseclj"
-       :depends (a))
+       :checkout "main")

--- a/recipes/zoutline.rcp
+++ b/recipes/zoutline.rcp
@@ -1,0 +1,4 @@
+(:name zoutline
+       :description "Emacs library for outlines."
+       :type github
+       :pkgname "abo-abo/zoutline")


### PR DESCRIPTION
The PR introduces the following changes since commit a620c91fe7d6d482c0e7538df75e10af0af1bb16:

- Update the recipe for `doom-themes`
- Add a recipe for `org-transclusion`
- Add a recipe for `org-menu`
- Update the recipe for `lispy`
- Update the recipe for `parseclj`
- Add a recipe for `org-remark`
- Add recipe for `org-hyperscheduler`

```
 recipes/doom-themes.rcp        | 1 +
 recipes/lispy.rcp              | 2 +-
 recipes/org-hyperscheduler.rcp | 6 ++++++
 recipes/org-menu.rcp           | 6 ++++++
 recipes/org-remark.rcp         | 5 +++++
 recipes/org-transclusion.rcp   | 8 ++++++++
 recipes/parseclj.rcp           | 2 +-
 recipes/zoutline.rcp           | 4 ++++
 8 files changed, 32 insertions(+), 2 deletions(-)
 create mode 100644 recipes/org-hyperscheduler.rcp
 create mode 100644 recipes/org-menu.rcp
 create mode 100644 recipes/org-remark.rcp
 create mode 100644 recipes/org-transclusion.rcp
 create mode 100644 recipes/zoutline.rcp
```