### PR TITLE
Add tomelr and dwim-shell-command recipes, Fix ox-hugo recipe

### DIFF
--- a/recipes/dwim-shell-command.rcp
+++ b/recipes/dwim-shell-command.rcp
@@ -1,0 +1,5 @@
+(:name dwim-shell-command
+       :description "Shell commands with DWIM behaviour"
+       :type github
+       :pkgname "xenodium/dwim-shell-command"
+       :minimum-emacs-version "27.1")

--- a/recipes/ox-hugo.rcp
+++ b/recipes/ox-hugo.rcp
@@ -2,4 +2,4 @@
        :description "A carefully crafted Org exporter back-end for Hugo https://ox-hugo.scripter.co"
        :type github
        :pkgname "kaushalmodi/ox-hugo"
-       :depends (org-mode))
+       :depends (org-mode tomelr))

--- a/recipes/tomelr.rcp
+++ b/recipes/tomelr.rcp
@@ -1,0 +1,6 @@
+(:name tomelr
+       :description "Convert S-expressions to TOML"
+       :type github
+       :pkgname "kaushalmodi/tomelr"
+       :minimum-emacs-version "26.3"
+       :depends (map seq))


### PR DESCRIPTION
`kaushalmodi/tomelr` is a package to convert S-expressions to TOML, and is used by `kaushalmodi/ox-hugo`. This was missing and causing the package to fail compilation.

This PR also adds a recipe for `xenodium/dwim-shell-command` which provides `dwim-shell-command` as an
opinionated DWIM alternative to `shell-command`. This is a stand-alone recipe with no dependencies.
