### PR TITLE
sunrise-commander and company-mode

### DIFF
--- a/recipes/company-mode.rcp
+++ b/recipes/company-mode.rcp
@@ -2,4 +2,5 @@
        :website "http://company-mode.github.io/"
        :description "Modular in-buffer completion framework for Emacs"
        :type github
-       :pkgname "company-mode/company-mode")
+       :pkgname "company-mode/company-mode"
+       :features company)

--- a/recipes/sunrise-commander.rcp
+++ b/recipes/sunrise-commander.rcp
@@ -1,4 +1,5 @@
 (:name sunrise-commander
        :description "Two-pane file manager for Emacs based on Dired and inspired by MC"
        :type github
-       :pkgname "sunrise-commander/sunrise-commander")
+       :pkgname "sunrise-commander/sunrise-commander"
+       :features sunrise)

--- a/recipes/sunrise-commander.rcp
+++ b/recipes/sunrise-commander.rcp
@@ -1,4 +1,4 @@
 (:name sunrise-commander
        :description "Two-pane file manager for Emacs based on Dired and inspired by MC"
        :type github
-       :pkgname "escherdragon/sunrise-commander")
+       :pkgname "sunrise-commander/sunrise-commander")


### PR DESCRIPTION
`sunrise-commander` provides `sunrise` not `sunrise-commander`.  adding `company-mode` recipe.

ps. Accidentally included two recipes together