### PR TITLE
Add / Update recipes for qpdf.el, pdf-tools and elisp-tree-sitter

### DIFF
--- a/recipes/elisp-tree-sitter.rcp
+++ b/recipes/elisp-tree-sitter.rcp
@@ -1,9 +1,8 @@
-;; NOTE: This recipe has been deprecated in favor of elisp-tree-sitter.rcp. Please install that instead.
-(:name emacs-tree-sitter
-       :description "NOTE: This recipe has been deprecated in favor of elisp-tree-sitter. Please install that instead."
+(:name elisp-tree-sitter
+       :description "Tree-sitter bindings for Emacs Lisp."
        :type github
        :minimum-emacs-version "25.1"
-       :pkgname "vedang/emacs-tree-sitter"
+       :pkgname "emacs-tree-sitter/elisp-tree-sitter"
        :load-path ("core" "lisp" "langs")
        ;; Recipe based on instructions from:
        ;; https://emacs-tree-sitter.github.io/installation/

--- a/recipes/pdf-tools.rcp
+++ b/recipes/pdf-tools.rcp
@@ -1,18 +1,10 @@
 (:name pdf-tools
        :description "pdf tools"
        :type github
-       :minimum-emacs-version "24.3"
-       ;; On Debian, "libpoppler-glib-dev" "libpoppler-dev"
-       ;; "libpoppler-private-dev" are needed to build c code in this package.
+       :minimum-emacs-version "26.3"
        :pkgname "vedang/pdf-tools"
        :depends (let-alist tablist)
-
-       ;; pdf-tools' code written to find "epdfinfo" executable in the lisp
-       ;; directory. we preset following variable to avoid that.
-       :prepare (setq pdf-info-epdfinfo-program
-                      (concat (el-get-package-directory "pdf-tools")
-                              "server/epdfinfo"))
        :build (("make" "autobuild"))
        :build/berkeley-unix (("gmake" "autobuild"))
-       :load-path (("lisp"))
+       :load-path ("lisp")
        :compile ("lisp/"))

--- a/recipes/qpdf.rcp
+++ b/recipes/qpdf.rcp
@@ -1,0 +1,6 @@
+(:name qpdf
+       :description "A transient wrapper for qpdf/qpdf."
+       :type github
+       :pkgname "orgtre/qpdf.el"
+       :minimum-emacs-version "26.3"
+       :depends (transient))


### PR DESCRIPTION
* Add `orgtre/qpdf.el` : A wrapper over `qpdf` for PDF transformations
* Update `pdf-tools` : Clean up the recipe
* Rename `emacs-tree-sitter` to `elisp-tree-sitter` : The repo has been renamed