### PR TITLE
Add Emacs 28.2 to CI builds and fix newly introduced warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
         - 25.3
         - 26.3
         - 27.2
+        - 28.2
         - snapshot
     env:
       EMACS_VERSION: ${{ matrix.emacs_version }}

--- a/el-get-check.el
+++ b/el-get-check.el
@@ -65,7 +65,8 @@ Current possibe elements are:
              1))))
 
 (defun el-get-check-recipe-batch ()
-  "emacs -Q -batch -f el-get-check-recipe-batch [-W<:level>] [-Wno-<warning>...] *.rcp
+  "emacs -Q -batch -f el-get-check-recipe-batch [-W<:level>]
+[-Wno-<warning>...] *.rcp
 
 <:level> can be any valid warning level, see `warning-levels'.
 See `el-get-check-suppressed-warnings' for possible <warning> values."

--- a/el-get-status.el
+++ b/el-get-status.el
@@ -331,7 +331,8 @@ REMOVED are added and removed properties, respectively."
 (defun el-get-merge-properties-into-status (package-or-source
                                             operation
                                             &rest keys)
-  "Merge updatable properties for package into package status alist (or status file).
+  "Merge updatable properties for package into package status
+alist (or status file).
 
 The first argument is either a package source or a package name,
 in which case the source will be read using

--- a/el-get.el
+++ b/el-get.el
@@ -203,7 +203,8 @@
   "List of packages to install next, used when dealing with dependencies.")
 
 (defun el-get-installation-failed (package signal-data)
-  "Run all the failure hooks for PACKAGE and `signal' the car and cdr of SIGNAL-DATA."
+  "Run all the failure hooks for PACKAGE and `signal' the car and
+cdr of SIGNAL-DATA."
   (run-hook-with-args 'el-get-post-error-hooks package signal-data)
   (signal (car signal-data) (cdr signal-data)))
 
@@ -336,7 +337,8 @@ which defaults to the first element in `el-get-recipe-path'."
         (eval form el-get-eval-lexical)))))
 
 (defun el-get-lazy-run-package-support (form fname package)
-  "Like `el-get-run-package-support', but using `eval-after-load' to wait until PACKAGE is loaded."
+  "Like `el-get-run-package-support', but using `eval-after-load'
+to wait until PACKAGE is loaded."
   (el-get-eval-after-load package
     `(el-get-run-package-support ',form ',fname ',package)))
 


### PR DESCRIPTION
Currently, there are no builds for Emacs 28.

Emacs 28 seems have introduced warnings about the line length in code documentation. These warnings have been fixed as well.