### PR TITLE
Fix for mu4e to get mu4e.info from proper location

### DIFF
--- a/recipes/mu4e.rcp
+++ b/recipes/mu4e.rcp
@@ -13,5 +13,5 @@
        :build `(("./autogen.sh")
                 ("make"))
        :load-path "mu4e"
-       :info "mu4e/mu4e.info"
+       :info "build/mu4e/mu4e.info"
        )


### PR DESCRIPTION
The current recipe ends with an error "/usr/sbin/install-info el-get could not build mu4e" and if you do the trace it says that the file mu4e.info could not be found. There has been some changes apparently to the mu4e build system and so the info is actually produced with makeinfo into the build directory. The small change reflects this and everything seems to install correctly now.