### PR TITLE
Add llama as a new magit dependency

### DIFF
--- a/recipes/llama.rcp
+++ b/recipes/llama.rcp
@@ -1,0 +1,4 @@
+(:name llama
+       :description "Compact syntax for short lambda"
+       :type github
+       :pkgname "tarsius/llama")

--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -7,7 +7,7 @@
        :minimum-emacs-version "25.1"
        ;; Note: `git-commit' is shipped with `magit' code itself.
        ;; Note: `magit-section' is shipped with `magit' code itself.
-       :depends (dash transient with-editor compat)
+       :depends (dash transient with-editor compat llama)
        :info "docs"
        :load-path "lisp/"
        :compile "lisp/"


### PR DESCRIPTION
Since
https://github.com/magit/magit/commit/0a649821007e643ab8c13e770e2a2e10b0389bc4 llama is used in magit, this PR adds it and set it as a magit dependency