### PR TITLE
Add cond-let as a new magit dependency

### DIFF
--- a/recipes/cond-let.rcp
+++ b/recipes/cond-let.rcp
@@ -1,0 +1,4 @@
+(:name cond-let
+       :description "Additional and improved binding conditionals"
+       :type github
+       :pkgname "tarsius/cond-let")

--- a/recipes/magit.rcp
+++ b/recipes/magit.rcp
@@ -7,7 +7,7 @@
        :minimum-emacs-version "25.1"
        ;; Note: `git-commit' is shipped with `magit' code itself.
        ;; Note: `magit-section' is shipped with `magit' code itself.
-       :depends (dash transient with-editor compat llama)
+       :depends (dash transient with-editor compat llama cond-let)
        :info "docs"
        :load-path "lisp/"
        :compile "lisp/"


### PR DESCRIPTION
Since https://github.com/magit/magit/commit/614942c8aa442ac9113bffd51ee4c81d01dcd73f cond-let is used in magit, this PR adds it and set it as a magit dependency