### PR TITLE
Fix qmake-mode repo

### DIFF
--- a/recipes/qmake-mode.rcp
+++ b/recipes/qmake-mode.rcp
@@ -1,7 +1,7 @@
 (:name qmake-mode
        :description "Qmake mode for Emacs"
-       :type hg
-       :url "https://qmake-mode.googlecode.com/hg/"
+       :type github
+       :pkgname "jobor/qmake-mode"
        :prepare (progn
                   (autoload 'qmake-mode "qmake"
                     "Major mode for qmake files." t)


### PR DESCRIPTION
https://qmake-mode.googlecode.com/hg/ no longer exists so I've updated the recipe to point to https://github.com/jobor/qmake-mode. (Last updated 5 years ago but better than nothing). 