### PR TITLE
Migrate type go

### DIFF
--- a/el-get-check.el
+++ b/el-get-check.el
@@ -169,6 +169,10 @@ object or a file path."
                    (eq type 'git) (string-match "//github.com/" url))
           (el-get-check-warning :warning
             "Use `:type github' for github type recipe"))
+        ;; Is go type used?
+        (when (eq type 'go)
+          (el-get-check-warning :warning
+            "Do not use `:type go', it will fail with modern (1.16+) go tools"))
         ;; Warn when `:autoloads nil' is specified.
         (when (and (not (memq 'autoloads el-get-check-suppressed-warnings))
                    (null autoloads) (plist-member recipe :autoloads))

--- a/methods/el-get-go.el
+++ b/methods/el-get-go.el
@@ -27,6 +27,10 @@
 
 (defun el-get-go-install (package _url post-install-fun)
   "go install PACKAGE"
+  (lwarn '(el-get deprecation) :warning
+         "Trying to install `%s' which has :type go.
+This will likely fail with modern (1.16+) versions of go tools."
+         package)
   (let* ((gopath (getenv "GOPATH"))
          (source (el-get-package-def package))
          (pkgname (el-get-as-string (plist-get source :pkgname)))

--- a/recipes/go-company.rcp
+++ b/recipes/go-company.rcp
@@ -1,9 +1,0 @@
-(:name go-company
-       :description "An autocompletion daemon for the Go programming language"
-       :type go
-       :pkgname "github.com/nsf/gocode"
-       :depends (company-mode go-mode)
-       :load-path ("src/github.com/nsf/gocode/emacs-company")
-       :prepare (eval-after-load 'go-mode
-                  '(require 'company-go))
-       :post-init (add-to-list 'exec-path (concat default-directory "bin")))

--- a/recipes/go-def.rcp
+++ b/recipes/go-def.rcp
@@ -1,5 +1,8 @@
 (:name go-def
        :description "Required for go-mode godef functions"
-       :type go
-       :pkgname "github.com/rogpeppe/godef"
-       :post-init (add-to-list 'exec-path (concat default-directory "bin")))
+       :type github
+       :pkgname "rogpeppe/godef"
+       :load-path (()) ; The .el file comes from go-mode.
+       :depends (go-mode)
+       :build (("go" "build" "-o" "bin/godef" "."))
+       :post-init (setq godef-command (concat default-directory "bin/godef")))

--- a/recipes/go-errcheck.rcp
+++ b/recipes/go-errcheck.rcp
@@ -1,7 +1,6 @@
 (:name go-errcheck
        :description "Program for checking for unchecked errors in go code"
-       :type go
-       :pkgname "github.com/kisielk/errcheck"
-       :post-init (progn
-                    (add-to-list 'exec-path (concat default-directory "bin"))
-                    (el-get-envpath-prepend "PATH" (concat default-directory "bin"))))
+       :type github
+       :pkgname "dominikh/go-errcheck.el"
+       :build (("go" "install" "github.com/kisielk/errcheck@latest"))
+       :compile "go-errcheck.el")

--- a/recipes/go-flymake.rcp
+++ b/recipes/go-flymake.rcp
@@ -1,9 +1,10 @@
 (:name go-flymake
        :description "Flymake for the Go programming language"
-       :type go
-       :pkgname "github.com/dougm/goflymake"
-       :depends (go-mode)
-       :load-path "src/github.com/dougm/goflymake"
+       :type github
+       :pkgname "dougm/goflymake"
+       :depends (go-mode flymake)
+       :build (("go" "build" "-o" "goflymake" "."))
+       :compile (".")
        :post-init (progn
-                    (add-to-list 'exec-path (concat default-directory "bin"))
+                    (add-to-list 'exec-path default-directory)
                     (eval-after-load 'go-mode '(require 'go-flymake))))

--- a/recipes/go-imports.rcp
+++ b/recipes/go-imports.rcp
@@ -1,5 +1,8 @@
 (:name go-imports
        :description "Tool to fix (add, remove) your Go imports automatically"
-       :type go
-       :pkgname "golang.org/x/tools/cmd/goimports"
+       :type github
+       :pkgname "golang/tools"
+       :load-path (()) ; The .el file comes from go-mode.
+       :depends (go-mode)
+       :build (("go" "build" "-o" "bin/goimports" "./cmd/goimports"))
        :post-init (setq gofmt-command (concat default-directory "bin/goimports")))

--- a/recipes/go-lint.rcp
+++ b/recipes/go-lint.rcp
@@ -1,9 +1,0 @@
-(:name go-lint
-       :description "lint for the Go source code"
-       :type go
-       :pkgname "golang.org/x/lint/golint"
-       :features golint
-       :load-path "src/golang.org/x/lint/misc/emacs"
-       :post-init (progn
-                    (add-to-list 'exec-path (concat default-directory "bin"))
-                    (el-get-envpath-prepend "PATH" (concat default-directory "bin"))))

--- a/recipes/go-rename.rcp
+++ b/recipes/go-rename.rcp
@@ -1,8 +1,8 @@
 (:name go-rename
        :description "Integration of the Go 'rename' tool into Emacs"
-       :type go
-       :pkgname "golang.org/x/tools/cmd/gorename"
-       :load-path "src/golang.org/x/tools/refactor/rename"
-       :post-init (progn
-                    (setq go-rename-command (concat default-directory "bin/gorename"))
-                    (load "go-rename.el")))
+       :type github
+       :pkgname "golang/tools"
+       :load-path (()) ; The .el file comes from go-mode.
+       :depends (go-mode)
+       :build (("go" "build" "-o" "bin/gorename" "./cmd/gorename"))
+       :post-init (setq go-rename-command (concat default-directory "bin/gorename")))


### PR DESCRIPTION
Fixes #2856.

As explained there `:type go` no longer works with current go tooling. Migrate to `:type github`. I'm not a go programmer, so I'm not sure if all these are correct, but since they're currently all broken this probably doesn't making anything worse.