### PR TITLE
Update Git time machine repo

### DIFF
--- a/recipes/git-timemachine.rcp
+++ b/recipes/git-timemachine.rcp
@@ -1,5 +1,5 @@
 (:name git-timemachine
        :description "Step through historic versions of git controlled file using everyone's favourite editor"
        :type git
-       :url "https://gitlab.com/pidu/git-timemachine"
+       :url "https://codeberg.org/pidu/git-timemachine"
        :minimum-emacs-version "24")


### PR DESCRIPTION
The Git time machine recipe no longer works because the repository has moved. This PR updates the recipe to use the new repository.