### PR TITLE
Update recipe for magit: generate only info docs

### DIFF
--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -15,7 +15,7 @@
        ;; handle compilation and autoloads on its own.  Create an
        ;; empty autoloads file because magit.el explicitly checks for
        ;; a file of that name.
-       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "docs")
+       :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "info")
                 ("touch" "lisp/magit-autoloads.el"))
        :build/berkeley-unix `(("gmake" ,(format "EMACSBIN=%s" el-get-emacs) "docs")
                               ("touch" "lisp/magit-autoloads.el"))


### PR DESCRIPTION
Today I did a fresh reinstall of el-get and magit, and the magit recipe install failed on `make docs` because this system doesn't have the tools needed to generate PDF documentation.

Switching to only generating info docs worked for me, and seems like a better default.