### PR TITLE
Split off ac-php-core.rcp & company-php.rcp from ac-php.rcp

### DIFF
--- a/recipes/ac-php-core.rcp
+++ b/recipes/ac-php-core.rcp
@@ -1,0 +1,6 @@
+(:name ac-php-core
+       :description "Auto complete source for php - common core"
+       :type github
+       :pkgname "xcwen/ac-php"
+       :compile "ac-php-core.el" ;; This is common to company & ac.
+       :depends (php-mode s f popup xcscope dash))

--- a/recipes/ac-php.rcp
+++ b/recipes/ac-php.rcp
@@ -2,4 +2,5 @@
        :description "Auto complete source for php"
        :type github
        :pkgname "xcwen/ac-php"
-       :depends (php-mode auto-complete yasnippet xcscope f s))
+       :compile "ac-php.el" ;; We split from core to handle dependencies.
+       :depends (ac-php-core yasnippet auto-complete))

--- a/recipes/company-php.rcp
+++ b/recipes/company-php.rcp
@@ -1,0 +1,6 @@
+(:name company-php
+       :description "Company source for php"
+       :type github
+       :pkgname "xcwen/ac-php"
+       :compile "company-php.el"
+       :depends (ac-php-core company-mode))


### PR DESCRIPTION
Otherwise, someone wanting to install ac-php for its company support would end up pulling auto-complete as a dependency (or vice versa).

Fixes #2413