### PR TITLE
Add new dependency

### DIFF
--- a/recipes/no-littering.rcp
+++ b/recipes/no-littering.rcp
@@ -3,4 +3,4 @@
        :description "Help keeping ~/.emacs.d clean"
        :type github
        :pkgname "emacscollective/no-littering"
-       :depends (cl-lib))
+       :depends (cl-lib compat))


### PR DESCRIPTION
No-littering depends also on `compat`. See it source code:

https://github.com/emacscollective/no-littering/blob/main/no-littering.el#L9

```
;; Package-Requires: ((emacs "25.1") (compat "29.1.3.4"))
```