### PR TITLE
Add new recipes, Update existing recipes

### DIFF
--- a/recipes/cider-storm.rcp
+++ b/recipes/cider-storm.rcp
@@ -1,0 +1,7 @@
+(:name cider-storm
+       :description "Cider front-end for the FlowStorm debugger"
+       :type github
+       :pkgname "flow-storm/cider-storm"
+       :load-path (".")
+       :depends (cider)
+       :minimum-emacs-version "26")

--- a/recipes/denote-explore.rcp
+++ b/recipes/denote-explore.rcp
@@ -1,0 +1,7 @@
+(:name denote-explore
+       :description "A collection of functions to explore Denote files"
+       :type github
+       :pkgname "pprevos/denote-explore"
+       :load-path (".")
+       :depends (denote f emacs-dashboard)
+       :minimum-emacs-version "29.1")

--- a/recipes/denote.rcp
+++ b/recipes/denote.rcp
@@ -1,6 +1,6 @@
 (:name denote
        :description "Simple notes with an efficient file-naming scheme"
-       :type git
-       :url "https://git.sr.ht/~protesilaos/denote"
-       :load-path (".")
-       :minimum-emacs-version "28.1")
+       :type github
+       :branch "main"
+       :minimum-emacs-version "28.1"
+       :pkgname "protesilaos/denote")

--- a/recipes/docker.rcp
+++ b/recipes/docker.rcp
@@ -2,5 +2,5 @@
        :description "Manage docker images & containers from Emacs"
        :type github
        :pkgname "Silex/docker.el"
-       :minimum-emacs-version "24.5"
-       :depends (magit s dash docker-tramp tablist transient json-mode))
+       :minimum-emacs-version "26.1"
+       :depends (emacs-aio dash s tablist transient))

--- a/recipes/edit-indirect.rcp
+++ b/recipes/edit-indirect.rcp
@@ -1,4 +1,5 @@
 (:name edit-indirect
        :description "Edit regions in separate buffers"
        :type github
-       :pkgname "Fanael/edit-indirect")
+       :pkgname "Fanael/edit-indirect"
+       :minimum-emacs-version "24.3")

--- a/recipes/ef-themes.rcp
+++ b/recipes/ef-themes.rcp
@@ -1,0 +1,6 @@
+(:name ef-themes
+       :description "Colorful and legible themes for GNU Emacs"
+       :type github
+       :branch "main"
+       :minimum-emacs-version "27.1"
+       :pkgname "protesilaos/ef-themes")

--- a/recipes/eglot.rcp
+++ b/recipes/eglot.rcp
@@ -2,4 +2,5 @@
        :type github
        :description "Client for Language Server Protocol (LSP) servers"
        :pkgname "joaotavora/eglot"
-       :minimum-emacs-version "26.1")
+       :minimum-emacs-version "26.3"
+       :builtin "29")

--- a/recipes/elm-mode.rcp
+++ b/recipes/elm-mode.rcp
@@ -1,6 +1,6 @@
 (:name elm-mode
        :website "https://github.com/jcollard/elm-mode#readme"
        :description "Major mode for Elm"
-       :depends (f let-alist s reformatter)
+       :depends (f seq let-alist s reformatter)
        :type github
        :pkgname "jcollard/elm-mode")

--- a/recipes/emacs-dashboard.rcp
+++ b/recipes/emacs-dashboard.rcp
@@ -1,0 +1,6 @@
+(:name emacs-dashboard
+       :description "A startup screen extracted from Spacemacs"
+       :type github
+       :pkgname "emacs-dashboard/emacs-dashboard"
+       :load-path (".")
+       :minimum-emacs-version "26.1")

--- a/recipes/flycheck-eglot.rcp
+++ b/recipes/flycheck-eglot.rcp
@@ -1,0 +1,6 @@
+(:name flycheck
+       :type github
+       :pkgname "flycheck/flycheck-eglot"
+       :minimum-emacs-version "28.1"
+       :depends (eglot flycheck)
+       :description "Flycheck support for eglot")

