### PR TITLE
Add a recipe for denote-explore

### DIFF
--- a/recipes/denote-explore.rcp
+++ b/recipes/denote-explore.rcp
@@ -1,0 +1,7 @@
+(:name denote-explore
+       :description "A collection of functions to explore Denote files"
+       :type github
+       :pkgname "pprevos/denote-explore"
+       :load-path (".")
+       :depends (denote f emacs-dashboard)
+       :minimum-emacs-version "29.1")


### PR DESCRIPTION
Denote Explore is a collection of functions to explore Denote files.

It depends on Emacs Dashboard, which the previous PR adds.