### PR TITLE
Update recipe for eglot

### DIFF
--- a/recipes/eglot.rcp
+++ b/recipes/eglot.rcp
@@ -2,4 +2,5 @@
        :type github
        :description "Client for Language Server Protocol (LSP) servers"
        :pkgname "joaotavora/eglot"
-       :minimum-emacs-version "26.1")
+       :minimum-emacs-version "26.3"
+       :builtin "29")


### PR DESCRIPTION
- Mention that it is built into Emacs 29
- Bump minimum emacs version to 26.3