### PR TITLE
Update org-noter recipe to point to maintained fork

### DIFF
--- a/recipes/org-noter.rcp
+++ b/recipes/org-noter.rcp
@@ -2,4 +2,4 @@
        :description "Emacs document annotator, using org-mode."
        :type github
        :depends (org-mode cl-lib)
-       :pkgname "weirdNox/org-noter")
+       :pkgname "org-noter/org-noter")


### PR DESCRIPTION
This fork is now the official version of `org-noter` and is almost 500 commits ahead at the time of this writing.