### PR TITLE
Update mu4e.rcp

### DIFF
--- a/recipes/mu4e.rcp
+++ b/recipes/mu4e.rcp
@@ -12,6 +12,6 @@
                           (el-get-package-directory 'mu4e))))
        :build `(("./autogen.sh")
                 ("make"))
-       :load-path "mu4e"
+       :load-path "build/mu4e"
        :info "build/mu4e/mu4e.info"
        )


### PR DESCRIPTION
The build directory actually contains the finished product which are never moved out of that directory. You cannot load mu4e until you point the load-path to the build directory first. An alternative work around is to specify this parameter: (el-get-bundle mu4e :load-path "build/mu4e")