### PR TITLE
Slightly better suggestion of how to set load-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ manual.
 Here is the basic setup to add to your `user-init-file` (`.emacs`):
 
 ```lisp
-(add-to-list 'load-path "~/.emacs.d/el-get/el-get")
+(add-to-list 'load-path (expand-file-name "el-get/el-get" user-emacs-directory))
 
 (unless (require 'el-get nil 'noerror)
   (with-current-buffer
@@ -163,7 +163,7 @@ Here is the basic setup to add to your `user-init-file` (`.emacs`):
 ### Alternative Basic Setup with Installation via MELPA
 
 ```elisp
-(add-to-list 'load-path "~/.emacs.d/el-get/el-get")
+(add-to-list 'load-path (expand-file-name "el-get/el-get" user-emacs-directory))
 
 (unless (require 'el-get nil 'noerror)
   (require 'package)
@@ -291,7 +291,7 @@ tries to initialize the package.
 ```lisp
 ;; Basic setup
 
-(add-to-list 'load-path "~/.emacs.d/el-get/el-get")
+(add-to-list 'load-path (expand-file-name "el-get/el-get" user-emacs-directory))
 
 (unless (require 'el-get nil 'noerror)
   (with-current-buffer

--- a/el-get.info
+++ b/el-get.info
@@ -384,7 +384,7 @@ File: el-get.info,  Node: Basic Setup,  Next: The el-get function,  Up: Setup
 You can then arrange to have El-Get part of your setup, so that at next
 emacs startup the installed packages are initialized.
 
-     (add-to-list 'load-path "~/.emacs.d/el-get/el-get")
+     (add-to-list 'load-path (expand-file-name "el-get/el-get" user-emacs-directory))
 
      (unless (require 'el-get nil t)
        (with-current-buffer
@@ -459,7 +459,7 @@ documentation is usable as-is. It is recommended that you not store the
 El-Get tree in git, however; to prevent this, so you can add a pattern
 `/el-get' to `.emacs.d/.gitignore'.
 
-     (add-to-list 'load-path "~/.emacs.d/el-get/el-get")
+     (add-to-list 'load-path (expand-file-name "el-get/el-get" user-emacs-directory))
      (require 'el-get)
 
      ;; local sources
@@ -506,7 +506,7 @@ directory, and still enjoy a truly portable emacs configuration.
 specify a local source to install.  With this macro, nothing other than
 specified packages is installed.
 
-     (add-to-list 'load-path "~/.emacs.d/el-get/el-get")
+     (add-to-list 'load-path (expand-file-name "el-get/el-get" user-emacs-directory))
      (require 'el-get)
 
      ;; packages from recipe files

--- a/el-get.texi
+++ b/el-get.texi
@@ -385,7 +385,7 @@ You can then arrange to have El-Get part of your setup, so that at
 next emacs startup the installed packages are initialized.
 
 @example
-(add-to-list 'load-path "~/.emacs.d/el-get/el-get")
+(add-to-list 'load-path (expand-file-name "el-get/el-get" user-emacs-directory))
 
 (unless (require 'el-get nil t)
   (with-current-buffer
@@ -458,7 +458,7 @@ however; to prevent this, so you can add a pattern @code{/el-get} to
 @code{.emacs.d/.gitignore}.
 
 @example
-(add-to-list 'load-path "~/.emacs.d/el-get/el-get")
+(add-to-list 'load-path (expand-file-name "el-get/el-get" user-emacs-directory))
 (require 'el-get)
 
 ;; local sources
@@ -510,7 +510,7 @@ specify a local source to install.  With this macro, nothing other
 than specified packages is installed.
 
 @example
-(add-to-list 'load-path "~/.emacs.d/el-get/el-get")
+(add-to-list 'load-path (expand-file-name "el-get/el-get" user-emacs-directory))
 (require 'el-get)
 
 ;; packages from recipe files


### PR DESCRIPTION
Changed:

`(add-to-list 'load-path "~/.emacs.d/el-get/el-get")`

to

`(add-to-list 'load-path (expand-file-name "el-get/el-get" user-emacs-directory))`

in 9 places allowing the user's emacs directory to be somewhere other than `~/.emacs.d` such as `~/.config/emacs`.