### PR TITLE
Add / Update recipes for typescript and ziglang development

### DIFF
--- a/recipes/apheleia.rcp
+++ b/recipes/apheleia.rcp
@@ -1,0 +1,5 @@
+(:name apheleia
+       :description "Run code formatter on buffer contents without moving point"
+       :type github
+       :minimum-emacs-version "26"
+       :pkgname "radian-software/apheleia")

--- a/recipes/ctrlf.rcp
+++ b/recipes/ctrlf.rcp
@@ -1,0 +1,5 @@
+(:name ctrlf
+       :description "Emacs finally learns how to ctrl+F"
+       :type github
+       :minimum-emacs-version "25.1"
+       :pkgname "radian-software/ctrlf")

--- a/recipes/emacs-humanoid-themes.rcp
+++ b/recipes/emacs-humanoid-themes.rcp
@@ -1,0 +1,6 @@
+(:name emacs-humanoid-themes
+       :description "Light and Dark humanoid themes for Emacs GUI and terminal"
+       :type github
+       :minimum-emacs-version "24.3"
+       :pkgname "humanoid-colors/emacs-humanoid-themes"
+       :load ("humanoid-themes.el"))

--- a/recipes/tsi.el.rcp
+++ b/recipes/tsi.el.rcp
@@ -1,0 +1,6 @@
+(:name tsi.el
+       :description "tree-sitter indentation minor mode for Emacs"
+       :type github
+       :minimum-emacs-version "24.3"
+       :depends (elisp-tree-sitter)
+       :pkgname "orzechowskid/tsi.el")

--- a/recipes/typescript-mode.rcp
+++ b/recipes/typescript-mode.rcp
@@ -1,4 +1,5 @@
 (:name typescript-mode
-       :description "TypeScript mode"
+       :description "TypeScript support for Emacs"
        :type github
-       :pkgname "ananthakumaran/typescript.el")
+       :minimum-emacs-version "24.3"
+       :pkgname "emacs-typescript/typescript.el")

--- a/recipes/zig-mode.rcp
+++ b/recipes/zig-mode.rcp
@@ -1,4 +1,5 @@
 (:name zig-mode
        :description "Syntax highlighting for the Zig programming language"
        :type github
-       :pkgname "AndreaOrru/zig-mode")
+       :minimum-emacs-version "24.3"
+       :pkgname "ziglang/zig-mode")


### PR DESCRIPTION
* Update `typescript-mode` and `zig-mode` recipe organisations : 
   - Both repositories have moved to official organisations now.
* Add a recipe for `tsi.el` : 
   - `orzechowskid/ttsi.el` is a minor mode which uses the `tree-sitter` syntax tree to provide better indentation. 
* Add recipes for `apheleia` and `ctrlf` from `radian-software`:
   -  `apheleia` is a generic mode for intelligent formatting using external tools
   - `ctrlf` is a modern replacement for `isearch`
* Add a recipe for `humanoid-themes`:
   - `humanoid-colors/emacs-humanoid-themes` provides a beautiful light theme and a beautiful dark theme for Emacs GUI and terminal.