### PR TITLE
Add and update recipes for supporting Flycheck Eglot

### DIFF
--- a/recipes/eglot.rcp
+++ b/recipes/eglot.rcp
@@ -2,4 +2,5 @@
        :type github
        :description "Client for Language Server Protocol (LSP) servers"
        :pkgname "joaotavora/eglot"
-       :minimum-emacs-version "26.1")
+       :minimum-emacs-version "26.3"
+       :builtin "29")

--- a/recipes/flycheck-eglot.rcp
+++ b/recipes/flycheck-eglot.rcp
@@ -1,0 +1,6 @@
+(:name flycheck
+       :type github
+       :pkgname "flycheck/flycheck-eglot"
+       :minimum-emacs-version "28.1"
+       :depends (eglot flycheck)
+       :description "Flycheck support for eglot")

--- a/recipes/flycheck.rcp
+++ b/recipes/flycheck.rcp
@@ -1,6 +1,5 @@
 (:name flycheck
        :type github
        :pkgname "flycheck/flycheck"
-       :minimum-emacs-version "24.3"
-       :description "On-the-fly syntax checking extension"
-       :depends (dash pkg-info let-alist seq))
+       :minimum-emacs-version "26.1"
+       :description "On-the-fly syntax checking extension")


### PR DESCRIPTION
By default, `eglot` LSP client uses `flymake` for project diagnostics. The package `flycheck-eglot` adds `flycheck` support for `eglot`. This PR adds and updates the recipes needed for this package.