--- a/recipes/flycheck.rcp
+++ b/recipes/flycheck.rcp
@@ -1,6 +1,5 @@
 (:name flycheck
        :type github
        :pkgname "flycheck/flycheck"
-       :minimum-emacs-version "24.3"
-       :description "On-the-fly syntax checking extension"
-       :depends (dash pkg-info let-alist seq))
+       :minimum-emacs-version "26.1"
+       :description "On-the-fly syntax checking extension")

--- a/recipes/fontaine.rcp
+++ b/recipes/fontaine.rcp
@@ -1,0 +1,6 @@
+(:name fontaine
+       :description "Set font configurations using presets"
+       :type github
+       :branch "main"
+       :minimum-emacs-version "27.1"
+       :pkgname "protesilaos/fontaine")

--- a/recipes/fontaine.rcp
+++ b/recipes/fontaine.rcp
@@ -2,5 +2,5 @@
        :description "Set font configurations using presets"
        :type github
        :branch "main"
-       :minimum-emacs-version "27.1"
+       :minimum-emacs-version "29.1"
        :pkgname "protesilaos/fontaine")

--- a/recipes/forge.rcp
+++ b/recipes/forge.rcp
@@ -7,8 +7,8 @@
        :minimum-emacs-version "25.1"
        ;; The package.el dependency is on `emacsql-sqlite', but el-get
        ;; provides that via `emacsql'.
-       :depends (closql dash emacsql ghub let-alist magit markdown-mode
-                        transient yaml)
+       :depends (compat closql dash emacsql ghub let-alist magit markdown-mode
+                        seq transient yaml)
        :info "docs"
        :load-path "lisp/"
        :compile "lisp/"

--- a/recipes/json-mode.rcp
+++ b/recipes/json-mode.rcp
@@ -2,4 +2,5 @@
        :description "Major mode for editing JSON files, extends the builtin js-mode to add better syntax highlighting for JSON."
        :type github
        :pkgname "joshwnj/json-mode"
-       :depends (json-snatcher json-reformat))
+       :depends (json-snatcher)
+       :minimum-emacs-version "24.4")

--- a/recipes/json-mode.rcp
+++ b/recipes/json-mode.rcp
@@ -1,6 +1,6 @@
 (:name json-mode
-       :description "Major mode for editing JSON files, extends the builtin js-mode to add better syntax highlighting for JSON."
+       :description "Major mode for editing JSON files with Emacs"
        :type github
-       :pkgname "joshwnj/json-mode"
+       :pkgname "json-emacs/json-mode"
        :depends (json-snatcher)
        :minimum-emacs-version "24.4")

--- a/recipes/json-snatcher.rcp
+++ b/recipes/json-snatcher.rcp
@@ -1,4 +1,5 @@
 (:name json-snatcher
        :description "Find the path to a value in JSON"
        :type github
-       :pkgname "Sterlingg/json-snatcher")
+       :pkgname "Sterlingg/json-snatcher"
+       :minimum-emacs-version "24")

--- a/recipes/jupyter.rcp
+++ b/recipes/jupyter.rcp
@@ -1,0 +1,6 @@
+(:name jupyter
+       :description "An interface to communicate with Jupyter kernels."
+       :type github
+       :pkgname "emacs-jupyter/jupyter"
+       :minimum-emacs-version "26"
+       :depends (cl-lib org-mode zmq simple-httpd websocket))

--- a/recipes/keycast.rcp
+++ b/recipes/keycast.rcp
@@ -1,4 +1,7 @@
 (:name keycast
        :description "Show current command and its key in the mode line."
        :type github
+       :branch "main"
+       :depends (compat)
+       :minimum-emacs-version "25.3"
        :pkgname "tarsius/keycast")

