### PR TITLE
Update fsharp receipt

### DIFF
--- a/recipes/fsharp-mode.rcp
+++ b/recipes/fsharp-mode.rcp
@@ -1,6 +1,7 @@
 (:name fsharp-mode
        :description "Major mode for editing fsharp code."
        :type github
-       :pkgname "rneatherway/emacs-fsharp-mode-bin"
-       :website "https://github.com/fsharp/fsharpbinding"
-       :depends (auto-complete popup pos-tip s dash))
+       :pkgname "fsharp/emacs-fsharp-mode"
+       :load-path (".")
+       :depends (eglot jsonrpc)
+       :website "https://github.com/fsharp/emacs-fsharp-mode")

--- a/recipes/jsonrpc.rcp
+++ b/recipes/jsonrpc.rcp
@@ -1,0 +1,4 @@
+(:name jsonrpc
+       :description "JSON-RPC library"
+       :type elpa
+       :website "https://elpa.gnu.org/packages/jsonrpc.html")


### PR DESCRIPTION
- https://github.com/fsharp/fsharpbinding is deprecated(archived) now
- Current repository is https://github.com/fsharp/emacs-fsharp-mode