### PR TITLE
Emacs 29 fix - make-directory behavior

### DIFF
--- a/el-get-status.el
+++ b/el-get-status.el
@@ -140,7 +140,7 @@
             (make-directory el-get-dir t)))
          (p-s
           (cond
-           ((null ps) ;; nothing installed, we should install el-get
+           ((not (consp ps)) ;; nothing installed, we should install el-get
             (list (list 'el-get 'status "required")))
            ;; ps is an alist, no conversion needed
            ((consp (car ps)) ps)


### PR DESCRIPTION
The behavior of `make-directory` changed such that it will return `t` if the directory exists, rather than always returning `nil`. Here, we update the conditional so that it ensures that `ps` is not a list, instead of just checking if `null`.