### PR TITLE
Add elixir-ts-mode

### DIFF
--- a/recipes/elixir-ts-mode.rcp
+++ b/recipes/elixir-ts-mode.rcp
@@ -1,0 +1,6 @@
+(:name elixir-ts-mode
+       :type github
+       :pkgname "wkirschbaum/elixir-ts-mode"
+       :description "Major mode for Elixir with tree-sitter support"
+       :depends (heex-ts-mode)
+       :minimum-emacs-version "29.1")

--- a/recipes/heex-ts-mode.rcp
+++ b/recipes/heex-ts-mode.rcp
@@ -1,0 +1,5 @@
+(:name heex-ts-mode
+       :type github
+       :pkgname "wkirschbaum/heex-ts-mode"
+       :description "Major mode for Heex with tree-sitter support"
+       :minimum-emacs-version "29.1")


### PR DESCRIPTION
elixir-ts-mode is the major mode for Elixir with tree-sitter support.

It depends on heex-ts-mode, which we also add as part of this PR