### PR TITLE
recipes: patch follow-mouse to remove obsolete unibyte: t

### DIFF
--- a/recipes/follow-mouse.rcp
+++ b/recipes/follow-mouse.rcp
@@ -1,4 +1,8 @@
 (:name follow-mouse
        :type emacswiki
        :description "Move point to mouse location."
-       :website "https://raw.githubusercontent.com/emacsmirror/emacswiki.org/master/follow-mouse.el")
+       :website "https://raw.githubusercontent.com/emacsmirror/emacswiki.org/master/follow-mouse.el"
+       ;; Patch out obsolete `unibyte: t` file-local variable that
+       ;; triggers a warning on Emacs 28+.
+       :build (("sh" "-c"
+                "sed -e 's/-\\*-unibyte: t; coding:/-*- coding:/' -ix follow-mouse.el && rm follow-mouse.elx")))


### PR DESCRIPTION
## Summary
- Add build step to follow-mouse recipe that patches out obsolete `unibyte: t` file-local variable

## Problem
`follow-mouse.el` has `-*-unibyte: t; coding: iso-8859-1;-*-` in its header.
Emacs 28+ warns that `unibyte: t` is obsolete. Since follow-mouse is an
unmaintained emacswiki package, the recipe now patches it out after download.

## Test plan
- Verified `el-get install follow-mouse` produces no `unibyte: t` warning
- Verified clean Emacs startup with no follow-mouse warnings

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>