### PR TITLE
Fix package name at GitHub for polymode package

### DIFF
--- a/recipes/polymode.rcp
+++ b/recipes/polymode.rcp
@@ -3,5 +3,5 @@
        :description "Object oriented framework for multiple emacs
        modes based on indirect buffers"
        :type github
-       :pkgname "vitoshka/polymode"
+       :pkgname "polymode/polymode"
        :load-path ("."))


### PR DESCRIPTION
At GitHub, the project slug "vitoshka/polymode" apparently redirects to "polymode/polymode". However, this later is the official slug.