### PR TITLE
Fix swiper build

### DIFF
--- a/recipes/swiper.rcp
+++ b/recipes/swiper.rcp
@@ -1,10 +1,20 @@
 (:name swiper
        :description "Gives you an overview as you search for a regex."
        :type github
-       :depends (cl-lib avy)
+       :depends (cl-lib avy hydra)
        :pkgname "abo-abo/swiper"
-       :build `(("make" ,(format "emacs=%s -L %s" el-get-emacs (concat (file-name-as-directory el-get-dir) "avy")) "compile")
-               ("makeinfo" "-o" "doc/ivy.info" "doc/ivy.texi"))
-       :build/berkeley-unix `(("gmake" ,(format "emacs=%s -L %s" el-get-emacs (concat (file-name-as-directory el-get-dir) "avy")) "compile")
-                             ("gmakeinfo" "-o" "doc/ivy.info" "doc/ivy.texi"))
+       :build `(("make"
+                 ,(format "emacs=%s -L %s -L %s"
+                          el-get-emacs
+                          (concat (file-name-as-directory el-get-dir) "avy")
+                          (concat (file-name-as-directory el-get-dir) "hydra"))
+                 "compile")
+                ("makeinfo" "-o" "doc/ivy.info" "doc/ivy.texi"))
+       :build/berkeley-unix `(("gmake"
+                               ,(format "emacs=%s -L %s -L %s"
+                                        el-get-emacs
+                                        (concat (file-name-as-directory el-get-dir) "avy")
+                                        (concat (file-name-as-directory el-get-dir) "hydra"))
+                               "compile")
+                              ("gmakeinfo" "-o" "doc/ivy.info" "doc/ivy.texi"))
        :info "doc/ivy.info")


### PR DESCRIPTION
hydra is a build-time dependency of swiper since
40e017dc1bc4655f7c3cf4bbbe3a827ce2fff213 and this patch follows that change in the recipe

Also see https://github.com/abo-abo/swiper/issues/3011