### PR TITLE
Update recipe for json-mode

### DIFF
--- a/recipes/json-mode.rcp
+++ b/recipes/json-mode.rcp
@@ -2,4 +2,5 @@
        :description "Major mode for editing JSON files, extends the builtin js-mode to add better syntax highlighting for JSON."
        :type github
        :pkgname "joshwnj/json-mode"
-       :depends (json-snatcher json-reformat))
+       :depends (json-snatcher)
+       :minimum-emacs-version "24.4")

--- a/recipes/json-mode.rcp
+++ b/recipes/json-mode.rcp
@@ -1,6 +1,6 @@
 (:name json-mode
-       :description "Major mode for editing JSON files, extends the builtin js-mode to add better syntax highlighting for JSON."
+       :description "Major mode for editing JSON files with Emacs"
        :type github
-       :pkgname "joshwnj/json-mode"
+       :pkgname "json-emacs/json-mode"
        :depends (json-snatcher)
        :minimum-emacs-version "24.4")

--- a/recipes/json-snatcher.rcp
+++ b/recipes/json-snatcher.rcp
@@ -1,4 +1,5 @@
 (:name json-snatcher
        :description "Find the path to a value in JSON"
        :type github
-       :pkgname "Sterlingg/json-snatcher")
+       :pkgname "Sterlingg/json-snatcher"
+       :minimum-emacs-version "24")


### PR DESCRIPTION
This package no longer depends on `json-refactor`, and it has moved to the `json-emacs` Github repo