### PR TITLE
fix company-posframe recipe file name and recipe name

### DIFF
--- a/recipes/company-posframe.rcp
+++ b/recipes/company-posframe.rcp
@@ -1,4 +1,4 @@
-(:name company-postframe
+(:name company-posframe
        :description "Use child frame as company candidate menu."
        :website "https://github.com/tumashu/company-posframe/"
        :type github


### PR DESCRIPTION
`company-posframe` is misspelled as `company-postframe`.