### PR TITLE
Fix URL of cython-mode

### DIFF
--- a/recipes/cython-mode.rcp
+++ b/recipes/cython-mode.rcp
@@ -1,6 +1,6 @@
 (:name cython-mode
        :description "Major mode for the Cython language"
        :type http
-       :url "https://raw.github.com/cython/cython/master/Tools/cython-mode.el"
+       :url "https://raw.githubusercontent.com/cython/emacs-cython-mode/master/cython-mode.el"
        :features cython-mode
        :localname "cython-mode.el")


### PR DESCRIPTION
I found that the URL of cython-mode was changed.