### PR TITLE
Update keycast recipe to use the main branch

### DIFF
--- a/recipes/keycast.rcp
+++ b/recipes/keycast.rcp
@@ -1,4 +1,7 @@
 (:name keycast
        :description "Show current command and its key in the mode line."
        :type github
+       :branch "main"
+       :depends (compat)
+       :minimum-emacs-version "25.3"
        :pkgname "tarsius/keycast")


### PR DESCRIPTION
tarsius has moved all his projects to use the `main` branch by default.