### PR TITLE
Add recipes for denote and combobulate, Update recipes for Emacsql and Closql

### DIFF
--- a/recipes/closql.rcp
+++ b/recipes/closql.rcp
@@ -2,5 +2,6 @@
        :description "Store EIEIO objects using EmacSQL"
        :type github
        :pkgname "emacscollective/closql"
+       :branch "main"
        :minimum-emacs-version "25.1"
        :depends (esqlite))

--- a/recipes/combobulate.rcp
+++ b/recipes/combobulate.rcp
@@ -1,0 +1,6 @@
+(:name combobulate
+       :description "Structured Editing and Navigation in Emacs"
+       :type github
+       :pkgname "mickeynp/combobulate"
+       :load-path (".")
+       :minimum-emacs-version "29")

--- a/recipes/denote.rcp
+++ b/recipes/denote.rcp
@@ -1,0 +1,6 @@
+(:name denote
+       :description "Simple notes with an efficient file-naming scheme"
+       :type git
+       :url "https://git.sr.ht/~protesilaos/denote"
+       :load-path (".")
+       :minimum-emacs-version "28.1")

--- a/recipes/emacsql.rcp
+++ b/recipes/emacsql.rcp
@@ -1,5 +1,6 @@
 (:name emacsql
        :description "High-level SQL database front-end."
        :type github
+       :branch "main"
        :pkgname "skeeto/emacsql"
        :minimum-emacs-version "25.1")


### PR DESCRIPTION
- `emacsql` and `closql` have moved from using `master` to `main` as the default branch.
- Add recipe for `mickeynp/combobulate` ~ Structured editing based on `tree-sitter`
- Add recipe for `~protesilaos/denote` ~ Simple note-taking with a focus on file-naming