--- a/recipes/org-modern.rcp
+++ b/recipes/org-modern.rcp
@@ -1,0 +1,6 @@
+(:name org-modern
+       :description "Modern looks for Org"
+       :type github
+       :depends (org-mode compat)
+       :pkgname "minad/org-modern"
+       :minimum-emacs-version "27.1")

--- a/recipes/org-noter.rcp
+++ b/recipes/org-noter.rcp
@@ -2,4 +2,4 @@
        :description "Emacs document annotator, using org-mode."
        :type github
        :depends (org-mode cl-lib)
-       :pkgname "weirdNox/org-noter")
+       :pkgname "org-noter/org-noter")

--- a/recipes/pinboard.rcp
+++ b/recipes/pinboard.rcp
@@ -1,5 +1,6 @@
 (:name pinboard
        :description "A pinboard.in client in Emacs"
        :type github
+       :branch "main"
        :pkgname "davep/pinboard.el"
        :depends (cl-lib))

--- a/recipes/rfc-mode.rcp
+++ b/recipes/rfc-mode.rcp
@@ -1,0 +1,5 @@
+(:name rfc-mode
+       :description "An Emacs major mode to read and browse RFC documents."
+       :type github
+       :pkgname "galdor/rfc-mode"
+       :minimum-emacs-version "25.1")

--- a/recipes/separedit.rcp
+++ b/recipes/separedit.rcp
@@ -1,0 +1,6 @@
+(:name separedit
+       :type github
+       :pkgname "twlz0ne/separedit.el"
+       :minimum-emacs-version "25.1"
+       :depends (dash edit-indirect)
+       :description "Edit comment/string/docstring/code block in separate buffer")

--- a/recipes/shrface.rcp
+++ b/recipes/shrface.rcp
@@ -2,4 +2,5 @@
        :description "Extend shr/eww with org features and analysis capability."
        :type github
        :pkgname "chenyanming/shrface"
+       :minimum-emacs-version "25.1"
        :depends (org-mode language-detection))

--- a/recipes/spacious-padding.rcp
+++ b/recipes/spacious-padding.rcp
@@ -1,0 +1,6 @@
+(:name spacious-padding
+       :description "Increase the padding/spacing of frames and windows"
+       :type github
+       :branch "main"
+       :minimum-emacs-version "28.1"
+       :pkgname "protesilaos/spacious-padding")

--- a/recipes/zmq.rcp
+++ b/recipes/zmq.rcp
@@ -1,0 +1,6 @@
+(:name zmq
+       :description "ZMQ bindings in elisp"
+       :type github
+       :pkgname "nnicandro/emacs-zmq"
+       :minimum-emacs-version "26"
+       :depends (cl-lib))


### PR DESCRIPTION
This PR submits the following changes:

# Updates:

1. Updates dependencies in recipe for docker: Removes the warning that `docker-tramp` is deprecated
2. Updates following recipes to use the main branch: keycast, pinboard
3. Updates the organizations of following github recipes: json-mode, org-noter
4. Updates dependencies in recipe for elm: The package depends on seq
5. Updates dependencies in recipe for json-mode: Remove dependency on json-refactor 

# Adds:
1. Adds recipe for fontaine: Font configuration presets
6. Adds recipe for ef-themes: Colorful and legible themes for GNU Emacs
7. Adds recipe for emacs-jupyter: An interface to communicate with Jupyter kernels.
8. Adds recipe for emacs-zmq: ZMQ bindings in elisp
9. Adds recipe for flowstorm: An interface to using Flowstorm via Cider
10. Adds recipe for denote-explore: a collection of functions to explore Denote files.
11. Adds recipe for emacs-dashboard: A startup screen extracted from Spacemacs. denote-explore depends on this.
12. Adds recipe for rfc-mode: An Emacs major mode to read and browse RFC documents.
13. Adds recipe for org-modern: Implements a Modern Org Style using font-locking and text-properties.