### PR TITLE
Switch location for `adoc-mode`

### DIFF
--- a/recipes/adoc-mode.rcp
+++ b/recipes/adoc-mode.rcp
@@ -1,6 +1,6 @@
 (:name adoc-mode
-       :website "https://github.com/sensorflo/adoc-mode/wiki"
+       :website "https://github.com/bbatsov/adoc-mode/wiki"
        :description "A major-mode for editing AsciiDoc files in Emacs."
        :type github
-       :pkgname "sensorflo/adoc-mode"
+       :pkgname "bbatsov/adoc-mode"
        :depends markup-faces)


### PR DESCRIPTION
Now uses https://github.com/bbatsov/adoc-mode

Fixes #2871