### PR TITLE
Update recipe for silex/docker

### DIFF
--- a/recipes/docker.rcp
+++ b/recipes/docker.rcp
@@ -2,5 +2,5 @@
        :description "Manage docker images & containers from Emacs"
        :type github
        :pkgname "Silex/docker.el"
-       :minimum-emacs-version "24.5"
-       :depends (magit s dash docker-tramp tablist transient json-mode))
+       :minimum-emacs-version "26.1"
+       :depends (emacs-aio dash s tablist transient))


### PR DESCRIPTION
Bring the dependencies up-to-date. 

This removes the warning than `docker-tramp` is now deprecated.