### PR TITLE
fix: car for t in el-get-read-status-file-force

### DIFF
--- a/el-get-status.el
+++ b/el-get-status.el
@@ -143,7 +143,7 @@
            ((null ps) ;; nothing installed, we should install el-get
             (list (list 'el-get 'status "required")))
            ;; ps is an alist, no conversion needed
-           ((consp (car ps)) ps)
+           ((and (consp ps) (consp (car ps))) ps)
            ;; looks like we might have an old format status list
            (t (el-get-convert-from-old-status-format ps)))))
     ;; double check some status "conditions"


### PR DESCRIPTION
When I remove el-get dir and try to reinitialize,
`el-get-read-status-file-force` fails with an error `Wrong type argument: listp, t`. This is due to `make-directory` returns `t` when directry is aleady exists. Indeed, it actually guarantees that retruning non-nil [1]. So, `el-get-read-status-file-force` tries to evaluate the following sexp:

```
(let ((ps t))
  (cond
   ((null ps)
    (list (list 'el-get 'status "required")))
   ((consp (car ps)) ps)
   (t (el-get-convert-from-old-status-format ps))))
```

This patch ensures that this case is handled by the default branch.

[1] https://www.gnu.org/software/emacs/manual/html_node/elisp/Create_002fDelete-Dirs.html#index-make_002ddirectory