### PR TITLE
Update gnuplot-mode.rcp

### DIFF
--- a/recipes/gnuplot-mode.rcp
+++ b/recipes/gnuplot-mode.rcp
@@ -2,5 +2,4 @@
        :description "Drive gnuplot from within emacs"
        :type github
        :pkgname "bruceravel/gnuplot-mode"
-       :build `(("make" ,(concat "EMACS=" el-get-emacs)))
-       :info "gnuplot.info")
+       :build `(("make" ,(concat "EMACS=" el-get-emacs))))


### PR DESCRIPTION
texinfo build is removed because gnplot.info is not distributed with gnuplot.el from https://github.com/emacs-gnuplot/gnuplot/commit/d13412973d08ed3090bd5ffeef8e0680d4b58cb1