### PR TITLE
Installer updates

### DIFF
--- a/el-get-install.el
+++ b/el-get-install.el
@@ -87,7 +87,7 @@
       (let ((el-get-default-process-sync t) ; force sync operations for installer
             (el-get-verbose t))             ; let's see it all
         (el-get-post-install "el-get"))
-      (unless (boundp 'el-get-install-skip-emacswiki-recipes)
+      (when (boundp 'el-get-install-emacswiki-recipes)
         (condition-case err
             (el-get-emacswiki-build-local-recipes)
           (error (display-warning 'el-get (error-message-string err)))))

--- a/el-get-install.el
+++ b/el-get-install.el
@@ -51,7 +51,7 @@
            (status
             (apply #'call-process
                    `(,git nil (,buf t) t "--no-pager" "clone" "-v"
-                     ,@(when (boundp 'el-get-install-shallow-clone)
+                     ,@(unless (boundp 'el-get-install-no-shallow-clone)
                          '("--depth" "1"))
                      ,url ,package))))
 

--- a/methods/el-get-emacswiki.el
+++ b/methods/el-get-emacswiki.el
@@ -65,6 +65,9 @@ filename.el ;;; filename.el --- description"
 ;;;
 (defun el-get-emacswiki-retrieve-package-list ()
   "return a list of (URL PACKAGE DESCRIPTION) from emacswiki"
+  ;; Set this cookie because we promise to be good and download
+  ;; only the one page we need, not the entire wiki.
+  (url-cookie-store "botcheck" "1" nil "www.emacswiki.org" "/")
   (with-current-buffer
       (url-retrieve-synchronously el-get-emacswiki-elisp-file-list-url)
     ;; skip HTTP headers


### PR DESCRIPTION
I noticed emacswiki recipe building was broken due to anti-scraper bot defense on the emacswiki. I've added a workaround for it (I asked Alex the wiki admin if it was okay and he said yes). I've also set the default on the installer to skip emacswiki recipes, I don't think it's sensible as a default.

Also made shallow clone the default. Fixes #915