### PR TITLE
Update helm.rcp

### DIFF
--- a/recipes/helm.rcp
+++ b/recipes/helm.rcp
@@ -17,5 +17,5 @@
          nil)
        :build/berkeley-unix `(("gmake"
                                ,(concat "ASYNC_ELPA_DIR=" (el-get-package-directory 'emacs-async))))
-       :features "helm-config"
+       :features "helm-autoloads"
        :post-init (helm-mode))


### PR DESCRIPTION
helm-config.el was removed from emacs-helm/helm by the commit below. Use helm-autoloads instead.
https://github.com/emacs-helm/helm/commit/e81fbbc687705595ab65ae5cd3bdf93c17a90743