### PR TITLE
all magit/ repos at github now use "main" branch instead of "master"

### DIFF
--- a/recipes/git-modes.rcp
+++ b/recipes/git-modes.rcp
@@ -1,5 +1,5 @@
 (:name git-modes
        :description "GNU Emacs modes for various Git-related files"
        :type github
-       :branch "master" ; default to master, like magit.rcp
+       :branch "main" ; default to main, like magit.rcp
        :pkgname "magit/git-modes")

--- a/recipes/transient.rcp
+++ b/recipes/transient.rcp
@@ -3,7 +3,7 @@
        :description "Transient commands used by magit."
        :type github
        :pkgname "magit/transient"
-       :branch "master"
+       :branch "main"
        :minimum-emacs-version "25.1"
        :info "docs"
        :load-path "lisp/"


### PR DESCRIPTION
I recently got an error while installing `magit` with `el-get` and this fixed it.